### PR TITLE
Emit FinishRequest event

### DIFF
--- a/spec/route_handler_spec.cr
+++ b/spec/route_handler_spec.cr
@@ -26,7 +26,7 @@ describe Athena::Routing::RouteHandler do
 
         handler.handle context
 
-        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::Response, ART::Events::Terminate]
+        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::Response, ART::Events::FinishRequest, ART::Events::Terminate]
         context.response.headers["content-type"].should eq "application/json"
         context.response.closed?.should be_true
         context.response.status.should eq HTTP::Status::OK
@@ -54,7 +54,7 @@ describe Athena::Routing::RouteHandler do
 
         handler.handle context
 
-        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::Response, ART::Events::Terminate]
+        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::Response, ART::Events::FinishRequest, ART::Events::Terminate]
         context.response.headers["content-type"].should eq "application/json"
         context.response.headers["FOO"].should eq "BAR"
         context.response.closed?.should be_true
@@ -76,7 +76,7 @@ describe Athena::Routing::RouteHandler do
 
         handler.handle context
 
-        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::Exception, ART::Events::Response, ART::Events::Terminate]
+        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::Exception, ART::Events::Response, ART::Events::FinishRequest, ART::Events::Terminate]
         context.response.headers["content-type"].should eq "application/json"
         context.response.closed?.should be_true
         context.response.status.should eq HTTP::Status::BAD_REQUEST
@@ -95,7 +95,7 @@ describe Athena::Routing::RouteHandler do
 
         handler.handle context
 
-        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::Exception, ART::Events::Response, ART::Events::Terminate]
+        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::Exception, ART::Events::Response, ART::Events::FinishRequest, ART::Events::Terminate]
         context.response.headers["content-type"].should eq "application/json"
         context.response.closed?.should be_true
         context.response.status.should eq HTTP::Status::INTERNAL_SERVER_ERROR

--- a/src/events/finish_request.cr
+++ b/src/events/finish_request.cr
@@ -1,0 +1,7 @@
+# Emitted after the route's action has been executed and response has been written but before the response has been returned.
+#
+# This event can be listened on to modify the response object's body IO; such as for compression,
+# or to handle any cleanup that needs to happen before the response is returned.
+class Athena::Routing::Events::FinishRequest < AED::Event
+  include Athena::Routing::Events::Context
+end

--- a/src/events/response_event.cr
+++ b/src/events/response_event.cr
@@ -1,4 +1,8 @@
-# Emitted after the route's action has been executed and response has been written.
+# Emitted after the route's action has been executed, but before the response has been written in order to allow setting additional headers.
+# See [HTTP::Server::Response](https://crystal-lang.org/api/HTTP/Server/Response.html#overview).
+# ```
+# The response `#status` and `#headers` must be configured before writing the response body. Once response output is written, changing the `#status` and `#headers` properties has no effect.
+# ```
 #
 # This event can be listened on to modify the response object further before it is returned; such as adding headers/cookies etc.
 class Athena::Routing::Events::Response < AED::Event

--- a/src/route_handler.cr
+++ b/src/route_handler.cr
@@ -89,7 +89,11 @@ struct Athena::Routing::RouteHandler
 
     context.response.content_type = "application/json"
 
+    # Yield the context to write the response
     yield context
+
+    # Emit the finish request event
+    @event_dispatcher.dispatch ART::Events::FinishRequest.new context
 
     # Reset the request store
     @request_store.reset


### PR DESCRIPTION
Adds a new event that is emitted after the `Response` event, but before the `Terminate` event.  It allows modifying of the response IO, such as for compression.  