### PR TITLE
Handle raised exceptions while rescuing an exception

### DIFF
--- a/src/route_handler.cr
+++ b/src/route_handler.cr
@@ -29,7 +29,11 @@ struct Athena::Routing::RouteHandler
       response.headers.merge! exception.headers
     end
 
-    return_response finish_response(response, context.request), context
+    begin
+      return_response finish_response(response, context.request), context
+    rescue
+      return_response response, context
+    end
   end
 
   private def return_response(response : ART::Response, context : HTTP::Server::Context) : Nil


### PR DESCRIPTION
* Rescues exceptions that occur within an `ART::Events::Response` listener
  * Returns the previous response when this happens