### PR TITLE
Run specs with strict multi-assign flag

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,7 +4,7 @@ EXIT_CODE=0
 
 for component in $(find src/components/ -maxdepth 2 -type f -name shard.yml | xargs -I{} dirname {} | sort); do
   echo "::group::$component"
-  crystal spec $component/spec --order random --error-on-warnings --exclude-warnings $component/spec || EXIT_CODE=1
+  crystal spec -Dstrict_multi_assign $component/spec --order random --error-on-warnings --exclude-warnings $component/spec || EXIT_CODE=1
   echo "::endgroup::"
 done
 

--- a/src/components/image_size/spec/athena-image_size_spec.cr
+++ b/src/components/image_size/spec/athena-image_size_spec.cr
@@ -11,7 +11,7 @@ struct ImageTest < ASPEC::TestCase
       # width, height, bits, channels, format
       /(\d+)x(\d+)_(\d+)_(\d+)\.(\w+)$/.match(filename)
 
-      _, expected_width, expected_height, expected_bits, expected_channels, expected_format = $~
+      expected_width, expected_height, expected_bits, expected_channels, expected_format = $~[1..5]
 
       expected_bits = "0" == expected_bits ? nil : expected_bits.to_i
       expected_channels = "0" == expected_channels ? nil : expected_channels.to_i
@@ -93,7 +93,7 @@ struct ImageTest < ASPEC::TestCase
     # width, height, bits, channels, format
     /(\d+)x(\d+)_(\d+)_(\d+)\.(\w+)$/.match(filename)
 
-    _, expected_width, expected_height, expected_bits, expected_channels, expected_format = $~
+    expected_width, expected_height, expected_bits, expected_channels, expected_format = $~[1..5]
 
     expected_bits = "0" == expected_bits ? nil : expected_bits.to_i
     expected_channels = "0" == expected_channels ? nil : expected_channels.to_i


### PR DESCRIPTION
* Fix incompatibility

Assuming this will become the default in Crystal 2.0. This'll keep thing future proof by preventing unexpected errors later on.