### PR TITLE
Better versioning support

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -12,14 +12,14 @@ class TestController < ART::Controller
   end
 end
 
-macro create_action(return_type, view = nil, &)
+macro create_action(return_type, view_context = nil, &)
   ART::Action.new(
     ->{ ->{ {{yield}} } },
     "fake_method",
     "GET",
     Array(ART::Arguments::ArgumentMetadata(Nil)).new,
     Array(ART::ParamConverterInterface::ConfigurationInterface).new,
-    {{view}} || ART::Action::View.new,
+    {{view_context}} || ART::Action::ViewContext.new,
     ACF::AnnotationConfigurations.new,
     TestController,
     {{return_type}},
@@ -38,7 +38,7 @@ end
 def new_action(
   arguments : Array(ART::Arguments::ArgumentMetadata)? = nil,
   param_converters : Array(ART::ParamConverterInterface::ConfigurationInterface)? = nil,
-  view : ART::Action::View = ART::Action::View.new
+  view_context : ART::Action::ViewContext = ART::Action::ViewContext.new
 ) : ART::ActionBase
   ART::Action.new(
     ->{ test_controller = TestController.new; ->test_controller.get_test },
@@ -46,7 +46,7 @@ def new_action(
     "GET",
     arguments || Array(ART::Arguments::ArgumentMetadata(Nil)).new,
     param_converters || Array(ART::ParamConverterInterface::ConfigurationInterface).new,
-    view,
+    view_context,
     ACF::AnnotationConfigurations.new,
     TestController,
     String,

--- a/src/annotations.cr
+++ b/src/annotations.cr
@@ -194,12 +194,13 @@ module Athena::Routing
 
   # Configures how the endpoint should be rendered.
   #
-  # See `ART::Action::View`.
+  # See `ART::Action::ViewContext`.
   #
   # ## Fields
   #
   # * status : `HTTP::Status` - The `HTTP::Status` the endpoint should return.  Defaults to `HTTP::Status::OK` (200).
-  # * serialization_groups : `Array(String)` - The serialization groups to use for this route as part of `ASR::ExclusionStrategies::Groups`.  Defaults to `["default"]`.
+  # * serialization_groups : `Array(String)?` - The serialization groups to use for this route as part of `ASR::ExclusionStrategies::Groups`.
+  # * validation_groups : `Array(String)?` - Groups that should be used to validate any objects related to this route; see `AVD::Constraint@validation-groups`.
   # * emit_nil : `Bool` - If `nil` values should be serialized.  Defaults to `false`.
   #
   # ## Example

--- a/src/athena.cr
+++ b/src/athena.cr
@@ -619,12 +619,3 @@ module Athena::Routing
     end
   end
 end
-
-# class ExampleController < ART::Controller
-#   get "/" do
-#     "Hello World"
-#   end
-# end
-
-# # Run the server
-# ART.run

--- a/src/athena.cr
+++ b/src/athena.cr
@@ -482,20 +482,28 @@ module Athena::Routing
     # Stores runtime configuration data from the `ART::View` annotation about how to render the output of the related action.
     #
     # This includes the action's `HTTP::Status` and any serialization related configuration options.
-    struct View
+    class ViewContext
       # Returns `true` if the action related to `self` defined a custom status via the `ART::View` annotation, otherwise `false`.
       getter? has_custom_status : Bool
 
-      # The `HTTP::Status` this action should return.  Defaults to `HTTP::Status::OK` (200).
-      getter status : HTTP::Status
+      # Returns the `HTTP::Status` this action should return.  Defaults to `HTTP::Status::OK` (200).
+      property status : HTTP::Status
 
-      # The serialization groups to use for this route as part of `ASR::ExclusionStrategies::Groups`.
-      getter serialization_groups : Array(String)?
+      # Returns the groups that should be used for serialization as part of `ASR::ExclusionStrategies::Groups`.
+      property serialization_groups : Array(String)?
 
-      # If `nil` values should be serialized.
-      getter emit_nil : Bool = false
+      # Returns `true` if `nil` values should be serialized.
+      property emit_nil : Bool = false
 
-      getter validation_groups : Array(String)?
+      # Returns the groups that should be used to validate any objects related to this route.
+      #
+      # See `AVD::Constraint@validation-groups`.
+      property validation_groups : Array(String)?
+
+      # Returns the serialization version to use for this route as part of `ASR::ExclusionStrategies::Version`.
+      #
+      # Can be set as part of an `ART::Events::Action` event listener based on the resolved version of the request.
+      property version : String?
 
       def initialize(
         status : HTTP::Status? = nil,
@@ -508,20 +516,20 @@ module Athena::Routing
       end
     end
 
-    # The HTTP method associated with `self`.
+    # Returns the HTTP method associated with `self`.
     getter method : String
 
-    # The name of the the controller action related to `self`.
+    # Returns the name of the the controller action related to `self`.
     getter action_name : String
 
-    # An `Array(ART::Arguments::ArgumentMetadata)` that `self` requires.
+    # Returns an `Array(ART::Arguments::ArgumentMetadata)` that `self` requires.
     getter arguments : ArgumentsType
 
-    # An `Array(ART::ParamConverterInterface::ConfigurationInterface)` representing the `ART::ParamConverter`s applied to `self`.
+    # Returns an `Array(ART::ParamConverterInterface::ConfigurationInterface)` representing the `ART::ParamConverter`s applied to `self`.
     getter param_converters : Array(ART::ParamConverterInterface::ConfigurationInterface)
 
-    # The `ART::Action::View` configuration related to `self`.
-    getter view : View
+    # Returns the `ART::Action::ViewContext` related to `self`.
+    getter view_context : ART::Action::ViewContext
 
     # Returns annotation configurations registered via `Athena::Config.configuration_annotation` and applied to `self`.
     #
@@ -535,7 +543,7 @@ module Athena::Routing
       @method : String,
       @arguments : ArgumentsType,
       @param_converters : Array(ART::ParamConverterInterface::ConfigurationInterface),
-      @view : View,
+      @view_context : ART::Action::ViewContext,
       @annotation_configurations : ACF::AnnotationConfigurations,
       # Don't bother making these ivars since we just need them to set the generic types
       _controller : Controller.class,
@@ -611,3 +619,12 @@ module Athena::Routing
     end
   end
 end
+
+# class ExampleController < ART::Controller
+#   get "/" do
+#     "Hello World"
+#   end
+# end
+
+# # Run the server
+# ART.run

--- a/src/route_resolver.cr
+++ b/src/route_resolver.cr
@@ -126,10 +126,10 @@ class Athena::Routing::RouteResolver
             {% qp.raise "Route action '#{klass.name}##{m.name}' has an ART::QueryParam annotation but does not have a corresponding action argument for '#{arg_name.id}'." unless arg_names.includes? arg_name %}
           {% end %}
 
-          {% view = "ART::Action::View.new".id %}
+          {% view_context = "ART::Action::ViewContext.new".id %}
 
           {% if view_ann = m.annotation(View) %}
-            {% view = %(ART::Action::View.new(#{view_ann.named_args.double_splat})).id %}
+            {% view_context = %(ART::Action::ViewContext.new(#{view_ann.named_args.double_splat})).id %}
           {% end %}
 
           {% annotation_configurations = {} of Nil => Nil %}
@@ -165,7 +165,7 @@ class Athena::Routing::RouteResolver
               {{method}},
               {{arguments.empty? ? "Array(ART::Arguments::ArgumentMetadata(Nil)).new".id : arguments}},
               ({{param_converters}} of ART::ParamConverterInterface::ConfigurationInterface),
-              {{view}},
+              {{view_context}},
               ACF::AnnotationConfigurations.new({{annotation_configurations}} of ACF::AnnotationConfigurations::Classes => Array(ACF::AnnotationConfigurations::ConfigurationBase)),
               {{klass.id}},
               {{m.return_type}},
@@ -194,7 +194,7 @@ class Athena::Routing::RouteResolver
                 "HEAD",
                 {{arguments.empty? ? "Array(ART::Arguments::ArgumentMetadata(Nil)).new".id : arguments}},
                 ({{param_converters}} of ART::ParamConverterInterface::ConfigurationInterface),
-                {{view}},
+                {{view_context}},
                 ACF::AnnotationConfigurations.new({{annotation_configurations}} of ACF::AnnotationConfigurations::Classes => Array(ACF::AnnotationConfigurations::ConfigurationBase)),
                 {{klass.id}},
                 {{m.return_type}},


### PR DESCRIPTION
* Renames `ART::Action::View` to `ART::Action::ViewContext` to make it clearer it simply holds contextual runtime data about how a route should be serialized
  * Makes the `ViewContext` object a class to enable it to be mutated as part of event listeners
  * Updates getters/ivar names to reflect this
* Support setting the `version` on the serialization context off of the view context