### PR TITLE
Refactor macro from inline if to ||=

### DIFF
--- a/src/components/dependency_injection/src/athena-dependency_injection.cr
+++ b/src/components/dependency_injection/src/athena-dependency_injection.cr
@@ -138,8 +138,7 @@ module Athena::DependencyInjection
       {% type = Crystal::Macros::Nop %}
     {% end %}
 
-    # TODO: Refactor this to ||= once https://github.com/crystal-lang/crystal/pull/9409 is released
-    {% BINDINGS[name] = {typed: [] of Nil, untyped: [] of Nil} if BINDINGS[name] == nil %}
+    {% BINDINGS[name] ||= {typed: [] of Nil, untyped: [] of Nil} %}
 
     {% if type == Crystal::Macros::Nop %}
       {% BINDINGS[name][:untyped].unshift({value: value, type: type}) %}


### PR DESCRIPTION
https://github.com/crystal-lang/crystal/pull/9409 was merged, adding support for ||= in macros