### PR TITLE
Use UTF-8 as charset in default renderers content-type headers

### DIFF
--- a/spec/error_renderer_spec.cr
+++ b/spec/error_renderer_spec.cr
@@ -8,7 +8,7 @@ describe ART::ErrorRenderer do
 
     response = renderer.render exception
 
-    response.headers.should eq HTTP::Headers{"retry-after" => "42", "content-type" => "application/json"}
+    response.headers.should eq HTTP::Headers{"retry-after" => "42", "content-type" => "application/json; charset=UTF-8"}
     response.status.should eq HTTP::Status::TOO_MANY_REQUESTS
     response.content.should eq %({"code":429,"message":"cool your jets"})
   end
@@ -20,7 +20,7 @@ describe ART::ErrorRenderer do
 
     response = renderer.render exception
 
-    response.headers.should eq HTTP::Headers{"content-type" => "application/json"}
+    response.headers.should eq HTTP::Headers{"content-type" => "application/json; charset=UTF-8"}
     response.status.should eq HTTP::Status::INTERNAL_SERVER_ERROR
     response.content.should eq %({"code":500,"message":"Internal Server Error"})
   end

--- a/spec/listeners/view_listener_spec.cr
+++ b/spec/listeners/view_listener_spec.cr
@@ -40,7 +40,7 @@ describe ART::Listeners::View do
 
       response = event.response.should_not be_nil
       response.status.should eq HTTP::Status::NO_CONTENT
-      response.headers.should eq HTTP::Headers{"content-type" => "application/json"}
+      response.headers.should eq HTTP::Headers{"content-type" => "application/json; charset=UTF-8"}
       response.content.should be_empty
     end
 
@@ -52,7 +52,7 @@ describe ART::Listeners::View do
 
       response = event.response.should_not be_nil
       response.status.should eq HTTP::Status::IM_A_TEAPOT
-      response.headers.should eq HTTP::Headers{"content-type" => "application/json"}
+      response.headers.should eq HTTP::Headers{"content-type" => "application/json; charset=UTF-8"}
       response.content.should be_empty
     end
 
@@ -64,7 +64,7 @@ describe ART::Listeners::View do
 
       response = event.response.should_not be_nil
       response.status.should eq HTTP::Status::OK
-      response.headers.should eq HTTP::Headers{"content-type" => "application/json"}
+      response.headers.should eq HTTP::Headers{"content-type" => "application/json; charset=UTF-8"}
       response.content.should be_empty
     end
   end
@@ -78,7 +78,7 @@ describe ART::Listeners::View do
 
         response = event.response.should_not be_nil
         response.status.should eq HTTP::Status::OK
-        response.headers.should eq HTTP::Headers{"content-type" => "application/json"}
+        response.headers.should eq HTTP::Headers{"content-type" => "application/json; charset=UTF-8"}
         response.content.should eq %({"id":123})
       end
     end
@@ -91,7 +91,7 @@ describe ART::Listeners::View do
 
         response = event.response.should_not be_nil
         response.status.should eq HTTP::Status::OK
-        response.headers.should eq HTTP::Headers{"content-type" => "application/json"}
+        response.headers.should eq HTTP::Headers{"content-type" => "application/json; charset=UTF-8"}
         response.content.should eq %("SERIALIZED_DATA")
       end
 
@@ -122,7 +122,7 @@ describe ART::Listeners::View do
 
         response = event.response.should_not be_nil
         response.status.should eq HTTP::Status::OK
-        response.headers.should eq HTTP::Headers{"content-type" => "application/json"}
+        response.headers.should eq HTTP::Headers{"content-type" => "application/json; charset=UTF-8"}
         response.content.should eq %("SERIALIZED_DATA")
       end
     end
@@ -134,7 +134,7 @@ describe ART::Listeners::View do
 
       response = event.response.should_not be_nil
       response.status.should eq HTTP::Status::IM_A_TEAPOT
-      response.headers.should eq HTTP::Headers{"content-type" => "application/json"}
+      response.headers.should eq HTTP::Headers{"content-type" => "application/json; charset=UTF-8"}
       response.content.should eq %("SERIALIZED_DATA")
     end
   end

--- a/src/error_renderer.cr
+++ b/src/error_renderer.cr
@@ -13,7 +13,7 @@ struct Athena::Routing::ErrorRenderer
       headers = HTTP::Headers.new
     end
 
-    headers["content-type"] = "application/json"
+    headers["content-type"] = "application/json; charset=UTF-8"
 
     ART::Response.new status, headers do |io|
       exception.to_json io

--- a/src/listeners/view_listener.cr
+++ b/src/listeners/view_listener.cr
@@ -53,6 +53,6 @@ struct Athena::Routing::Listeners::View
   end
 
   private def get_headers : HTTP::Headers
-    HTTP::Headers{"content-type" => "application/json"}
+    HTTP::Headers{"content-type" => "application/json; charset=UTF-8"}
   end
 end


### PR DESCRIPTION
* Sets `charset=UTF-8` within the `content-type` header for both the default view listener and error renderer
  * Given Crystal only supports `UTF-8`, this better represents the content.