### PR TITLE
Integrate Serializer Component

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Dependencies
-        run: shards install --production
+        run: shards install --production --ignore-crystal-version
       - name: Specs
         run: make spec

--- a/shard.yml
+++ b/shard.yml
@@ -29,8 +29,11 @@ dependencies:
   amber_router:
     github: amberframework/amber-router
     version: ~> 0.4.1
+  athena-serializer:
+    github: athena-framework/serializer
+    branch: master
 
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.12.0
+    version: ~> 0.13.0

--- a/shard.yml
+++ b/shard.yml
@@ -31,7 +31,7 @@ dependencies:
     version: ~> 0.4.1
   athena-serializer:
     github: athena-framework/serializer
-    branch: master
+    version: ~> 0.1.0
 
 development_dependencies:
   ameba:

--- a/spec/listeners/view_listener_spec.cr
+++ b/spec/listeners/view_listener_spec.cr
@@ -1,11 +1,37 @@
 require "../spec_helper"
 
+private struct TestSerializer
+  include ASR::SerializerInterface
+
+  def serialize(data : _, format : ASR::Format | String, context : ASR::SerializationContext = ASR::SerializationContext.new, **named_args) : String
+    String.build do |str|
+      serialize data, format, str, context, **named_args
+    end
+  end
+
+  def serialize(data : _, format : ASR::Format | String, io : IO, context : ASR::SerializationContext = ASR::SerializationContext.new, **named_args) : Nil
+    io << "SERIALIZED_DATA".to_json
+  end
+
+  def deserialize(type : ASR::Model.class, data : String | IO, format : ASR::Format | String, context : ASR::DeserializationContext = ASR::DeserializationContext.new)
+  end
+end
+
+private record JSONSerializableModel, id : Int32 do
+  include JSON::Serializable
+end
+
+private record BothSerializableModel, id : Int32 do
+  include JSON::Serializable
+  include ASR::Serializable
+end
+
 describe ART::Listeners::View do
   it "with a Nil return type" do
     route = create_route(Nil) { }
     event = ART::Events::View.new new_request(route: route), ART::View.new nil
 
-    ART::Listeners::View.new.call(event, TracableEventDispatcher.new)
+    ART::Listeners::View.new(TestSerializer.new).call(event, TracableEventDispatcher.new)
 
     response = event.response.should_not be_nil
     response.status.should eq HTTP::Status::NO_CONTENT
@@ -13,14 +39,44 @@ describe ART::Listeners::View do
     response.content.should be_empty
   end
 
-  it "with a non Nil return type" do
-    event = ART::Events::View.new new_request, ART::View.new "DATA"
+  describe "with a non Nil return type" do
+    describe JSON::Serializable do
+      it "should just use .to_json" do
+        event = ART::Events::View.new new_request, ART::View.new JSONSerializableModel.new 123
 
-    ART::Listeners::View.new.call(event, TracableEventDispatcher.new)
+        ART::Listeners::View.new(TestSerializer.new).call(event, TracableEventDispatcher.new)
 
-    response = event.response.should_not be_nil
-    response.status.should eq HTTP::Status::OK
-    response.headers.should eq HTTP::Headers{"content-type" => "application/json"}
-    response.content.should eq %("DATA")
+        response = event.response.should_not be_nil
+        response.status.should eq HTTP::Status::OK
+        response.headers.should eq HTTP::Headers{"content-type" => "application/json"}
+        response.content.should eq %({"id":123})
+      end
+    end
+
+    describe "JSON::Serializable and ASR::Serializable" do
+      it "prioritizes ASR::Serializable" do
+        event = ART::Events::View.new new_request, ART::View.new BothSerializableModel.new 456
+
+        ART::Listeners::View.new(TestSerializer.new).call(event, TracableEventDispatcher.new)
+
+        response = event.response.should_not be_nil
+        response.status.should eq HTTP::Status::OK
+        response.headers.should eq HTTP::Headers{"content-type" => "application/json"}
+        response.content.should eq %("SERIALIZED_DATA")
+      end
+    end
+
+    describe "non JSON::Serializable" do
+      it "should use the serializer object" do
+        event = ART::Events::View.new new_request, ART::View.new "DATA"
+
+        ART::Listeners::View.new(TestSerializer.new).call(event, TracableEventDispatcher.new)
+
+        response = event.response.should_not be_nil
+        response.status.should eq HTTP::Status::OK
+        response.headers.should eq HTTP::Headers{"content-type" => "application/json"}
+        response.content.should eq %("SERIALIZED_DATA")
+      end
+    end
   end
 end

--- a/src/athena.cr
+++ b/src/athena.cr
@@ -6,6 +6,7 @@ require "amber_router"
 require "athena-config"
 require "athena-dependency_injection"
 require "athena-event_dispatcher"
+require "athena-serializer"
 
 require "./annotations"
 require "./controller"
@@ -32,6 +33,7 @@ require "./ext/configuration_resolver"
 require "./ext/conversion_types"
 require "./ext/event_dispatcher"
 require "./ext/request"
+require "./ext/serializer"
 
 # Convenience alias to make referencing `Athena::Routing` types easier.
 alias ART = Athena::Routing

--- a/src/ext/serializer.cr
+++ b/src/ext/serializer.cr
@@ -1,15 +1,5 @@
-require "athena-serializer"
-
 @[ADI::Register]
 struct Athena::Serializer::Serializer; end
-
-struct Athena::Routing::Listeners::View
-  def initialize(@serializer : ASR::SerializerInterface); end
-
-  protected def serialize(data, io : IO)
-    @serializer.serialize data, :json, io
-  end
-end
 
 @[ADI::Register]
 struct Athena::Serializer::Navigators::NavigatorFactory; end

--- a/src/ext/serializer.cr
+++ b/src/ext/serializer.cr
@@ -1,0 +1,18 @@
+require "athena-serializer"
+
+@[ADI::Register]
+struct Athena::Serializer::Serializer; end
+
+struct Athena::Routing::Listeners::View
+  def initialize(@serializer : ASR::SerializerInterface); end
+
+  protected def serialize(data, io : IO)
+    @serializer.serialize data, :json, io
+  end
+end
+
+@[ADI::Register]
+struct Athena::Serializer::Navigators::NavigatorFactory; end
+
+@[ADI::Register]
+struct Athena::Serializer::InstantiateObjectConstructor; end

--- a/src/listeners/view_listener.cr
+++ b/src/listeners/view_listener.cr
@@ -16,11 +16,15 @@ struct Athena::Routing::Listeners::View
   end
 
   def call(event : ART::Events::View, dispatcher : AED::EventDispatcherInterface) : Nil
-    event.response = if event.request.route.return_type == Nil?
+    event.response = if event.request.route.return_type == Nil
                        ART::Response.new status: :no_content, headers: get_headers
                      else
-                       ART::Response.new(headers: get_headers) { |io| event.view.data.to_json io }
+                       ART::Response.new(headers: get_headers) { |io| serialize event.view.data, io }
                      end
+  end
+
+  protected def serialize(data, io : IO)
+    data.to_json io
   end
 
   private def get_headers : HTTP::Headers

--- a/src/listeners/view_listener.cr
+++ b/src/listeners/view_listener.cr
@@ -24,7 +24,9 @@ struct Athena::Routing::Listeners::View
                        ART::Response.new(headers: get_headers) do |io|
                          data = event.view.data
 
-                         if data.is_a? JSON::Serializable
+                         # Still use `#to_json` for `JSON::Serializable`,
+                         # but prioritize `ASR::Serializable` if the type includes both.
+                         if data.is_a? JSON::Serializable && !data.is_a? ASR::Serializable
                            data.to_json io
                          else
                            @serializer.serialize data, :json, io


### PR DESCRIPTION
* Implements the https://github.com/athena-framework/serializer component into the core framework
  * Registers some serializer types as services
  * Integrates the serializer into the `View` listener
    * Still supports `JSON::Serializable`
* Bumps `Ameba` to `0.13.0`