### PR TITLE
Some cleanup based on new DI updates

### DIFF
--- a/src/arguments/argument_resolver.cr
+++ b/src/arguments/argument_resolver.cr
@@ -1,8 +1,5 @@
-# Responsible for resolving the arguments that will be passed to a controller action.
-module Athena::Routing::Arguments::ArgumentResolverInterface
-  # Returns an array of arguments resolved from the provided *request* for the given *route*.
-  abstract def get_arguments(request : HTTP::Request, route : ART::Action) : Array
-end
+require "./resolvers/argument_value_resolver_interface"
+require "./argument_resolver_interface"
 
 # :nodoc:
 #
@@ -17,7 +14,7 @@ class Array
   end
 end
 
-ADI.bind argument_resolvers, "!athena.argument_value_resolver"
+ADI.bind argument_resolvers : Array(Athena::Routing::Arguments::Resolvers::ArgumentValueResolverInterface), "!athena.argument_value_resolver"
 
 @[ADI::Register]
 # The default implementation of `ART::Arguments::ArgumentResolverInterface`.

--- a/src/arguments/argument_resolver_interface.cr
+++ b/src/arguments/argument_resolver_interface.cr
@@ -1,0 +1,5 @@
+# Responsible for resolving the arguments that will be passed to a controller action.
+module Athena::Routing::Arguments::ArgumentResolverInterface
+  # Returns an array of arguments resolved from the provided *request* for the given *route*.
+  abstract def get_arguments(request : HTTP::Request, route : ART::Action) : Array
+end

--- a/src/athena.cr
+++ b/src/athena.cr
@@ -71,12 +71,13 @@ module Athena::Routing
 
   # The `AED::EventListenerInterface` that act upon `ART::Events` to handle a request.  Custom listeners can also be defined, see `AED::EventListenerInterface`.
   #
-  # NOTE: In order for `Athena::Routing` to pick up your custom listener, be sure to `ADI::Register` it as a service, and tag it as `ART::Listeners::TAG`.
-  #
   # See each listener for more detailed information.
   module Athena::Routing::Listeners
     # The tag name for Athena event listeners.
     TAG = "athena.event_dispatcher.listener"
+
+    # Apply `TAG` to all `AED::EventListenerInterface` instances automatically.
+    ADI.auto_configure AED::EventListenerInterface, {tags: [ART::Listeners::TAG]}
   end
 
   # Namespace for types related to controller action arguments.
@@ -88,6 +89,7 @@ module Athena::Routing
   # Custom argument value resolvers can also be defined, see `ART::Arguments::Resolvers::ArgumentValueResolverInterface`.
   #
   # NOTE: In order for `Athena::Routing` to pick up your custom value resolvers, be sure to `ADI::Register` it as a service, and tag it as `ART::Arguments::Resolvers::TAG`.
+  # A `priority` field can also be optionally included in the annotation, the higher the value the sooner in the array it'll be when injected.
   #
   # See each resolver for more detailed information.
   module Athena::Routing::Arguments::Resolvers

--- a/src/listeners/cors_listener.cr
+++ b/src/listeners/cors_listener.cr
@@ -1,4 +1,4 @@
-@[ADI::Register(tags: [ART::Listeners::TAG])]
+@[ADI::Register]
 # Handles [Cross-Origin Resource Sharing](https://enable-cors.org) (CORS).
 #
 # Handles CORS preflight `OPTIONS` requests as well as adding CORS headers to each response.

--- a/src/listeners/error_listener.cr
+++ b/src/listeners/error_listener.cr
@@ -1,4 +1,4 @@
-@[ADI::Register(tags: [ART::Listeners::TAG])]
+@[ADI::Register]
 # Handles an exception by converting it into an `ART::Response` via an `ART::ErrorRendererInterface`.
 struct Athena::Routing::Listeners::Error
   include AED::EventListenerInterface

--- a/src/listeners/param_converter_listener.cr
+++ b/src/listeners/param_converter_listener.cr
@@ -1,4 +1,4 @@
-@[ADI::Register(_param_converters: "!athena.param_converter", tags: [ART::Listeners::TAG])]
+@[ADI::Register(_param_converters: "!athena.param_converter")]
 # Applies any `ART::ParamConverterInterface` defined on a given `ART::Route`.
 #
 # Injects all `ART::ParamConverterInterface` tagged with `ART::ParamConverterInterface::TAG`.

--- a/src/listeners/routing_listener.cr
+++ b/src/listeners/routing_listener.cr
@@ -1,4 +1,4 @@
-@[ADI::Register(tags: [ART::Listeners::TAG])]
+@[ADI::Register]
 # Sets the related `ART::Route` on the current request using `ART::RouteResolver`.
 struct Athena::Routing::Listeners::Routing
   include AED::EventListenerInterface

--- a/src/listeners/view_listener.cr
+++ b/src/listeners/view_listener.cr
@@ -1,4 +1,4 @@
-@[ADI::Register(tags: [ART::Listeners::TAG])]
+@[ADI::Register]
 # The view listener attempts to resolve a non `ART::Response` into an `ART::Response`.
 # Currently this is achieved by JSON serializing the controller action's resulting value.
 #

--- a/src/param_converter_interface.cr
+++ b/src/param_converter_interface.cr
@@ -98,6 +98,9 @@ abstract struct Athena::Routing::ParamConverterInterface
   # The tag name to apply to `self` in order for it to be registered with `ART::Listeners::ParamConverter`.
   TAG = "athena.param_converter"
 
+  # Apply `TAG` to all `AED::EventListenerInterface` instances automatically.
+  ADI.auto_configure Athena::Routing::ParamConverterInterface, {tags: [ART::ParamConverterInterface::TAG]}
+
   # Allows defining extra configuration data that can be supplied within the `ART::ParamConverter` annotation.
   # By default this type includes the name of the argument that should be converted and the
   # the `ART::ParamConverterInterface` that should be used for the conversion.

--- a/src/response.cr
+++ b/src/response.cr
@@ -27,11 +27,10 @@ class Athena::Routing::Response
   #   end
   # end
   #
-  # @[ADI::Register(tags: ["athena.event_dispatcher.listener"])]
+  # @[ADI::Register]
   # # Next define a new event listener to handle applying this writer
   # struct CompressionListener
   #   include AED::EventListenerInterface
-  #   include ADI::Service
   #
   #   def self.subscribed_events : AED::SubscribedEvents
   #     AED::SubscribedEvents{

--- a/src/time_converter.cr
+++ b/src/time_converter.cr
@@ -29,7 +29,7 @@ require "./param_converter_interface"
 #
 # # GET /event/2020-04-07/2020-04-08T12:34:56Z
 # ```
-@[ADI::Register(tags: [ART::ParamConverterInterface::TAG])]
+@[ADI::Register]
 struct Athena::Routing::TimeConverter < Athena::Routing::ParamConverterInterface
   configuration format : String? = nil, location : Time::Location = Time::Location::UTC
 


### PR DESCRIPTION
* Use `ADI.auto_configure` to handle applying tags to listeners
* Use type restriction on value resolvers binding to avoid possible name conflicts 
* Break argument resolver interface into own file