### PR TITLE
Disallow whitespace when converting numeric inputs

### DIFF
--- a/spec/athena_spec.cr
+++ b/spec/athena_spec.cr
@@ -7,8 +7,20 @@ describe Athena::Routing do
         Int64.from_parameter("123").should eq 123_i64
       end
 
+      it "Int with whitespace" do
+        expect_raises ArgumentError, "Invalid Int32:    123" do
+          Int32.from_parameter("   123")
+        end
+      end
+
       it Float32 do
         Float32.from_parameter("3.14").should eq 3.14_f32
+      end
+
+      it "Float with whitespace" do
+        expect_raises ArgumentError, "Invalid Float64:    123.5" do
+          Float64.from_parameter("   123.5")
+        end
       end
     end
 

--- a/src/ext/conversion_types.cr
+++ b/src/ext/conversion_types.cr
@@ -34,7 +34,7 @@ end
 
 # :nodoc:
 def Number.from_parameter(value : String) : Number
-  new value
+  new value, whitespace: false
 end
 
 # :nodoc:


### PR DESCRIPTION
```cr
@[ARTA::Get("/foo/:id")]
def foo(id : Int32) : Int32
  id
end

GET /foo/%20%20%20123
```

Now results in a `400`.