### PR TITLE
Improved param validation

### DIFF
--- a/spec/exceptions/invalid_parameter_spec.cr
+++ b/spec/exceptions/invalid_parameter_spec.cr
@@ -17,7 +17,7 @@ describe ATH::Exceptions::InvalidParameter do
 
       exception = ATH::Exceptions::InvalidParameter.with_violations param, errors
 
-      exception.message.should eq "Parameter 'id' of value '' violated a constraint: 'ERROR'\n"
+      exception.message.should eq "Parameter 'id' is invalid."
       exception.status.should eq HTTP::Status::UNPROCESSABLE_ENTITY
       exception.violations.should eq errors
       exception.parameter.name.should eq "id"

--- a/spec/param_spec.cr
+++ b/spec/param_spec.cr
@@ -6,7 +6,7 @@ struct ParamTest < ATH::Spec::APITestCase
   end
 
   def test_required_query_param_missing : Nil
-    self.request("GET", "/query").body.should eq %({"code":422,"message":"Parameter 'search' of value '' violated a constraint: 'This value should not be null.'\\n"})
+    self.request("GET", "/query").body.should eq %({"code":422,"message":"Parameter 'search' is invalid.","errors":[{"property":"search","message":"This value should not be null.","code":"c7e77b14-744e-44c0-aa7e-391c69cc335c"}]})
   end
 
   def test_regex_query_param_provided_with_default : Nil
@@ -48,7 +48,7 @@ struct ParamTest < ATH::Spec::APITestCase
   def test_nilable_strict_regex_query_param_invalid_value : Nil
     response = self.request("GET", "/query/page-nilable-strict?page=20")
     response.status.should eq HTTP::Status::UNPROCESSABLE_ENTITY
-    response.body.should eq %({"code":422,"message":"Parameter 'page' of value '20' violated a constraint: 'Parameter 'page' value does not match requirements: (?-imsx:^(?-imsx:1\\\\d)$)'\\n"})
+    response.body.should eq %({"code":422,"message":"Parameter 'page' is invalid.","errors":[{"property":"page","message":"Parameter 'page' value does not match requirements: (?-imsx:^(?-imsx:1\\\\d)$)","code":"108987a0-2d81-44a0-b8d4-1c7ab8815343"}]})
   end
 
   def test_nilable_strict_regex_query_param_missing : Nil
@@ -62,7 +62,7 @@ struct ParamTest < ATH::Spec::APITestCase
   def test_annotation_query_param_invalid : Nil
     response = self.request("GET", "/query/annotation?search=")
     response.status.should eq HTTP::Status::UNPROCESSABLE_ENTITY
-    response.body.should eq %({"code":422,"message":"Parameter 'search' of value '' violated a constraint: 'This value should not be blank.'\\n"})
+    response.body.should eq %({"code":422,"message":"Parameter 'search' is invalid.","errors":[{"property":"search","message":"This value should not be blank.","code":"0d0c3254-3642-4cb0-9882-46ee5918e6e3"}]})
   end
 
   def test_annotation_array_valid : Nil
@@ -72,7 +72,7 @@ struct ParamTest < ATH::Spec::APITestCase
   def test_annotation_array_invalid : Nil
     response = self.request("GET", "/query/ids?ids=3.14&ids=-2.5")
     response.status.should eq HTTP::Status::UNPROCESSABLE_ENTITY
-    response.body.should eq %({"code":422,"message":"Parameter 'ids[1]' of value '-2.5' violated a constraint: 'This value should be positive or zero.'\\nParameter 'ids[1]' of value '-2.5' violated a constraint: 'This value should be between -1.0 and 10.'\\n"})
+    response.body.should eq %({"code":422,"message":"Parameter 'ids' is invalid.","errors":[{"property":"ids[1]","message":"This value should be positive or zero.","code":"e09e52d0-b549-4ba1-8b4e-420aad76f0de"},{"property":"ids[1]","message":"This value should be between -1.0 and 10.","code":"7e62386d-30ae-4e7c-918f-1b7e571c6d69"}]})
   end
 
   def test_param_converter_class : Nil

--- a/src/exceptions/invalid_parameter.cr
+++ b/src/exceptions/invalid_parameter.cr
@@ -5,18 +5,21 @@ class Athena::Framework::Exceptions::InvalidParameter < Athena::Framework::Excep
   getter violations : AVD::Violation::ConstraintViolationListInterface
 
   def self.with_violations(parameter : ATH::Params::ParamInterface, violations : AVD::Violation::ConstraintViolationListInterface) : self
-    message = String.build do |str|
-      violations.each do |violation|
-        invalid_value = violation.invalid_value
-
-        str.puts "Parameter '#{parameter.name}#{violation.property_path}' of value '#{invalid_value}' violated a constraint: '#{violation.message}'"
-      end
-    end
-
-    new parameter, violations, message
+    new parameter, violations, "Parameter '#{parameter.name}' is invalid."
   end
 
   def initialize(@parameter : ATH::Params::ParamInterface, @violations : AVD::Violation::ConstraintViolationListInterface, message : String, cause : Exception? = nil, headers : HTTP::Headers = HTTP::Headers.new)
     super message, cause, headers
+  end
+
+  def to_json(builder : JSON::Builder) : Nil
+    builder.object do
+      builder.field "code", self.status_code
+      builder.field "message", @message
+
+      builder.field "errors" do
+        @violations.to_json builder
+      end
+    end
   end
 end

--- a/src/params/param_fetcher.cr
+++ b/src/params/param_fetcher.cr
@@ -58,7 +58,8 @@ class Athena::Framework::Params::ParamFetcher
     return value if (constraints = param.constraints).empty?
 
     begin
-      errors = @validator.validate value, constraints
+      # Manually start the context so we can set the base path to the param's name.
+      errors = @validator.start_context(value).at_path(param.name).validate(value, constraints).violations
     rescue ex : AVD::Exceptions::ValidatorError
       violation = AVD::Violation::ConstraintViolation.new(
         ex.message || "Unhandled exception while validating '#{param.name}' param.",

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -6,7 +6,7 @@ require "athena-dependency_injection/spec"
 # Monkey patch HTTP::Server::Response to allow accessing the response body directly.
 class HTTP::Server::Response
   @body_io : IO = IO::Memory.new
-  getter body : String? = nil
+  @body : String? = nil
 
   def write(slice : Bytes) : Nil
     @body_io.write slice


### PR DESCRIPTION
* Include error list in `ATH::Exceptions::InvalidParameter`
  * Makes it more like the validation failed exception and much more useful as string parsing isnt required
* Set the base path to the parameter's name when validating params
  * Ensures the `property` in each error object correctly points to the param name + index if applicable