### PR TITLE
Expose the raw wrapped `HTTP::Request` instance

### DIFF
--- a/src/request.cr
+++ b/src/request.cr
@@ -53,6 +53,9 @@ class Athena::Routing::Request
   # Sets the `#request_format` to the explicitly passed format.
   setter request_format : String? = nil
 
+  # Returns the raw wrapped `HTTP::Request` instance.
+  getter request : HTTP::Request
+
   # :nodoc:
   forward_missing_to @request
 


### PR DESCRIPTION
* Supports stdlib/external library usages