### PR TITLE
Remove links to subheadings of other docstrings

### DIFF
--- a/src/annotations.cr
+++ b/src/annotations.cr
@@ -378,7 +378,7 @@ module Athena::Routing
   #
   # #### Extra Configuration
   #
-  # In some cases a param converter may require [additional configuration](./ParamConverterInterface.html#additional-configuration).
+  # In some cases a param converter may require [additional configuration][Athena::Routing::ParamConverterInterface].
   # In this case a `NamedTuple` may be provided as the value of `converter`.
   # The named tuple must contain a `name` key that represents the `ART::ParamConverterInterface.class` you wish to use for this query parameter.
   # Any additional key/value pairs will be passed to the param converter.

--- a/src/param_converter_interface.cr
+++ b/src/param_converter_interface.cr
@@ -105,7 +105,7 @@ abstract struct Athena::Routing::ParamConverterInterface
   # By default this type includes the name of the argument that should be converted and the
   # the `ART::ParamConverterInterface` that should be used for the conversion.
   #
-  # See the [Additional Configuration](../ParamConverterInterface.html#additional-configuration) example for more information.
+  # See the "Additional Configuration" example of `ParamConverterInterface` for more information.
   abstract struct ConfigurationInterface
     # The name of the argument the converter should be applied to.
     getter name : String
@@ -136,7 +136,7 @@ abstract struct Athena::Routing::ParamConverterInterface
   # Helper macro for defining an `ART::ParamConverterInterface::ConfigurationInterface`; similar to the `record` macro.
   # Accepts a variable amount of variable names, types, and optionally default values.
   #
-  # See the [Additional Configuration](./ParamConverterInterface.html#additional-configuration) example for more information.
+  # See the "Additional Configuration" example of `ParamConverterInterface` for more information.
   macro configuration(*args)
     struct Configuration < ConfigurationInterface
       {% for arg in args %}

--- a/src/params/param.cr
+++ b/src/params/param.cr
@@ -44,7 +44,7 @@ abstract struct Athena::Routing::Params::Param
 
   # Returns the key that should be used to access `self` from a given request.
   #
-  # Defaults to `#name`, but may be customized.  See [ART::QueryParam@key](../QueryParam.html#key).
+  # Defaults to `#name`, but may be customized.  See the "Key" section of `ART::QueryParam`.
   def key : String
     @key || @name
   end

--- a/src/params/param_fetcher_interface.cr
+++ b/src/params/param_fetcher_interface.cr
@@ -2,11 +2,11 @@
 module Athena::Routing::Params::ParamFetcherInterface
   # Returns the value of the parameter with the provided *name*.
   #
-  # Optionally allows determing if the params should be validated strictly.  See [ART::QueryParam@strict](../QueryParam.html#strict).
+  # Optionally allows determing if the params should be validated strictly.  See the "Strict" section of `ART::QueryParam`.
   abstract def get(name : String, strict : Bool? = nil)
 
   # Yields the name and value of each `ART::Params::ParamInterface` related to the current `ART::Action#params`.
   #
-  # Optionally allows determing if the params should be validated strictly.  See [ART::QueryParam@strict](../QueryParam.html#strict).
+  # Optionally allows determing if the params should be validated strictly.  See the "Strict" section of `ART::QueryParam`.
   abstract def each(strict : Bool? = nil, & : String, _ -> Nil) : Nil
 end

--- a/src/params/param_interface.cr
+++ b/src/params/param_interface.cr
@@ -12,13 +12,13 @@ module Athena::Routing::Params::ParamInterface
   # In the future this may be used to supplement auto generated endpoint documentation.
   abstract def description : String?
 
-  # Returns the parameters that may not be present at the same time as `self`.  See [ART::QueryParam@incompatibles](../QueryParam.html#incompatibles).
+  # Returns the parameters that may not be present at the same time as `self`.  See the "Incompatibilities" section of `ART::QueryParam`.
   abstract def incompatibles : Array(String)?
 
   # Returns the `AVD::Constraint`s that should be used to validate the parameter's value.
   abstract def constraints : Array(AVD::Constraint)
 
-  # Denotes whether `self` should be processed strictly.  See [ART::QueryParam@strict](../QueryParam.html#strict).
+  # Denotes whether `self` should be processed strictly.  See the "Strict" section of `ART::QueryParam`.
   abstract def strict? : Bool
 
   # Returns the `self`'s value from the provided *request*, or *default* if it was not present.

--- a/src/params/scalar_param.cr
+++ b/src/params/scalar_param.cr
@@ -2,12 +2,12 @@
 abstract struct Athena::Routing::Params::ScalarParam < Athena::Routing::Params::Param
   # Returns the requirements that the value is required to pass in order to be considered valid.
   #
-  # See [ART::QueryParam@requirements](../QueryParam.html#requirements).
+  # See the "Requirements" section of `ART::QueryParam`.
   getter requirements : AVD::Constraint | Array(AVD::Constraint) | Regex | Nil
 
   # Denotes whether the `#requirements` should be applied to the whole value, or to each item a part of the value.
   #
-  # See [ART::QueryParam@map](../QueryParam.html#map).
+  # See the "Map" section of `ART::QueryParam`.
   getter? map : Bool = false
 
   def initialize(


### PR DESCRIPTION
The links were Crystal-generator-specific, but mkdocstrings-crystal doesn't even have any equivalent.
