### PR TITLE
Handle actions whose sole argument comes from a param converter

### DIFF
--- a/spec/controllers/param_converter_controller.cr
+++ b/spec/controllers/param_converter_controller.cr
@@ -17,21 +17,28 @@ class RequestBodyConverter(T)
 end
 
 class ParamConverterController < ART::Controller
-  @[ART::ParamConverter("doubled_num", converter: DoubleConverter(Int32))]
   @[ART::Get(path: "/double/:num")]
+  @[ART::ParamConverter("doubled_num", converter: DoubleConverter(Int32))]
   def double(doubled_num : Int32) : Int32
     doubled_num
   end
 
-  @[ART::QueryParam("num", converter: DoubleConverter(Int32))]
   @[ART::Get(path: "/double-query")]
+  @[ART::QueryParam("num", converter: DoubleConverter(Int32))]
   def double_query(num : Int32) : Int32
     num
   end
 
-  @[ART::QueryParam(name: "obj", converter: RequestBodyConverter(NamedTuple(name: String, id: Int32)))]
   @[ART::Post(path: "/user")]
+  @[ART::ParamConverter("obj", converter: RequestBodyConverter(NamedTuple(name: String, id: Int32)))]
   def new_type(obj : NamedTuple(name: String, id: Int32)) : Int32
     obj["id"]
+  end
+
+  @[ART::Post("type")]
+  @[ART::QueryParam("id")]
+  @[ART::ParamConverter("obj", converter: RequestBodyConverter(NamedTuple(name: String, id: Int32)))]
+  def new_type_post_qp(id : Int32, obj : NamedTuple(name: String, id: Int32)) : Int32
+    obj["id"] + id
   end
 end

--- a/spec/param_converter_spec.cr
+++ b/spec/param_converter_spec.cr
@@ -14,4 +14,8 @@ describe Athena::Routing::ParamConverter do
   it "should be able to process request bodies" do
     CLIENT.post("/user", body: {name: "Jim", id: 1}.to_json).body.should eq "1"
   end
+
+  it "should be able to process a converter only argument with a qp" do
+    CLIENT.post("/type?id=10", body: {name: "Jim", id: 5}.to_json).body.should eq "15"
+  end
 end

--- a/src/route_resolver.cr
+++ b/src/route_resolver.cr
@@ -103,8 +103,9 @@ class Athena::Routing::RouteResolver
         {% end %}
 
         # Raise compile time error if the number of action arguments != (queryParams + path arguments + if 1 if there is an HTTP::Request argument).
+        # Also handle the case where a route's only arg is via a param converter
         {% arg_count = ("/" + method + prefix + path).count(':') + m.annotations(ART::QueryParam).size + (m.args.any? &.restriction.resolve.==(HTTP::Request) ? 1 : 0) + (m.args.any? &.restriction.resolve.==(HTTP::Server::Response) ? 1 : 0) %}
-        {% raise "Route action '#{klass.name}##{m.name}' doesn't have the correct number of arguments.  Expected #{arg_count} but got #{m.args.size}." if m.args.size != arg_count %}
+        {% raise "Route action '#{klass.name}##{m.name}' doesn't have the correct number of arguments.  Expected #{arg_count} but got #{m.args.size}." if m.args.size != arg_count && m.annotations(ParamConverter).select { |pc| m.args.map(&.name.stringify).includes?(pc[0] || pc[:name]) }.size == 0 %}
 
         # Add the route to the router
         @routes.add(


### PR DESCRIPTION
* Fix a spec to use an actual `ParamConverter` annotation
  * Would have caught this earlier