### PR TITLE
Remove extra spaces between paren and method call

### DIFF
--- a/src/components/console/src/descriptor/application.cr
+++ b/src/components/console/src/descriptor/application.cr
@@ -37,7 +37,7 @@ record Athena::Console::Descriptor::Application, application : ACON::Application
     namespaces = Hash(String, NamedTuple(id: String, commands: Array(String))).new
     aliases = Hash(String, ACON::Command).new
 
-    all_commands = @application.commands ((namespace = @namespace) ? @application.find_namespace(namespace) : nil)
+    all_commands = @application.commands((namespace = @namespace) ? @application.find_namespace(namespace) : nil)
 
     self.sort_commands(all_commands).each do |namespace, command_hash|
       names = Array(String).new

--- a/src/components/negotiation/spec/negotiator_spec.cr
+++ b/src/components/negotiation/spec/negotiator_spec.cr
@@ -47,7 +47,7 @@ struct NegotiatorTest < NegotiatorTestCase
     expected = expected.should_not be_nil
 
     accept_header.media_range.should eq expected[0]
-    accept_header.parameters.should eq (expected[1] || Hash(String, String).new)
+    accept_header.parameters.should eq(expected[1] || Hash(String, String).new)
   end
 
   def best_data_provider : Tuple

--- a/src/components/validator/spec/constraints/compound_validator_spec.cr
+++ b/src/components/validator/spec/constraints/compound_validator_spec.cr
@@ -4,7 +4,7 @@ private class DummyCompoundConstraint < AVD::Constraints::Compound
   def constraints : Array(AVD::Constraint)
     [
       AVD::Constraints::NotBlank.new,
-      AVD::Constraints::Size.new (..3),
+      AVD::Constraints::Size.new(..3),
     ]
   end
 end


### PR DESCRIPTION
Fixes the formatter error uncovered in CI: https://github.com/athena-framework/athena/runs/4734342116?check_suite_focus=true.