### PR TITLE
Dup the static route data hash

### DIFF
--- a/src/components/routing/spec/matcher/url_matcher_spec.cr
+++ b/src/components/routing/spec/matcher/url_matcher_spec.cr
@@ -118,6 +118,36 @@ struct URLMatcherTest < ASPEC::TestCase
     self.get_matcher(routes).match("/foo/baz").should eq({"_route" => "foo", "bar" => "baz", "def" => "test"})
   end
 
+  def test_match_returned_results_do_not_mutate_the_original_static_route : Nil
+    routes = self.build_collection do
+      add "foo", ART::Route.new "/foo", {"def" => "test"}
+    end
+
+    matcher = self.get_matcher routes
+
+    parameters = matcher.match("/foo")
+    parameters.should eq({"_route" => "foo", "def" => "test"})
+
+    parameters.delete "_route"
+
+    matcher.match("/foo").should eq({"_route" => "foo", "def" => "test"})
+  end
+
+  def test_match_returned_results_do_not_mutate_the_original_dynamic_route : Nil
+    routes = self.build_collection do
+      add "foo", ART::Route.new "/foo/{id}"
+    end
+
+    matcher = self.get_matcher routes
+
+    parameters = matcher.match("/foo/10")
+    parameters.should eq({"_route" => "foo", "id" => "10"})
+
+    parameters.delete "_route"
+
+    matcher.match("/foo/10").should eq({"_route" => "foo", "id" => "10"})
+  end
+
   def test_match_method_is_ignored_if_none_are_provided : Nil
     routes = self.build_collection do
       add "foo", ART::Route.new "/foo", methods: {"GET", "HEAD"}

--- a/src/components/routing/src/matcher/url_matcher.cr
+++ b/src/components/routing/src/matcher/url_matcher.cr
@@ -68,6 +68,9 @@ class Athena::Routing::Matcher::URLMatcher
         next
       end
 
+      # Dup the data hash so we don't mutate the original.
+      data = data.dup
+
       required_host.try do |h|
         case h
         in String then next if h != host


### PR DESCRIPTION
Otherwise any changes made to the matched route would mutate the original causing it to returned the altered on subsequent matches.