### PR TITLE
Reduce constraint docs heading by one

### DIFF
--- a/src/components/validator/src/constraints/all.cr
+++ b/src/components/validator/src/constraints/all.cr
@@ -2,35 +2,35 @@ require "./composite"
 
 # Validates each element of an `Iterable` is valid based on a collection of constraints.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Required Arguments
+# ## Required Arguments
 #
-# #### constraints
+# ### constraints
 #
 # **Type:** `Array(AVD::Constraint) | AVD::Constraint`
 #
 # The `AVD::Constraint`(s) that you want to apply to each element of the underlying iterable.
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
 # NOTE: This constraint does not support a `message` argument.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #
 # Any arbitrary domain-specific data that should be stored with this constraint.
 # The [payload][Athena::Validator::Constraint--payload] is not used by `Athena::Validator`, but its processing is completely up to you.
 #
-# ## Usage
+# # Usage
 #
 # ```
 # class Example

--- a/src/components/validator/src/constraints/at_least_one_of.cr
+++ b/src/components/validator/src/constraints/at_least_one_of.cr
@@ -3,33 +3,33 @@ require "./composite"
 # Validates that a value satisfies at least one of the provided constraints.
 # Validation stops as soon as one constraint is satisfied.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Required Arguments
+# ## Required Arguments
 #
-# #### constraints
+# ### constraints
 #
 # **Type:** `Array(AVD::Constraint) | AVD::Constraint`
 #
 # The `AVD::Constraint`(s) from which at least one of has to be satisfied in order for the validation to succeed.
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### include_internal_messages
+# ### include_internal_messages
 #
 # **Type:** `Bool` **Default:** `true`
 #
 # If the validation failed message should include the list of messages for the internal constraints.
 # See the [message](#message) argument for an example.
 #
-# #### message_collection
+# ### message_collection
 #
 # **Type:** `String` **Default:** `Each element of this collection should satisfy its own set of constraints.`
 #
 # The message that will be shown if validation fails and the internal constraint is an `AVD::Constraints::All`.
 # See the [message](#message) argument for an example.
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should satisfy at least one of the following constraints:`
 #
@@ -41,21 +41,21 @@ require "./composite"
 #
 # > This value should satisfy at least one of the following constraints: [1] This value is too short. It should have 3 items or more. [2] Each element of this collection should satisfy its own set of constraints.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #
 # Any arbitrary domain-specific data that should be stored with this constraint.
 # The [payload][Athena::Validator::Constraint--payload] is not used by `Athena::Validator`, but its processing is completely up to you.
 #
-# ## Usage
+# # Usage
 #
 # ```
 # class Example

--- a/src/components/validator/src/constraints/blank.cr
+++ b/src/components/validator/src/constraints/blank.cr
@@ -1,29 +1,29 @@
 # Validates that a value is blank; meaning equal to an empty string or `nil`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should be blank.`
 #
 # The message that will be shown if the value is not blank.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/callback.cr
+++ b/src/components/validator/src/constraints/callback.cr
@@ -4,11 +4,11 @@
 # NOTE: The callback method itself does _fail_ or return any value.
 # Instead it should directly add violations to the `AVD::ExecutionContextInterface` argument.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Required Arguments
+# ## Required Arguments
 #
-# #### callback
+# ### callback
 #
 # **Type:** `AVD::Constraints::Callback::CallbackProc?` **Default:** `nil`
 #
@@ -16,7 +16,7 @@
 #
 # NOTE: If this argument is not supplied, the [callback_name](#callback_name) argument must be.
 #
-# #### callback_name
+# ### callback_name
 #
 # **Type:** `String?` **Default:** `nil`
 #
@@ -24,29 +24,29 @@
 #
 # NOTE: If this argument is not supplied, the [callback](#callback) argument must be.
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
 # NOTE: This constraint does not support a `message` argument.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #
 # Any arbitrary domain-specific data that should be stored with this constraint.
 # The [payload][Athena::Validator::Constraint--payload] is not used by `Athena::Validator`, but its processing is completely up to you.
 #
-# ## Usage
+# # Usage
 #
 # The callback constraint supports two callback methods when validating objects, and one callback method when using the constraint directly.
 #
-# ### Instance Methods
+# ## Instance Methods
 #
 # To define an instance callback method, apply the `@[Assert::Callback]` method to a public instance method defined within an object.
 # This method should accept two arguments: the `AVD::ExecutionContextInterface` to which violations should be added,
@@ -75,7 +75,7 @@
 # end
 # ```
 #
-# ### Class Methods
+# ## Class Methods
 #
 # The callback method can also be defined as a class method.
 # Since class methods do not have access to the related object instance, it is passed in as an argument.
@@ -109,7 +109,7 @@
 # end
 # ```
 #
-# ### Procs/Blocks
+# ## Procs/Blocks
 #
 # When working with constraints in a non object context, a callback passed in as a proc/block.
 # `AVD::Constraints::Callback::CallbackProc` alias can be used to more easily create a callback proc.

--- a/src/components/validator/src/constraints/choice.cr
+++ b/src/components/validator/src/constraints/choice.cr
@@ -1,51 +1,51 @@
 # Validates that a value is one of a given set of valid choices;
 # can also be used to validate that each item in a collection is one of those valid values.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Required Arguments
+# ## Required Arguments
 #
-# #### choices
+# ### choices
 #
 # **Type:** `Array(String | Number::Primitive | Symbol)`
 #
 # The choices that are considered valid.
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value is not a valid choice.`
 #
 # The message that will be shown if the value is not a valid choice and [multiple](#multiple) is `false`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 # * `{{ choices }}` - The available choices.
 #
-# #### multiple_message
+# ### multiple_message
 #
 # **Type:** `String` **Default:** `One or more of the given values is invalid.`
 #
 # The message that will be shown if one of the values is not a valid choice and [multiple](#multiple) is `true`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 # * `{{ choices }}` - The available choices.
 #
-# #### min_message
+# ### min_message
 #
 # **Type:** `String` **Default:** `You must select at least {{ limit }} choice.|You must select at least {{ limit }} choices.`
 #
 # The message that will be shown if too few choices are chosen as per the [range](#range) option.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -53,13 +53,13 @@
 # * `{{ choices }}` - The available choices.
 # * `{{ limit }}` - If [multiple](#multiple) is true, enforces that at most this many values may be selected in order to be valid.
 #
-# #### max_message
+# ### max_message
 #
 # **Type:** `String` **Default:** `You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.`
 #
 # The message that will be shown if too many choices are chosen as per the [range](#range) option.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -67,7 +67,7 @@
 # * `{{ choices }}` - The available choices.
 # * `{{ limit }}` - If [multiple](#multiple) is true, enforces that no more than this many values may be selected in order to be valid.
 #
-# #### range
+# ### range
 #
 # **Type:** `::Range?` **Default:** `nil`
 #
@@ -76,21 +76,21 @@
 #
 # Beginless/endless ranges can be used to define only a lower/upper bound.
 #
-# #### multiple
+# ### multiple
 #
 # **Type:** `Bool` **Default:** `false`
 #
 # If `true`, the input value is expected to be an `Enumerable` instead of a single scalar value.
 # The constraint will check each item in the enumerable is valid choice.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/compound.cr
+++ b/src/components/validator/src/constraints/compound.cr
@@ -2,27 +2,27 @@
 #
 # NOTE: See `AVD::Constraint@custom-constraints` for common documentation on defining custom constraints.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
 # NOTE: This constraint does not support a `message` argument.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #
 # Any arbitrary domain-specific data that should be stored with this constraint.
 # The [payload][Athena::Validator::Constraint--payload] is not used by `Athena::Validator`, but its processing is completely up to you.
 #
-# ## Usage
+# # Usage
 #
 # This constraint is not used directly on its own;
 # instead it's used to create another constraint.

--- a/src/components/validator/src/constraints/email.cr
+++ b/src/components/validator/src/constraints/email.cr
@@ -4,36 +4,36 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### mode
+# ### mode
 #
 # **Type:** `AVD::Constraints::Email::Mode` **Default:** `AVD::Constraints::Email::Mode::Loose`
 #
 # Defines the pattern that should be used to validate the email address.
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value is not a valid email address.`
 #
 # The message that will be shown if the value is not a valid email address.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/equal_to.cr
+++ b/src/components/validator/src/constraints/equal_to.cr
@@ -1,22 +1,22 @@
 # Validates that a value is equal to another.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Required Arguments
+# ## Required Arguments
 #
-# #### value
+# ### value
 #
 # Defines the value that the value being validated should be compared to.
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should be equal to {{ compared_value }}.`
 #
 # The message that will be shown if the value is not equal to the comparison value.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -24,14 +24,14 @@
 # * `{{ compared_value }}` - The expected value.
 # * `{{ compared_value_type }}` - The type of the expected value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/file.cr
+++ b/src/components/validator/src/constraints/file.cr
@@ -7,11 +7,11 @@ require "mime"
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### max_size
+# ### max_size
 #
 # **Type:** `Int | String | Nil` **Default:** `nil`
 #
@@ -26,14 +26,14 @@ require "mime"
 # | `Ki`   | kibibyte  | 1,024 bytes     | `"32Ki"`  |
 # | `Mi`   | mebibyte  | 1,048,576 bytes | `"8Mi"`   |
 #
-# #### mime_types
+# ### mime_types
 #
 # **Type:** `Enumerable(String)?` **Default:** `nil`
 #
 # If set, allows checking that the MIME type of the file is one of an allowed set of types.
 # This value is ignored if the MIME type of the file could not be determined.
 #
-# #### binary_format
+# ### binary_format
 #
 # **Type:** `Bool?` **Default:** `nil`
 #
@@ -41,13 +41,13 @@ require "mime"
 # When `false`, the sizes will be displayed with SI-prefixed units (kB, MB).
 # When `nil`, then the binaryFormat will be guessed from the value defined in the [max_size](#max_size) option.
 #
-# #### max_size_message
+# ### max_size_message
 #
 # **Type:** `String` **Default:** `The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.`
 #
 # The message that will be shown if the file is greater than the [max_size](#max_size).
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -57,51 +57,51 @@ require "mime"
 # * `{{ size }}` - The size of the invalid file.
 # * `{{ suffix }}` - Suffix for the used file size unit.
 #
-# #### not_found_message
+# ### not_found_message
 #
 # **Type:** `String` **Default:** `The file could not be found.`
 #
 # The message that will be shown if no file could be found at the given path.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ file }}` - Absolute path to the invalid file.
 #
-# #### empty_message
+# ### empty_message
 #
 # **Type:** `String` **Default:** `An empty file is not allowed.`
 #
 # The message that will be shown if the file is empty.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ file }}` - Absolute path to the invalid file.
 # * `{{ name }}` - Basename of the invalid file.
 #
-# #### not_readable_message
+# ### not_readable_message
 #
 # **Type:** `String` **Default:** `The file is not readable.`
 #
 # The message that will be shown if the file is not readable.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ file }}` - Absolute path to the invalid file.
 # * `{{ name }}` - Basename of the invalid file.
 #
-# #### mime_type_message
+# ### mime_type_message
 #
 # **Type:** `String` **Default:** `The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.`
 #
 # The message that will be shown if the MIME type of the file is not one of the valid [mime_types](#mime_types).
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -110,14 +110,14 @@ require "mime"
 # * `{{ type }}` - The MIME type of the invalid file.
 # * `{{ types }}` - The list of allowed MIME types.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/greater_than.cr
+++ b/src/components/validator/src/constraints/greater_than.cr
@@ -1,24 +1,24 @@
 # Validates that a value is greater than another.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Required Arguments
+# ## Required Arguments
 #
-# #### value
+# ### value
 #
 # **Type:** `Number | String | Time`
 #
 # Defines the value that the value being validated should be compared to.
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should be greater than {{ compared_value }}.`
 #
 # The message that will be shown if the value is not greater than the comparison value.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -26,14 +26,14 @@
 # * `{{ compared_value }}` - The expected value.
 # * `{{ compared_value_type }}` - The type of the expected value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/greater_than_or_equal.cr
+++ b/src/components/validator/src/constraints/greater_than_or_equal.cr
@@ -1,24 +1,24 @@
 # Validates that a value is greater than or equal to another.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Required Arguments
+# ## Required Arguments
 #
-# #### value
+# ### value
 #
 # **Type:** `Number | String | Time`
 #
 # Defines the value that the value being validated should be compared to.
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should be greater than or equal to {{ compared_value }}.`
 #
 # The message that will be shown if the value is not greater than or equal to the comparison value.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -26,14 +26,14 @@
 # * `{{ compared_value }}` - The expected value.
 # * `{{ compared_value_type }}` - The type of the expected value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/image.cr
+++ b/src/components/validator/src/constraints/image.cr
@@ -5,157 +5,157 @@ require "athena-image_size"
 #
 # See `AVD::Constraints::File` for common documentation.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### mime_types
+# ### mime_types
 #
 # **Type:** `Enumerable(String)?` **Default:** `{"image/*"}`
 #
 # Requires the file to have a valid image MIME type.
 # See [IANA website](https://www.iana.org/assignments/media-types/media-types.xhtml) for the full listing.
 #
-# #### mime_type_message
+# ### mime_type_message
 #
 # **Type:** `String` **Default:** `This file is not a valid image.`
 #
 # The message that will be shown if the file is not an image.
 #
-# #### min_height
+# ### min_height
 #
 # **Type:** `Int32` **Default:** `nil`
 #
 # If set, the image's height in pixels must be greater than or equal to this value.
 #
-# #### min_height_message
+# ### min_height_message
 #
 # **Type:** `String` **Default:** `The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.`
 #
 # The message that will be shown if the height of the image is less than `#min_height`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ height }}` - The current (invalid) height.
 # * `{{ min_height }}` - The minimum required height.
 #
-# #### max_height
+# ### max_height
 #
 # **Type:** `Int32` **Default:** `nil`
 #
 # If set, the image's height in pixels must be less than or equal to this value.
 #
-# #### max_height_message
+# ### max_height_message
 #
 # **Type:** `String` **Default:** `The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.`
 #
 # The message that will be shown if the height of the image exceeds `#max_height`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ height }}` - The current (invalid) height.
 # * `{{ max_height }}` - The maximum allowed height.
 #
-# #### min_width
+# ### min_width
 #
 # **Type:** `Int32` **Default:** `nil`
 #
 # If set, the image's width in pixels must be greater than or equal to this value.
 #
-# #### min_width_message
+# ### min_width_message
 #
 # **Type:** `String` **Default:** `The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.`
 #
 # The message that will be shown if the width of the image is less than `#min_width`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ width }}` - The current (invalid) width.
 # * `{{ min_width }}` - The minimum required width.
 #
-# #### max_width
+# ### max_width
 #
 # **Type:** `Int32` **Default:** `nil`
 #
 # If set, the image's width in pixels must be less than or equal to this value.
 #
-# #### max_width_message
+# ### max_width_message
 #
 # **Type:** `String` **Default:** `The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.`
 #
 # The message that will be shown if the width of the image exceeds `#max_width`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ width }}` - The current (invalid) width.
 # * `{{ max_width }}` - The maximum allowed width.
 #
-# #### size_not_detected_message
+# ### size_not_detected_message
 #
 # **Type:** `String` **Default:** `The size of the image could not be detected.`
 #
 # The message that will be shown if the size of the image is unable to be determined.
 # Will only occur if at least one of the size related options has been set.
 #
-# #### min_ratio
+# ### min_ratio
 #
 # **Type:** `Float64` **Default:** `nil`
 #
 # If set, the image's aspect ratio (`width / height`) must be greater than or equal to this value.
 #
-# #### min_ratio_message
+# ### min_ratio_message
 #
 # **Type:** `String` **Default:** `The image ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.`
 #
 # The message that will be shown if the aspect ratio of the image is less than `#min_ratio`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ ratio }}` - The current (invalid) ratio.
 # * `{{ min_ratio }}` - The minimum required ratio.
 #
-# #### max_ratio
+# ### max_ratio
 #
 # **Type:** `Float64` **Default:** `nil`
 #
 # If set, the image's aspect ratio (`width / height`) must be less than or equal to this value.
 #
-# #### max_ratio_message
+# ### max_ratio_message
 #
 # **Type:** `String` **Default:** `The image ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.`
 #
 # The message that will be shown if the aspect ratio of the image exceeds `#max_ratio`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ ratio }}` - The current (invalid) ratio.
 # * `{{ max_ratio }}` - The maximum allowed ratio.
 #
-# #### min_pixels
+# ### min_pixels
 #
 # **Type:** `Float64` **Default:** `nil`
 #
 # If set, the amount of pixels of the image file must be greater than or equal to this value.
 #
-# #### min_pixels_message
+# ### min_pixels_message
 #
 # **Type:** `String` **Default:** `The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.`
 #
 # The message that will be shown if the amount of pixels of the image is less than `#min_pixels`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -164,19 +164,19 @@ require "athena-image_size"
 # * `{{ pixels }}` - The image's pixels.
 # * `{{ min_pixels }}` - The minimum required pixels.
 #
-# #### max_pixels
+# ### max_pixels
 #
 # **Type:** `Float64` **Default:** `nil`
 #
 # If set, the amount of pixels of the image file must be less than or equal to this value.
 #
-# #### max_pixels_message
+# ### max_pixels_message
 #
 # **Type:** `String` **Default:** `The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.`
 #
 # The message that will be shown if the amount of pixels of the image is greater than `#max_pixels`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -185,72 +185,72 @@ require "athena-image_size"
 # * `{{ pixels }}` - The image's pixels.
 # * `{{ max_pixels }}` - The maximum allowed pixels.
 #
-# #### allow_landscape
+# ### allow_landscape
 #
 # **Type:** `Bool` **Default:** `true`
 #
 # If `false`, the image cannot be landscape oriented.
 #
-# #### allow_landscape_message
+# ### allow_landscape_message
 #
 # **Type:** `String` **Default:** `The image is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented images are not allowed.`
 #
 # The message that will be shown if the `#allow_landscape` is `false` and the image is landscape oriented.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ height }}` - The image's height.
 # * `{{ width }}` - The image's width.
 #
-# #### allow_portrait
+# ### allow_portrait
 #
 # **Type:** `Bool` **Default:** `true`
 #
 # If `false`, the image cannot be portrait oriented.
 #
-# #### allow_portrait_message
+# ### allow_portrait_message
 #
 # **Type:** `String` **Default:** `The image is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented images are not allowed.`
 #
 # The message that will be shown if the `#allow_portrait` is `false` and the image is portrait oriented.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ height }}` - The image's height.
 # * `{{ width }}` - The image's width.
 #
-# #### allow_square
+# ### allow_square
 #
 # **Type:** `Bool` **Default:** `true`
 #
 # If `false`, the image cannot be a square.
 # If you want to force the image to be a square, keep this as is and set `#allow_landscape` and `#allow_portrait` to `false`.
 #
-# #### allow_square_message
+# ### allow_square_message
 #
 # **Type:** `String` **Default:** `The image is square ({{ width }}x{{ height }}px). Square images are not allowed.`
 #
 # The message that will be shown if the `#allow_square` is `false` and the image is square.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ height }}` - The image's height.
 # * `{{ width }}` - The image's width.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/ip.cr
+++ b/src/components/validator/src/constraints/ip.cr
@@ -5,36 +5,36 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### version
+# ### version
 #
 # **Type:** `AVD::Constraints::IP::Version` **Default:** `AVD::Constraints::IP::Version::V4`
 #
 # Defines the pattern that should be used to validate the IP address.
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This is not a valid IP address.`
 #
 # The message that will be shown if the value is not a valid IP address.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/is_false.cr
+++ b/src/components/validator/src/constraints/is_false.cr
@@ -1,29 +1,29 @@
 # Validates that a value is `false`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should be false.`
 #
 # The message that will be shown if the value is not `false`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/is_nil.cr
+++ b/src/components/validator/src/constraints/is_nil.cr
@@ -1,29 +1,29 @@
 # Validates that a value is `nil`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should be null.`
 #
 # The message that will be shown if the value is not `nil`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/is_true.cr
+++ b/src/components/validator/src/constraints/is_true.cr
@@ -1,29 +1,29 @@
 # Validates that a value is `true`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should be true.`
 #
 # The message that will be shown if the value is not `true`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/isbn.cr
+++ b/src/components/validator/src/constraints/isbn.cr
@@ -4,73 +4,73 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### type
+# ### type
 #
 # **Type:** `AVD::Constraints::ISBN::Type` **Default:** `AVD::Constraints::ISBN::Type::Both`
 #
 # Type of ISBN to validate against.
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `""`
 #
 # The message that will be shown if the value is invalid.
 # This message has priority over the other messages if not empty.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### isbn10_message
+# ### isbn10_message
 #
 # **Type:** `String` **Default:** `This value is not a valid ISBN-10.`
 #
 # The message that will be shown if [type](#type) is `AVD::Constraints::ISBN::Type::ISBN10` and the value is invalid.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### isbn13_message
+# ### isbn13_message
 #
 # **Type:** `String` **Default:** `This value is not a valid ISBN-13.`
 #
 # The message that will be shown if [type](#type) is `AVD::Constraints::ISBN::Type::ISBN13` and the value is invalid.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### both_message
+# ### both_message
 #
 # **Type:** `String` **Default:** `This value is neither a valid ISBN-10 nor a valid ISBN-13.`
 #
 # The message that will be shown if [type](#type) is `AVD::Constraints::ISBN::Type::Both` and the value is invalid.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/isin.cr
+++ b/src/components/validator/src/constraints/isin.cr
@@ -4,30 +4,30 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value is not a valid International Securities Identification Number (ISIN).`
 #
 # The message that will be shown if the value is not a valid ISIN.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/issn.cr
+++ b/src/components/validator/src/constraints/issn.cr
@@ -4,44 +4,44 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### case_sensitive
+# ### case_sensitive
 #
 # **Type:** `Bool` **Default:** `false`
 #
 # The validator will allow ISSN values to end with a lowercase `x` by default.
 # When set to `true`, this requires an uppcase case `X`.
 #
-# #### require_hypen
+# ### require_hypen
 #
 # **Type:** `Bool` **Default:** `false`
 #
 # The validator will allow non hyphenated values by default.
 # When set to `true`, this requires a hyphenated ISSN value.
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value is not a valid International Standard Serial Number (ISSN).`
 #
 # The message that will be shown if the value is not a valid ISSN.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/less_than.cr
+++ b/src/components/validator/src/constraints/less_than.cr
@@ -1,24 +1,24 @@
 # Validates that a value is less than another.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Required Arguments
+# ## Required Arguments
 #
-# #### value
+# ### value
 #
 # **Type:** `Number | String | Time`
 #
 # Defines the value that the value being validated should be compared to.
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should be less than {{ compared_value }}.`
 #
 # The message that will be shown if the value is not less than the comparison value.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -26,14 +26,14 @@
 # * `{{ compared_value }}` - The expected value.
 # * `{{ compared_value_type }}` - The type of the expected value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/less_than_or_equal.cr
+++ b/src/components/validator/src/constraints/less_than_or_equal.cr
@@ -1,24 +1,24 @@
 # Validates that a value is less than or equal to another.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Required Arguments
+# ## Required Arguments
 #
-# #### value
+# ### value
 #
 # **Type:** `Number | String | Time`
 #
 # Defines the value that the value being validated should be compared to.
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should be less than or equal to {{ compared_value }}.`
 #
 # The message that will be shown if the value is not less than or equal to the comparison value.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -26,14 +26,14 @@
 # * `{{ compared_value }}` - The expected value.
 # * `{{ compared_value_type }}` - The type of the expected value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/luhn.cr
+++ b/src/components/validator/src/constraints/luhn.cr
@@ -4,30 +4,30 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value is not a valid credit card number.`
 #
 # The message that will be shown if the value is not pass the Luhn check.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/negative.cr
+++ b/src/components/validator/src/constraints/negative.cr
@@ -1,17 +1,17 @@
 # Validates that a value is a negative number.
 # Use `AVD::Constraints::NegativeOrZero` if you wish to also allow `0`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should be negative.`
 #
 # The message that will be shown if the value is not less than `0`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -19,14 +19,14 @@
 # * `{{ compared_value }}` - The expected value.
 # * `{{ compared_value_type }}` - The type of the expected value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/negative_or_zero.cr
+++ b/src/components/validator/src/constraints/negative_or_zero.cr
@@ -1,17 +1,17 @@
 # Validates that a value is a negative number, or `0`.
 # Use `AVD::Constraints::Negative` if you don't want to allow `0`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should be negative or zero.`
 #
 # The message that will be shown if the value is not less than or equal to `0`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -19,14 +19,14 @@
 # * `{{ compared_value }}` - The expected value.
 # * `{{ compared_value_type }}` - The type of the expected value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/not_blank.cr
+++ b/src/components/validator/src/constraints/not_blank.cr
@@ -1,35 +1,35 @@
 # Validates that a value is not blank; meaning not equal to a blank string, an empty `Iterable`, `false`, or optionally `nil`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### allow_nil
+# ### allow_nil
 #
 # **Type:** `Bool` **Default:** `false`
 #
 # If set to `true`, `nil` values are considered valid and will not trigger a violation.
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should not be blank.`
 #
 # The message that will be shown if the value is blank.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/not_equal_to.cr
+++ b/src/components/validator/src/constraints/not_equal_to.cr
@@ -1,22 +1,22 @@
 # Validates that a value is not equal to another.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Required Arguments
+# ## Required Arguments
 #
-# #### value
+# ### value
 #
 # Defines the value that the value being validated should be compared to.
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should not be equal to {{ compared_value }}.`
 #
 # The message that will be shown if the value is equal to the comparison value.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -24,14 +24,14 @@
 # * `{{ compared_value }}` - The expected value.
 # * `{{ compared_value_type }}` - The type of the expected value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/not_nil.cr
+++ b/src/components/validator/src/constraints/not_nil.cr
@@ -3,30 +3,30 @@
 # NOTE: Due to Crystal's static typing, when validating objects the property's type must be nilable,
 # otherwise `nil` is inherently not allowed due to the compiler's type checking.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should not be null.`
 #
 # The message that will be shown if the value is `nil`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/positive.cr
+++ b/src/components/validator/src/constraints/positive.cr
@@ -1,17 +1,17 @@
 # Validates that a value is a positive number.
 # Use `AVD::Constraints::PositiveOrZero` if you wish to also allow `0`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should be positive.`
 #
 # The message that will be shown if the value is not greater than `0`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -19,14 +19,14 @@
 # * `{{ compared_value }}` - The expected value.
 # * `{{ compared_value_type }}` - The type of the expected value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/positive_or_zero.cr
+++ b/src/components/validator/src/constraints/positive_or_zero.cr
@@ -1,17 +1,17 @@
 # Validates that a value is a positive number, or `0`.
 # Use `AVD::Constraints::Positive` if you don't want to allow `0`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should be positive or zero.`
 #
 # The message that will be shown if the value is not greater than or equal to `0`.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -19,14 +19,14 @@
 # * `{{ compared_value }}` - The expected value.
 # * `{{ compared_value_type }}` - The type of the expected value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/range.cr
+++ b/src/components/validator/src/constraints/range.cr
@@ -1,27 +1,27 @@
 # Validates that a `Number` or `Time` value is between some minimum and maximum.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Required Arguments
+# ## Required Arguments
 #
-# #### range
+# ### range
 #
 # **Type:** `::Range`
 #
 # The `::Range` that defines the minimum and maximum values, if any.
 # An endless range can be used to only have a minimum or maximum.
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
 # NOTE: This constraint does not support a `message` argument.
 #
-# #### not_in_range_message
+# ### not_in_range_message
 #
 # **Type:** `String` **Default:** `This value should be between {{ min }} and {{ max }}.`
 #
 # The message that will be shown if the value is less than the min or greater than the max.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -29,40 +29,40 @@
 # * `{{ min }}` - The lower limit.
 # * `{{ max }}` - The upper limit.
 #
-# #### min_message
+# ### min_message
 #
 # **Type:** `String` **Default:** `This value should be {{ limit }} or more.`
 #
 # The message that will be shown if the value is less than the min, and no max has been provided.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 # * `{{ limit }}` - The lower limit.
 #
-# #### max_message
+# ### max_message
 #
 # **Type:** `String` **Default:** `This value should be {{ limit }} or less.`
 #
 # The message that will be shown if the value is more than the max, and no min has been provided.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 # * `{{ limit }}` - The upper limit.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/regex.cr
+++ b/src/components/validator/src/constraints/regex.cr
@@ -4,45 +4,45 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Required Arguments
+# ## Required Arguments
 #
-# #### pattern
+# ### pattern
 #
 # **Type:** `::Regex`
 #
 # The `::Regex` pattern that the value should match.
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### match
+# ### match
 #
 # **Type:** `Bool` **Default:** `true`
 #
 # If set to `false`, validation will require the value does _NOT_ match the [pattern](#pattern).
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value should match '{{ pattern }}'.`
 #
 # The message that will be shown if the value does not match the [pattern](#pattern).
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 # * `{{ pattern }}` - The regular expression pattern that the value should match.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/sequentially.cr
+++ b/src/components/validator/src/constraints/sequentially.cr
@@ -1,34 +1,34 @@
 # Validates a value against a collection of constraints, stopping once the first violation is raised.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Required Arguments
+# ## Required Arguments
 #
-# #### constraints
+# ### constraints
 #
 # **Type:** `Array(AVD::Constraint) | AVD::Constraint`
 #
 # The `AVD::Constraint`(s) that are to be applied sequentially.
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
 # NOTE: This constraint does not support a `message` argument.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #
 # Any arbitrary domain-specific data that should be stored with this constraint.
 # The [payload][Athena::Validator::Constraint--payload] is not used by `Athena::Validator`, but its processing is completely up to you.
 #
-# ## Usage
+# # Usage
 #
 # Suppose you have an object with a `address` property which should meet the following criteria:
 #

--- a/src/components/validator/src/constraints/size.cr
+++ b/src/components/validator/src/constraints/size.cr
@@ -1,28 +1,28 @@
 # Validates that the `#size` of a `String` or `Indexable` value is between some minimum and maximum.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Required Arguments
+# ## Required Arguments
 #
-# #### range
+# ### range
 #
 # **Type:** `::Range`
 #
 # The `::Range` that defines the minimum and maximum values, if any.
 # An endless range can be used to only have a minimum or maximum.
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
 # NOTE: This constraint does not support a `message` argument.
 #
-# #### exact_message
+# ### exact_message
 #
 # **Type:** `String` **Default:** `This value should have exactly {{ limit }} {{ type }}.|This value should have exactly {{ limit }} {{ type }}s.`
 #
 # The message that will be shown if min and max values are equal and the underlying value’s size is not exactly this value.
 # The message is pluralized depending on how many elements/characters the underlying value has.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -30,14 +30,14 @@
 # * `{{ limit }}` - The exact expected size.
 # * `{{ type }}` - `character` if the value is a string or `item` if the value is an indexable.
 #
-# #### min_message
+# ### min_message
 #
 # **Type:** `String` **Default:** `This value is too short. It should have {{ limit }} {{ type }} or more.|This value is too short. It should have {{ limit }} {{ type }}s or more.`
 #
 # The message that will be shown if the underlying value’s size is less than the min.
 # The message is pluralized depending on how many elements/characters the underlying value has.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -45,14 +45,14 @@
 # * `{{ limit }}` - The expected minimum size.
 # * `{{ type }}` - `character` if the value is a string or `item` if the value is an indexable.
 #
-# #### max_message
+# ### max_message
 #
 # **Type:** `String` **Default:** `This value is too long. It should have {{ limit }} {{ type }} or less.|This value is too long. It should have {{ limit }} {{ type }}s or less.`
 #
 # The message that will be shown if the underlying value’s size is greater than the max.
 # The message is pluralized depending on how many elements/characters the underlying value has.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
@@ -60,14 +60,14 @@
 # * `{{ limit }}` - The expected minimum size.
 # * `{{ type }}` - `character` if the value is a string or `item` if the value is an indexable.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/unique.cr
+++ b/src/components/validator/src/constraints/unique.cr
@@ -1,29 +1,29 @@
 # Validates that all elements of an `Indexable` are unique.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This collection should contain only unique elements.`
 #
 # The message that will be shown if at least one element is repeated in the collection.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/url.cr
+++ b/src/components/validator/src/constraints/url.cr
@@ -4,42 +4,42 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
-# #### protocols
+# ### protocols
 #
 # **Type:** `Array(String)` **Default:** `["http", "https"]`
 #
 # The protocols considered to be valid for the URL.
 #
-# #### relative_protocol
+# ### relative_protocol
 #
 # **Type:** `Bool` **Default:** `false`
 #
 # If `true` the protocol is considered optional.
 #
-# #### message
+# ### message
 #
 # **Type:** `String` **Default:** `This value is not a valid URL.`
 #
 # The message that will be shown if the URL is not valid.
 #
-# ##### Placeholders
+# #### Placeholders
 #
 # The following placeholders can be used in this message:
 #
 # * `{{ value }}` - The current (invalid) value.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #

--- a/src/components/validator/src/constraints/valid.cr
+++ b/src/components/validator/src/constraints/valid.cr
@@ -1,26 +1,26 @@
 # Tells the validator that it should also validate objects embedded as properties on an object being validated.
 #
-# ## Configuration
+# # Configuration
 #
-# ### Optional Arguments
+# ## Optional Arguments
 #
 # NOTE: This constraint does not support a `message` argument.
 #
-# #### groups
+# ### groups
 #
 # **Type:** `Array(String) | String | Nil` **Default:** `nil`
 #
 # The [validation groups][Athena::Validator::Constraint--validation-groups] this constraint belongs to.
 # `AVD::Constraint::DEFAULT_GROUP` is assumed if `nil`.
 #
-# #### payload
+# ### payload
 #
 # **Type:** `Hash(String, String)?` **Default:** `nil`
 #
 # Any arbitrary domain-specific data that should be stored with this constraint.
 # The [payload][Athena::Validator::Constraint--payload] is not used by `Athena::Validator`, but its processing is completely up to you.
 #
-# ## Usage
+# # Usage
 #
 # Without this constraint, objects embedded in another object are not valided.
 #


### PR DESCRIPTION
* Makes them a bit easier to read as only `placeholders` is the grey color now