### PR TITLE
Write directly to the response IO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Dependencies
         run: shards install
       - name: Specs
-        run: crystal spec --order random --error-on-warnings
+        run: make spec
   test_nightly:
     runs-on: ubuntu-latest
     container:
@@ -45,4 +45,4 @@ jobs:
       - name: Install Dependencies
         run: shards install
       - name: Specs
-        run: crystal spec --order random --error-on-warnings
+        run: make spec

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Dependencies
         run: shards install --production
       - name: Build
-        run: crystal docs lib/athena-event_dispatcher/src/athena-event_dispatcher.cr lib/athena-config/src/athena-config.cr lib/athena-dependency_injection/src/athena-dependency_injection.cr src/athena.cr
+        run: make docs
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@2.0.1
         env:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Blacksmoke16
+Copyright (c) 2020 George Dietrich
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: docs
+docs: ## Generates Athena documentation
+	crystal docs lib/athena-event_dispatcher/src/athena-event_dispatcher.cr lib/athena-config/src/athena-config.cr lib/athena-dependency_injection/src/athena-dependency_injection.cr src/athena.cr
+
+.PHONY: spec
+spec: ## Runs the Athena spec suite
+	crystal spec --order random --error-on-warnings

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ Everything is documented in the [API Docs](https://athena-framework.github.io/at
 
 ## Contributors
 
-- [Blacksmoke16](https://github.com/blacksmoke16) - creator and maintainer
+- [George Dietrich](https://github.com/blacksmoke16) - creator and maintainer

--- a/shard.yml
+++ b/shard.yml
@@ -14,7 +14,7 @@ description: |
   A web framework comprised of reusable, independent components.
 
 authors:
-  - Blacksmoke16 <Blacksmoke16@eve.tools>
+  - George Dietrich <george@dietrich.app>
 
 dependencies:
   athena-event_dispatcher:

--- a/spec/argument_resolver_spec.cr
+++ b/spec/argument_resolver_spec.cr
@@ -14,7 +14,7 @@ struct MockParameter(T) < ART::Parameters::Parameter(T)
   end
 end
 
-describe ART::ArgumentResolver do
+pending ART::ArgumentResolver do
   describe "with a request parameter" do
     it "should return the current request's path" do
       route = new_route parameters: [ART::Parameters::Request(HTTP::Request).new "request"] of ART::Parameters::Param

--- a/spec/argument_resolver_spec.cr
+++ b/spec/argument_resolver_spec.cr
@@ -14,7 +14,7 @@ struct MockParameter(T) < ART::Parameters::Parameter(T)
   end
 end
 
-pending ART::ArgumentResolver do
+describe ART::ArgumentResolver do
   describe "with a request parameter" do
     it "should return the current request's path" do
       route = new_route parameters: [ART::Parameters::Request(HTTP::Request).new "request"] of ART::Parameters::Param

--- a/spec/controller_spec.cr
+++ b/spec/controller_spec.cr
@@ -9,7 +9,7 @@ describe ART::Controller do
 
       response.status.should eq HTTP::Status::OK
       response.headers.should eq HTTP::Headers{"content-type" => "text/html"}
-      response.io.rewind.gets_to_end.should eq "Greetings, TEST!\n"
+      response.content.should eq "Greetings, TEST!\n"
     end
 
     it "creates a proper response for the template with a layout" do
@@ -19,7 +19,7 @@ describe ART::Controller do
 
       response.status.should eq HTTP::Status::OK
       response.headers.should eq HTTP::Headers{"content-type" => "text/html"}
-      response.io.rewind.gets_to_end.should eq "<h1>Content:</h1> Greetings, TEST!\n"
+      response.content.should eq "<h1>Content:</h1> Greetings, TEST!\n"
     end
   end
 
@@ -29,7 +29,7 @@ describe ART::Controller do
 
       response.status.should eq HTTP::Status::FOUND
       response.headers.should eq HTTP::Headers{"location" => "URL"}
-      response.io.rewind.gets_to_end.should be_empty
+      response.content.should be_empty
     end
   end
 end

--- a/spec/error_renderer_spec.cr
+++ b/spec/error_renderer_spec.cr
@@ -10,7 +10,7 @@ describe ART::ErrorRenderer do
 
     response.headers.should eq HTTP::Headers{"retry-after" => "42", "content-type" => "application/json"}
     response.status.should eq HTTP::Status::TOO_MANY_REQUESTS
-    response.io.rewind.gets_to_end.should eq %({"code":429,"message":"cool your jets"})
+    response.content.should eq %({"code":429,"message":"cool your jets"})
   end
 
   it ::Exception do
@@ -22,6 +22,6 @@ describe ART::ErrorRenderer do
 
     response.headers.should eq HTTP::Headers{"content-type" => "application/json"}
     response.status.should eq HTTP::Status::INTERNAL_SERVER_ERROR
-    response.io.rewind.gets_to_end.should eq %({"code":500,"message":"Internal Server Error"})
+    response.content.should eq %({"code":500,"message":"Internal Server Error"})
   end
 end

--- a/spec/listeners/error_listener_spec.cr
+++ b/spec/listeners/error_listener_spec.cr
@@ -17,6 +17,6 @@ describe ART::Listeners::Error do
     response = event.response.should_not be_nil
     response.status.should eq HTTP::Status::IM_A_TEAPOT
     response.headers.should eq HTTP::Headers{"FOO" => "BAR"}
-    response.io.rewind.gets_to_end.should eq "ERR"
+    response.content.should eq "ERR"
   end
 end

--- a/spec/listeners/view_listener_spec.cr
+++ b/spec/listeners/view_listener_spec.cr
@@ -10,7 +10,7 @@ describe ART::Listeners::View do
     response = event.response.should_not be_nil
     response.status.should eq HTTP::Status::NO_CONTENT
     response.headers.should eq HTTP::Headers{"content-type" => "application/json"}
-    response.io.rewind.gets_to_end.should be_empty
+    response.content.should be_empty
   end
 
   it "with a non Nil return type" do
@@ -21,6 +21,6 @@ describe ART::Listeners::View do
     response = event.response.should_not be_nil
     response.status.should eq HTTP::Status::OK
     response.headers.should eq HTTP::Headers{"content-type" => "application/json"}
-    response.io.rewind.gets_to_end.should eq %("DATA")
+    response.content.should eq %("DATA")
   end
 end

--- a/spec/response_spec.cr
+++ b/spec/response_spec.cr
@@ -1,0 +1,103 @@
+require "./spec_helper"
+
+private struct TestWriter < ART::Response::Writer
+  def write(output : IO, & : IO -> Nil) : Nil
+    yield output
+    output.print "EOF"
+  end
+end
+
+describe ART::Response do
+  describe ".new" do
+    it "defaults" do
+      response = ART::Response.new
+      response.headers.should be_empty
+      response.content.should be_empty
+      response.status.should eq HTTP::Status::OK
+    end
+
+    it "accepts an Int" do
+      ART::Response.new(status: 201).status.should eq HTTP::Status::CREATED
+    end
+
+    it "accepts an HTTP::Status" do
+      ART::Response.new(status: HTTP::Status::CREATED).status.should eq HTTP::Status::CREATED
+    end
+
+    it "accepts a string" do
+      ART::Response.new("FOO").content.should eq "FOO"
+    end
+
+    it "accepts a block" do
+      (ART::Response.new { |io| io << "BAZ" }).content.should eq "BAZ"
+    end
+
+    it "accepts a proc" do
+      ART::Response.new(->(io : IO) { io << "BAR" }).content.should eq "BAR"
+    end
+  end
+
+  describe "#content" do
+    it "only executes the proc once" do
+      value = 0
+      response = ART::Response.new(->(io : IO) { io << "STRING"; value += 1 })
+      response.content.should eq "STRING"
+      value.should eq 1
+      response.content.should eq "STRING"
+      value.should eq 1
+    end
+
+    it "gets recalculated if the content changes" do
+      value = 0
+      response = ART::Response.new(->(io : IO) { io << "FOO"; value += 1 })
+      response.content.should eq "FOO"
+      value.should eq 1
+
+      response.content = ->(io : IO) { io << "BAR"; value += 1 }
+      response.content.should eq "BAR"
+      value.should eq 2
+    end
+  end
+
+  describe "#content=" do
+    it "accepts a string" do
+      response = ART::Response.new "FOO"
+      response.content.should eq "FOO"
+      response.content = "BAR"
+      response.content.should eq "BAR"
+    end
+  end
+
+  describe "#status=" do
+    it "accepts an Int" do
+      response = ART::Response.new
+      response.status = 201
+      response.status.should eq HTTP::Status::CREATED
+    end
+
+    it "accepts an HTTP::Status" do
+      response = ART::Response.new
+      response.status = HTTP::Status::CREATED
+      response.status.should eq HTTP::Status::CREATED
+    end
+  end
+
+  describe "#write" do
+    it "writes the content to the given output IO" do
+      io = IO::Memory.new
+      ART::Response.new("FOO BAR").write io
+
+      io.rewind.to_s.should eq "FOO BAR"
+    end
+
+    it "supports customization via an ART::Response::Writer" do
+      io = IO::Memory.new
+      response = ART::Response.new("FOO BAR")
+
+      response.writer = TestWriter.new
+      response.write io
+
+      io.rewind.to_s.should eq "FOO BAREOF"
+    end
+  end
+end

--- a/spec/routing_spec.cr
+++ b/spec/routing_spec.cr
@@ -46,14 +46,12 @@ describe Athena::Routing do
       response = CLIENT.get("/macro")
       response.body.should eq %("GET")
       response.status.should eq HTTP::Status::OK
-      response.headers["content-length"].should eq "5"
     end
 
     it "adds a HEAD route for GET requests" do
       response = CLIENT.head("/macro")
       response.body.should be_empty
       response.status.should eq HTTP::Status::OK
-      response.headers["content-length"].should eq "5"
     end
 
     it "works with POST endpoints" do

--- a/src/controller.cr
+++ b/src/controller.cr
@@ -144,9 +144,9 @@ abstract class Athena::Routing::Controller
   # CLIENT.get("/Fred").body # => Greetings, Fred!
   # ```
   macro render(template)
-    response = Athena::Routing::Response.new(nil, 200, HTTP::Headers{"content-type" => "text/html"})
-    ECR.embed {{template}}, response.io
-    response
+    Athena::Routing::Response.new(headers: HTTP::Headers{"content-type" => "text/html"}) do |io|
+      ECR.embed {{template}}, io
+    end
   end
 
   # Renders a template within a layout.

--- a/src/error_renderer.cr
+++ b/src/error_renderer.cr
@@ -16,6 +16,8 @@ struct Athena::Routing::ErrorRenderer
 
     headers["content-type"] = "application/json"
 
-    ART::Response.new exception.to_json, status, headers
+    ART::Response.new status, headers do |io|
+      exception.to_json io
+    end
   end
 end

--- a/src/listeners/view_listener.cr
+++ b/src/listeners/view_listener.cr
@@ -17,14 +17,14 @@ struct Athena::Routing::Listeners::View
   end
 
   def call(event : ART::Events::View, dispatcher : AED::EventDispatcherInterface) : Nil
-    if event.request.route.return_type == Nil
-      data = ""
-      status = HTTP::Status::NO_CONTENT
-    else
-      data = event.view.data.to_json
-      status = HTTP::Status::OK
-    end
+    event.response = if event.request.route.return_type == Nil?
+                       ART::Response.new status: :no_content, headers: get_headers
+                     else
+                       ART::Response.new(headers: get_headers) { |io| event.view.data.to_json io }
+                     end
+  end
 
-    event.response = ART::Response.new data, status, HTTP::Headers{"content-type" => "application/json"}
+  private def get_headers : HTTP::Headers
+    HTTP::Headers{"content-type" => "application/json"}
   end
 end

--- a/src/redirect_response.cr
+++ b/src/redirect_response.cr
@@ -19,17 +19,13 @@ class Athena::Routing::RedirectResponse < Athena::Routing::Response
   # Creates a response that should redirect to the provided *url* with the provided *status*, defaults to 302.
   #
   # An ArgumentError is raised if *url* is blank, or if *status* is not a valid redirection status code.
-  def initialize(@url : String, status : HTTP::Status = HTTP::Status::FOUND, headers : HTTP::Headers = HTTP::Headers.new)
-    raise ArgumentError.new "#{status.value} is not an HTTP redirect status code." unless status.redirection?
+  def initialize(@url : String, status : HTTP::Status | Int32 = HTTP::Status::FOUND, headers : HTTP::Headers = HTTP::Headers.new)
     raise ArgumentError.new "Cannot redirect to an empty URL." if @url.blank?
 
     headers["location"] = @url
 
     super "", status, headers
-  end
 
-  # :ditto:
-  def self.new(url : String, status : Int32 = HTTP::Status::FOUND.value, headers : HTTP::Headers = HTTP::Headers.new)
-    new url, HTTP::Status.new(status), headers
+    raise ArgumentError.new "#{@status.value} is not an HTTP redirect status code." unless @status.redirection?
   end
 end

--- a/src/response.cr
+++ b/src/response.cr
@@ -77,7 +77,12 @@ class Athena::Routing::Response
   # The response headers on `self.`
   getter headers : HTTP::Headers
 
+  # Stores the callback that run when `self` is being written to the `HTTP::Server::Response`.
   @content_callback : Proc(IO, Nil)
+
+  # The cached string representation of the content.
+  #
+  # Is reset if the content of `self` changes.
   @content_string : String? = nil
 
   # Creates a new response with optional *status*, and *headers* arguments.

--- a/src/response.cr
+++ b/src/response.cr
@@ -2,10 +2,10 @@
 class Athena::Routing::Response
   # Determines how the content of an `ART::Response` will be written to the requests' response `IO`.
   #
-  # By default the content is written directly to the requests' response `IO` via `ART::Response::PassThroughWriter`.
+  # By default the content is written directly to the requests' response `IO` via `ART::Response::DirectWriter`.
   # However, custom writers can be implemented to customize that behavior.  The most common use case would be for compression.
   #
-  # The writer objects can also be defined as services if it requires additional external dependencies.
+  # Writers can also be defined as services and injected into a listener if they require additional external dependencies.
   #
   # ### Example
   #
@@ -15,7 +15,7 @@ class Athena::Routing::Response
   # # Define a custom writer to gzip the response
   # struct GzipWriter < ART::Response::Writer
   #   def write(output : IO, & : IO -> Nil) : Nil
-  #     Gzip::Writer.open(output, sync_close: true) do |gzip_io|
+  #     Gzip::Writer.open(output) do |gzip_io|
   #       yield gzip_io
   #     end
   #   end
@@ -35,12 +35,12 @@ class Athena::Routing::Response
   #
   #   def call(event : ART::Events::Response, dispatcher : AED::EventDispatcherInterface) : Nil
   #     # If the request supports gzip encoding
-  #     if event.request.headers.includes_word?("Accept-Encoding", "gzip")
+  #     if event.request.headers.includes_word?("accept-encoding", "gzip")
   #       # Change the `ART::Response` object's writer to be our `GzipWriter`
   #       event.response.writer = GzipWriter.new
   #
   #       # Set the encoding of the response to gzip
-  #       event.response.headers["Content-Encoding"] = "gzip"
+  #       event.response.headers["content-encoding"] = "gzip"
   #     end
   #   end
   # end
@@ -52,8 +52,8 @@ class Athena::Routing::Response
 
   # The default `ART::Response::Writer` for an `ART::Response`.
   #
-  # `ART::Response` content is written directly to the *output* `IO`.
-  struct PassThroughWriter < Writer
+  # Writes directly to the *output* `IO`.
+  struct DirectWriter < Writer
     # :inherit:
     #
     # The *output* `IO` is yielded directly.
@@ -63,7 +63,7 @@ class Athena::Routing::Response
   end
 
   # See `ART::Response::Writer`.
-  setter writer : ART::Response::Writer = ART::Response::PassThroughWriter.new
+  setter writer : ART::Response::Writer = ART::Response::DirectWriter.new
 
   # The `HTTP::Status` of `self.`
   getter status : HTTP::Status

--- a/src/response.cr
+++ b/src/response.cr
@@ -1,29 +1,78 @@
-abstract struct Writer
-  def write(output : IO, & : IO -> Nil) : Nil
-  end
-end
-
-# Default behavior of just yielding the output to the block,
-# I.e. the proc writes directly to the response IO
-struct PassThroughWriter < Writer
-  def write(output : IO, & : IO -> Nil)
-    yield output
-  end
-end
-
 # Represents an HTTP response that should be returned to the client.
-#
-# The values on `self` are applied to the actual `HTTP::Server::Response` once the request is handled.
 class Athena::Routing::Response
-  getter content_callback : Proc(IO, Nil)
+  # Determines how the content of an `ART::Response` will be written to the requests' response `IO`.
+  #
+  # By default the content is written directly to the requests' response `IO` via `ART::Response::PassThroughWriter`.
+  # However, custom writers can be implemented to customize that behavior.  The most common use case would be for compression.
+  #
+  # The writer objects can also be defined as services if it requires additional external dependencies.
+  #
+  # ### Example
+  #
+  # ```
+  # require "gzip"
+  #
+  # # Define a custom writer to gzip the response
+  # struct GzipWriter < ART::Response::Writer
+  #   def write(output : IO, & : IO -> Nil) : Nil
+  #     Gzip::Writer.open(output, sync_close: true) do |gzip_io|
+  #       yield gzip_io
+  #     end
+  #   end
+  # end
+  #
+  # @[ADI::Register(tags: ["athena.event_dispatcher.listener"])]
+  # # Next define a new event listener to handle applying this writer
+  # struct CompressionListener
+  #   include AED::EventListenerInterface
+  #   include ADI::Service
+  #
+  #   def self.subscribed_events : AED::SubscribedEvents
+  #     AED::SubscribedEvents{
+  #       ART::Events::Response => -256, # Listen on the Response event with a very low priority
+  #     }
+  #   end
+  #
+  #   def call(event : ART::Events::Response, dispatcher : AED::EventDispatcherInterface) : Nil
+  #     # If the request supports gzip encoding
+  #     if event.request.headers.includes_word?("Accept-Encoding", "gzip")
+  #       # Change the `ART::Response` object's writer to be our `GzipWriter`
+  #       event.response.writer = GzipWriter.new
+  #
+  #       # Set the encoding of the response to gzip
+  #       event.response.headers["Content-Encoding"] = "gzip"
+  #     end
+  #   end
+  # end
+  # ```
+  abstract struct Writer
+    # Accepts an *output* `IO` that the content of the response should be written to.
+    abstract def write(output : IO, & : IO -> Nil) : Nil
+  end
 
-  setter writer : Writer = PassThroughWriter.new
+  # The default `ART::Response::Writer` for an `ART::Response`.
+  #
+  # `ART::Response` content is written directly to the *output* `IO`.
+  struct PassThroughWriter < Writer
+    # :inherit:
+    #
+    # The *output* `IO` is yielded directly.
+    def write(output : IO, & : IO -> Nil) : Nil
+      yield output
+    end
+  end
+
+  # See `ART::Response::Writer`.
+  setter writer : ART::Response::Writer = ART::Response::PassThroughWriter.new
 
   # The `HTTP::Status` of `self.`
   getter status : HTTP::Status
 
   # The response headers on `self.`
   getter headers : HTTP::Headers
+
+  @content_callback : Proc(IO, Nil)
+  @content_string : String? = nil
 
   def self.new(status : HTTP::Status | Int32 = HTTP::Status::OK, headers : HTTP::Headers = HTTP::Headers.new, &block : IO -> Nil)
     new block, status, headers
@@ -38,26 +87,37 @@ class Athena::Routing::Response
     @status = HTTP::Status.new status
   end
 
-  # Writes `#content_callback` to the provided *io*.
+  # Writes content of `self` to the provided *output*.
+  #
+  # Can be customized via a `ART::Response::Writer`.
   def write(output : IO) : Nil
     @writer.write(output) do |writer_io|
       @content_callback.call writer_io
     end
   end
 
-  def content=(@content_callback : Proc(IO, Nil)); end
+  def content=(@content_callback : Proc(IO, Nil))
+    # Reset the content string if the content changes
+    @content_string = nil
+  end
 
   def content=(content : String? = nil) : Nil
     self.content = Proc(IO, Nil).new { |io| io.print content }
   end
 
   # Returns the content of `self` as a `String`.
+  #
+  # The content string is cached to avoid unnecessarily regenerating
+  # the same string multiple times.
+  #
+  # The cached string is cleared when changing the content via `#content=`.
   def content : String
-    String.build do |io|
+    @content_string ||= String.build do |io|
       write io
     end
   end
 
+  # The `HTTP::Status` of `self.`
   def status=(code : HTTP::Status | Int32) : Nil
     @status = HTTP::Status.new code
   end

--- a/src/response.cr
+++ b/src/response.cr
@@ -1,24 +1,64 @@
+abstract struct Writer
+  def write(output : IO, & : IO -> Nil) : Nil
+  end
+end
+
+# Default behavior of just yielding the output to the block,
+# I.e. the proc writes directly to the response IO
+struct PassThroughWriter < Writer
+  def write(output : IO, & : IO -> Nil)
+    yield output
+  end
+end
+
 # Represents an HTTP response that should be returned to the client.
 #
 # The values on `self` are applied to the actual `HTTP::Server::Response` once the request is handled.
 class Athena::Routing::Response
-  # The `IO` that `self`'s content is written to.
-  #
-  # Can be replaced, such as for compressing the response content.
-  property io : IO
+  getter content_callback : Proc(IO, Nil)
+
+  setter writer : Writer = PassThroughWriter.new
 
   # The `HTTP::Status` of `self.`
-  property status : HTTP::Status
+  getter status : HTTP::Status
 
   # The response headers on `self.`
   getter headers : HTTP::Headers
 
-  def initialize(content : String? = "", @status : HTTP::Status = HTTP::Status::OK, @headers : HTTP::Headers = HTTP::Headers.new)
-    @io = IO::Memory.new
-    @io << content
+  def self.new(status : HTTP::Status | Int32 = HTTP::Status::OK, headers : HTTP::Headers = HTTP::Headers.new, &block : IO -> Nil)
+    new block, status, headers
   end
 
-  def self.new(content : String? = "", status : Int32 = 200, headers : HTTP::Headers = HTTP::Headers.new)
-    new content, HTTP::Status.new(status), headers
+  def initialize(content : String? = nil, status : HTTP::Status | Int32 = HTTP::Status::OK, @headers : HTTP::Headers = HTTP::Headers.new)
+    @status = HTTP::Status.new status
+    @content_callback = Proc(IO, Nil).new { |io| io.print content }
+  end
+
+  def initialize(@content_callback : Proc(IO, Nil), status : HTTP::Status | Int32 = HTTP::Status::OK, @headers : HTTP::Headers = HTTP::Headers.new)
+    @status = HTTP::Status.new status
+  end
+
+  # Writes `#content_callback` to the provided *io*.
+  def write(output : IO) : Nil
+    @writer.write(output) do |writer_io|
+      @content_callback.call writer_io
+    end
+  end
+
+  def content=(@content_callback : Proc(IO, Nil)); end
+
+  def content=(content : String? = nil) : Nil
+    self.content = Proc(IO, Nil).new { |io| io.print content }
+  end
+
+  # Returns the content of `self` as a `String`.
+  def content : String
+    String.build do |io|
+      write io
+    end
+  end
+
+  def status=(code : HTTP::Status | Int32) : Nil
+    @status = HTTP::Status.new code
   end
 end

--- a/src/route_handler.cr
+++ b/src/route_handler.cr
@@ -35,9 +35,12 @@ struct Athena::Routing::RouteHandler
 
   private def return_response(response : ART::Response, context : HTTP::Server::Context) : Nil
     # Apply the `ART::Response` to the actual `HTTP::Server::Response` object
-    IO.copy response.io.rewind, context.response
     context.response.headers.merge! response.headers
     context.response.status = response.status
+
+    # Write the response content last on purpose
+    # See https://github.com/crystal-lang/crystal/issues/8712
+    response.write context.response
 
     # Close the response
     context.response.close


### PR DESCRIPTION
* Stores the response content in a proc that writes directly the response IO
  * Adds a block constructor to `ART::Response`
* Introduces the concept of `ART::Response::Writer`s
  * Are used to control _HOW_ the content of a response is written to the output *IO*.
    * By default the content is written directly but can be customized, such as for compression
* Adds a `Makefile` to simplify running specs and generating documentation