### PR TITLE
Use an empty array if the access-control-request-headers header is missing

### DIFF
--- a/spec/listeners/cors_listener_spec.cr
+++ b/spec/listeners/cors_listener_spec.cr
@@ -173,6 +173,21 @@ describe ART::Listeners::CORS do
 
         assert_headers event.response
       end
+
+      it "without the access-control-request-headers header" do
+        listener = ART::Listeners::CORS.new MockCorsConfigResolver.new
+        event = new_event do |ctx|
+          ctx.request.method = "OPTIONS"
+          ctx.request.headers.add "origin", "https://example.com"
+          ctx.request.headers.add "access-control-request-method", "GET"
+        end
+
+        listener.call event, MockEventDispatcher.new
+
+        event.request.attributes.has_key?(Athena::Routing::Listeners::CORS::ALLOW_SET_ORIGIN).should be_false
+
+        assert_headers event.response
+      end
     end
 
     describe "non-preflight" do

--- a/src/listeners/cors_listener.cr
+++ b/src/listeners/cors_listener.cr
@@ -88,7 +88,7 @@ struct Athena::Routing::Listeners::CORS
       return response.status = :method_not_allowed
     end
 
-    headers = request.headers["access-control-request-headers"].split(/,\ ?/)
+    headers = (rh = request.headers["access-control-request-headers"]?) ? rh.split(/,\ ?/) : [] of String
 
     if !headers.empty? && !config.allow_headers.includes? WILDCARD
       headers.each do |header|


### PR DESCRIPTION
* Handles the case where a preflight CORS request doesn't have the `access-control-request-headers` header
  * Which seems to be what Chrome and Firefox do for a `DELETE` request