### PR TITLE
Add a new `Action` event

### DIFF
--- a/spec/listeners/param_converter_listener_spec.cr
+++ b/spec/listeners/param_converter_listener_spec.cr
@@ -9,7 +9,7 @@ end
 describe ART::Listeners::ParamConverter do
   it "applies param converters related to the given route" do
     converters = [MockParamConverter::Configuration.new("argument", MockParamConverter)] of ART::ParamConverterInterface::ConfigurationInterface
-    event = ART::Events::Request.new new_request(action: new_action(param_converters: converters))
+    event = ART::Events::Action.new new_request, new_action param_converters: converters
 
     event.request.attributes.has?("argument").should be_false
 

--- a/spec/route_handler_spec.cr
+++ b/spec/route_handler_spec.cr
@@ -29,7 +29,7 @@ describe Athena::Routing::RouteHandler do
 
         handler.handle context
 
-        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::Response, ART::Events::Terminate]
+        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::Action, ART::Events::Response, ART::Events::Terminate]
         context.response.closed?.should be_true
         context.response.status.should eq HTTP::Status::OK
 
@@ -53,7 +53,7 @@ describe Athena::Routing::RouteHandler do
 
         handler.handle context
 
-        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::View, ART::Events::Response, ART::Events::Terminate]
+        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::Action, ART::Events::View, ART::Events::Response, ART::Events::Terminate]
         context.response.closed?.should be_true
         context.response.headers["content-type"].should eq "application/json"
         context.response.status.should eq HTTP::Status::CREATED
@@ -114,7 +114,7 @@ describe Athena::Routing::RouteHandler do
 
         handler.handle context
 
-        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::Exception, ART::Events::Response, ART::Events::Terminate]
+        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::Action, ART::Events::Exception, ART::Events::Response, ART::Events::Terminate]
         context.response.closed?.should be_true
         context.response.status.should eq HTTP::Status::BAD_REQUEST
 
@@ -135,7 +135,7 @@ describe Athena::Routing::RouteHandler do
           handler.handle context
         end
 
-        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::Exception]
+        dispatcher.emitted_events.should eq [ART::Events::Request, ART::Events::Action, ART::Events::Exception]
       end
     end
   end

--- a/src/athena.cr
+++ b/src/athena.cr
@@ -469,6 +469,7 @@ module Athena::Routing
     # Returns annotation configurations registered via `Athena::Config.configuration_annotation` and applied to `self`.
     #
     # These configurations could then be accessed within `ART::ParamConverterInterface`s and/or `ART::Listeners`s.
+    # See `ART::Events::RequestAware` for an example.
     getter annotation_configurations : ACF::AnnotationConfigurations
 
     def initialize(

--- a/src/events/action_event.cr
+++ b/src/events/action_event.cr
@@ -1,0 +1,15 @@
+require "./request_aware"
+
+# Emitted after `ART::Events::Request` and the related `ART::Action` has been resolved, but before it has been executed.
+#
+# This event can be used with listeners that require information from the related `ART::Action`, such as `ART::Action#annotation_configurations`.
+class Athena::Routing::Events::Action < AED::Event
+  include Athena::Routing::Events::RequestAware
+
+  # The related `ART::Action` that will be used to handle the current request.
+  getter action : ART::ActionBase
+
+  def initialize(request : HTTP::Request, @action : ART::ActionBase)
+    super request
+  end
+end

--- a/src/events/request_event.cr
+++ b/src/events/request_event.cr
@@ -3,7 +3,11 @@ require "./settable_response"
 
 # Emitted very early in the request's life-cycle; before the corresponding `ART::Action` (if any) has been resolved.
 #
-# This event can be listened on to add information to the request, or return a response before even triggering the router; `ART::Listeners::CORS` is an example of this.
+# This event can be listened on in order to:
+# * Add information to the request, via its `ART::ParameterBag`
+# * Return a response immediately if there is enough information available; `ART::Listeners::CORS` is an example of this
+#
+# NOTE: If your listener logic requires that the the corresponding `ART::Action` has been resolved, use `ART::Events::Action` instead.
 class Athena::Routing::Events::Request < AED::Event
   include Athena::Routing::Events::SettableResponse
   include Athena::Routing::Events::RequestAware

--- a/src/events/response_event.cr
+++ b/src/events/response_event.cr
@@ -1,6 +1,6 @@
 require "./request_aware"
 
-# Emitted after the route's action has been executed, but before the response has been sent.
+# Emitted after the route's action has been executed, but before the response has been returned to the client.
 #
 # This event can be listened on to modify the response object further before it is returned;
 # such as adding headers/cookies, compressing the response, etc.

--- a/src/events/settable_response.cr
+++ b/src/events/settable_response.cr
@@ -1,4 +1,6 @@
 # Represents an event where an `ART::Response` can be set on `self` to handle the original `HTTP::Request`.
+#
+# NOTE: Once `#response=` is called, propagation stops.  Or in other words, listeners with lower priority will not be executed.
 module Athena::Routing::Events::SettableResponse
   # The response object, if any.
   getter response : ART::Response? = nil

--- a/src/listeners/error_listener.cr
+++ b/src/listeners/error_listener.cr
@@ -1,5 +1,11 @@
 @[ADI::Register]
 # Handles an exception by converting it into an `ART::Response` via an `ART::ErrorRendererInterface`.
+#
+# This listener defines a `log_exception` protected method that determines how the exception gets logged.
+# Non `ART::Exceptions::HTTPException`s and server errors are logged as errors.
+# Validation errors (`ART::Exceptions::UnprocessableEntity`) are logged as notice.
+# Everything else is logged as a warning.
+# The method can be redefined if different logic is desired.
 struct Athena::Routing::Listeners::Error
   include AED::EventListenerInterface
 

--- a/src/listeners/param_converter_listener.cr
+++ b/src/listeners/param_converter_listener.cr
@@ -7,7 +7,7 @@ struct Athena::Routing::Listeners::ParamConverter
 
   def self.subscribed_events : AED::SubscribedEvents
     AED::SubscribedEvents{
-      ART::Events::Request => -250,
+      ART::Events::Action => -250,
     }
   end
 
@@ -19,8 +19,8 @@ struct Athena::Routing::Listeners::ParamConverter
     end
   end
 
-  def call(event : ART::Events::Request, dispatcher : AED::EventDispatcherInterface) : Nil
-    event.request.action.param_converters.each do |configuration|
+  def call(event : ART::Events::Action, dispatcher : AED::EventDispatcherInterface) : Nil
+    event.action.param_converters.each do |configuration|
       @param_converters[configuration.converter].apply event.request, configuration
     end
   end

--- a/src/route_handler.cr
+++ b/src/route_handler.cr
@@ -61,6 +61,9 @@ struct Athena::Routing::RouteHandler
       return finish_response response, request
     end
 
+    # Emit the action event
+    @event_dispatcher.dispatch ART::Events::Action.new request, request.action
+
     # Resolve the arguments for this action from the request
     arguments = @argument_resolver.get_arguments request, request.action
 


### PR DESCRIPTION
* Is emitted after `Request` but before the action is executed
* Moves `ART::Listeners::ParamConverter` to use this event
* Updates some event type documentation