### PR TITLE
Fix framework specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Dependencies
-        run: SHARDS_OVERRIDE=shard.dev.yml shards install
+        run: shards install
+        env:
+          SHARDS_OVERRIDE: shard.dev.yml
       - name: Ameba
         run: ./bin/ameba
   test:
@@ -50,8 +52,8 @@ jobs:
         with:
           crystal: ${{ matrix.crystal }}
       - name: Install Dependencies
-        run: SHARDS_OVERRIDE=shard.dev.yml shards install
+        run: shards install
+        env:
+          SHARDS_OVERRIDE: shard.dev.yml
       - name: Specs
         run: ./scripts/test.sh
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,13 +3,9 @@
 EXIT_CODE=0
 
 for component in $(find src/components/ -maxdepth 2 -type f -name shard.yml | xargs -I{} dirname {} | sort); do
-  git diff --quiet --exit-code $BASE_SHA $GITHUB_SHA -- $component
-  HAS_COMPONENT_CHANGED=$?
-  if [[ $GITHUB_EVENT_NAME != 'pull_request' || $HAS_COMPONENT_CHANGED == 1 ]]; then
-    echo "::group::$component"
-    crystal spec $component/spec --order random --error-on-warnings --exclude-warnings $component/spec || EXIT_CODE=1
-    echo "::endgroup::"
-  fi
+  echo "::group::$component"
+  crystal spec $component/spec --order random --error-on-warnings --exclude-warnings $component/spec || EXIT_CODE=1
+  echo "::endgroup::"
 done
 
 exit $EXIT_CODE

--- a/src/components/validator/src/spec.cr
+++ b/src/components/validator/src/spec.cr
@@ -143,7 +143,7 @@ module Athena::Validator::Spec
     setter violations_callback : Proc(AVD::Violation::ConstraintViolationListInterface)
 
     def self.new(violations : AVD::Violation::ConstraintViolationListInterface = AVD::Violation::ConstraintViolationList.new) : self
-      new ->{ violations }
+      new &->{ violations.as AVD::Violation::ConstraintViolationListInterface }
     end
 
     def initialize(&@violations_callback : -> AVD::Violation::ConstraintViolationListInterface); end


### PR DESCRIPTION
https://github.com/athena-framework/athena/pull/155 introduced a change that ultimately worked in the validator component, but broke the framework component given it changes the API of a type it was using. This PR fixes that, and makes CI run all component specs on any change again. Will take longer to get thru, but ultimately that's better than regressions.