### PR TITLE
Refactor things to avoid large `Root` generic unions

### DIFF
--- a/src/components/framework/spec/request_body_converter_spec.cr
+++ b/src/components/framework/spec/request_body_converter_spec.cr
@@ -50,7 +50,7 @@ struct RequestBodyConverterTest < ASPEC::TestCase
 
     validator = AVD::Spec::MockValidator.new(
       AVD::Violation::ConstraintViolationList.new([
-        AVD::Violation::ConstraintViolation(String).new("error", "error", Hash(String, String).new, "", ".name", AVD::ValueContainer.new("")),
+        AVD::Violation::ConstraintViolation.new("error", "error", Hash(String, String).new, "", ".name", AVD::ValueContainer.new("")),
       ])
     )
 

--- a/src/components/validator/src/athena-validator.cr
+++ b/src/components/validator/src/athena-validator.cr
@@ -422,7 +422,7 @@ module Athena::Validator
       T
     end
 
-    def ==(other : self) : Bool
+    def ==(other : AVD::Container) : Bool
       @value == other.value
     end
   end

--- a/src/components/validator/src/athena-validator.cr
+++ b/src/components/validator/src/athena-validator.cr
@@ -439,6 +439,3 @@ module Athena::Validator
     AVD::Validator::RecursiveValidator.new
   end
 end
-
-violations = AVD.validator.validate "", AVD::Constraints::NotBlank.new
-pp violations

--- a/src/components/validator/src/athena-validator.cr
+++ b/src/components/validator/src/athena-validator.cr
@@ -69,24 +69,25 @@ alias Assert = AVD::Annotations
 #
 # violations.inspect # =>
 # # Athena::Validator::Violation::ConstraintViolationList(
-# #   @violations=
-# #     [Athena::Validator::Violation::ConstraintViolation(String)(
-# #     @cause=nil,
-# #     @code="0d0c3254-3642-4cb0-9882-46ee5918e6e3",
-# #     @constraint=
-# #       #<Athena::Validator::Constraints::NotBlank:0x7f97da08ced0
-# #       @allow_nil=false,
-# #       @groups=["default"],
+# #   @violations=[
+# #     Athena::Validator::Violation::ConstraintViolation(
+# #       @cause=nil,
+# #       @code="0d0c3254-3642-4cb0-9882-46ee5918e6e3",
+# #       @constraint=#<Athena::Validator::Constraints::NotBlank:0x7f8a7291fed0
+# #         @allow_nil=false,
+# #         @groups=["default"],
+# #         @message="This value should not be blank.",
+# #         @payload=nil>,
+# #       @invalid_value_container=Athena::Validator::ValueContainer(String)(@value=""),
 # #       @message="This value should not be blank.",
-# #       @payload=nil>,
-# #     @invalid_value_container=
-# #       Athena::Validator::ValueContainer(String)(@value=""),
-# #     @message="This value should not be blank.",
-# #     @message_template="This value should not be blank.",
-# #     @parameters={"{{ value }}" => ""},
-# #     @plural=nil,
-# #     @property_path="",
-# #     @root="")])
+# #       @message_template="This value should not be blank.",
+# #       @parameters={"{{ value }}" => ""},
+# #       @plural=nil,
+# #       @property_path="",
+# #       @root_container=Athena::Validator::ValueContainer(String)(@value="")
+# #     )
+# #   ]
+# )
 #
 # # Both the ConstraintViolationList and ConstraintViolation implement a `#to_s` method.
 # puts violations # =>
@@ -438,3 +439,6 @@ module Athena::Validator
     AVD::Validator::RecursiveValidator.new
   end
 end
+
+violations = AVD.validator.validate "", AVD::Constraints::NotBlank.new
+pp violations

--- a/src/components/validator/src/execution_context.cr
+++ b/src/components/validator/src/execution_context.cr
@@ -31,7 +31,7 @@ class Athena::Validator::ExecutionContext
   # The object that is currently being validated.
   getter object_container : AVD::Container = AVD::ValueContainer.new(nil)
 
-  def initialize(@validator : AVD::Validator::ValidatorInterface, root : _)
+  protected def initialize(@validator : AVD::Validator::ValidatorInterface, root : _)
     @root_container = AVD::ValueContainer.new root
   end
 

--- a/src/components/validator/src/execution_context.cr
+++ b/src/components/validator/src/execution_context.cr
@@ -2,7 +2,7 @@ require "./validator/validator_interface"
 require "./execution_context_interface"
 
 # Basic implementation of `AVD::ExecutionContextInterface`.
-class Athena::Validator::ExecutionContext(Root)
+class Athena::Validator::ExecutionContext
   include Athena::Validator::ExecutionContextInterface
 
   # :inherit:
@@ -26,13 +26,14 @@ class Athena::Validator::ExecutionContext(Root)
   # The value that is currently being validated.
   @value_container : AVD::Container = AVD::ValueContainer.new(nil)
 
-  # :inherit:
-  getter root : Root
+  protected getter root_container : AVD::Container
 
   # The object that is currently being validated.
   getter object_container : AVD::Container = AVD::ValueContainer.new(nil)
 
-  def initialize(@validator : AVD::Validator::ValidatorInterface, @root : Root); end
+  def initialize(@validator : AVD::Validator::ValidatorInterface, root : _)
+    @root_container = AVD::ValueContainer.new root
+  end
 
   # :nodoc:
   def constraint=(@constraint : AVD::Constraint?); end
@@ -48,6 +49,11 @@ class Athena::Validator::ExecutionContext(Root)
   # :inherit:
   def object
     @object_container.value
+  end
+
+  # :inherit:
+  def root
+    @root_container.value
   end
 
   # :inherit:
@@ -105,7 +111,7 @@ class Athena::Validator::ExecutionContext(Root)
       @constraint,
       message,
       parameters,
-      @root,
+      @root_container,
       @property_path,
       @value_container,
     )

--- a/src/components/validator/src/spec/constraint_validator_test_case.cr
+++ b/src/components/validator/src/spec/constraint_validator_test_case.cr
@@ -129,7 +129,7 @@ abstract struct Athena::Validator::Spec::ConstraintValidatorTestCase < ASPEC::Te
         @message,
         @message,
         @parameters,
-        @context.root,
+        @context.root_container,
         @property_path,
         @invalid_value,
         @plural,
@@ -147,7 +147,7 @@ abstract struct Athena::Validator::Spec::ConstraintValidatorTestCase < ASPEC::Te
   @root : String
   @property_path : String
   @constraint : AVD::Constraint
-  @context : AVD::ExecutionContext(String)?
+  @context : AVD::ExecutionContext?
   @validator : AVD::ConstraintValidatorInterface?
 
   def initialize
@@ -221,7 +221,7 @@ abstract struct Athena::Validator::Spec::ConstraintValidatorTestCase < ASPEC::Te
   end
 
   # Returns a reference to the context used for the current test.
-  def context : AVD::ExecutionContext(String)
+  def context : AVD::ExecutionContext
     @context.not_nil!
   end
 

--- a/src/components/validator/src/spec/constraint_validator_test_case.cr
+++ b/src/components/validator/src/spec/constraint_validator_test_case.cr
@@ -150,7 +150,7 @@ abstract struct Athena::Validator::Spec::ConstraintValidatorTestCase < ASPEC::Te
   @context : AVD::ExecutionContext?
   @validator : AVD::ConstraintValidatorInterface?
 
-  def initialize
+  protected def initialize
     @group = "my_group"
     @value = "invalid_value"
     @root = "root"
@@ -158,11 +158,11 @@ abstract struct Athena::Validator::Spec::ConstraintValidatorTestCase < ASPEC::Te
 
     @constraint = AVD::Constraints::NotBlank.new
 
-    context = self.create_context
+    ctx = self.create_context
     validator = self.create_validator
-    validator.context = context
+    validator.context = ctx
 
-    @context = context
+    @context = ctx
     @validator = validator
   end
 
@@ -233,11 +233,11 @@ abstract struct Athena::Validator::Spec::ConstraintValidatorTestCase < ASPEC::Te
   private def create_context : AVD::ExecutionContext
     validator = MockValidator.new
 
-    context = AVD::ExecutionContext.new validator, @root
-    context.group = @group
-    context.set_node @value, @object, @metadata, @property_path
-    context.constraint = @constraint
+    ctx = AVD::ExecutionContext.new validator, @root
+    ctx.group = @group
+    ctx.set_node @value, @object, @metadata, @property_path
+    ctx.constraint = @constraint
 
-    context
+    ctx
   end
 end

--- a/src/components/validator/src/violation/constraint_violation_builder.cr
+++ b/src/components/validator/src/violation/constraint_violation_builder.cr
@@ -1,7 +1,7 @@
 require "./constraint_violation_builder_interface"
 
 # Basic implementation of `AVD::Violation::ConstraintViolationBuilderInterface`.
-class Athena::Validator::Violation::ConstraintViolationBuilder(Root)
+class Athena::Validator::Violation::ConstraintViolationBuilder
   include Athena::Validator::Violation::ConstraintViolationBuilderInterface
 
   @plural : Int32?
@@ -12,7 +12,7 @@ class Athena::Validator::Violation::ConstraintViolationBuilder(Root)
     @constraint : AVD::Constraint?,
     @message : String,
     @parameters : Hash(String, String),
-    @root : Root,
+    @root_container : AVD::Container,
     @property_path : String,
     @invalid_value : AVD::Container
   )
@@ -31,11 +31,11 @@ class Athena::Validator::Violation::ConstraintViolationBuilder(Root)
 
     rendered_message = translated_message.gsub(/(?:{{ \w+ }})+/, @parameters)
 
-    @violations.add AVD::Violation::ConstraintViolation(Root).new(
+    @violations.add AVD::Violation::ConstraintViolation.new(
       rendered_message,
       @message,
       @parameters,
-      @root,
+      @root_container,
       @property_path,
       @invalid_value,
       @plural,

--- a/src/components/validator/src/violation/constraint_violation_builder.cr
+++ b/src/components/validator/src/violation/constraint_violation_builder.cr
@@ -7,7 +7,7 @@ class Athena::Validator::Violation::ConstraintViolationBuilder
   @plural : Int32?
   @cause : String?
 
-  def initialize(
+  protected def initialize(
     @violations : AVD::Violation::ConstraintViolationListInterface,
     @constraint : AVD::Constraint?,
     @message : String,


### PR DESCRIPTION
Leverages the `AVD::Container` pattern to avoid the large `Root` union. Ultimately makes the compiler happier and improves compile time performance.