### PR TITLE
Disallow multi char option shortcuts made up of diff chars

### DIFF
--- a/src/components/console/spec/fixtures/commands/foo_opt.cr
+++ b/src/components/console/spec/fixtures/commands/foo_opt.cr
@@ -4,7 +4,7 @@ class FooOptCommand < IOCommand
       .name("foo:bar")
       .description("The foo:bar command")
       .aliases("afoobar")
-      .option("fooopt", "fo", :optional, "fooopt description")
+      .option("fooopt", "f", :optional, "fooopt description")
   end
 
   protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status

--- a/src/components/console/spec/input/option_spec.cr
+++ b/src/components/console/spec/input/option_spec.cr
@@ -29,6 +29,22 @@ describe ACON::Input::Option do
         ACON::Input::Option.new("foo", "a|  -b").shortcut.should eq "a|b"
       end
 
+      it "string with different characters" do
+        expect_raises ACON::Exceptions::InvalidArgument, "An option shortcut must consist of the same character, got 'ab'." do
+          ACON::Input::Option.new "foo", "ab"
+        end
+
+        expect_raises ACON::Exceptions::InvalidArgument, "An option shortcut must consist of the same character, got 'aab'." do
+          ACON::Input::Option.new "foo", "a|aa|aab"
+        end
+      end
+
+      it "array with different characters" do
+        expect_raises ACON::Exceptions::InvalidArgument, "An option shortcut must consist of the same character, got 'ba'." do
+          ACON::Input::Option.new "foo", ["a", "ba"]
+        end
+      end
+
       it "blank" do
         expect_raises ACON::Exceptions::InvalidArgument, "An option shortcut cannot be blank." do
           ACON::Input::Option.new "foo", [] of String

--- a/src/components/console/src/input/option.cr
+++ b/src/components/console/src/input/option.cr
@@ -80,7 +80,16 @@ class Athena::Console::Input::Option
         shortcut = shortcut.join '|'
       end
 
-      shortcut = shortcut.lchop('-').split(/(?:\|)-?/, remove_empty: true).map(&.strip.lchop('-')).join '|'
+      shortcut = shortcut.lchop('-').split(/(?:\|)-?/, remove_empty: true).map(&.strip.lchop('-'))
+
+      # Ensure each grouping contains only the same character
+      shortcut.each do |s|
+        unless s.split("").uniq!.size == 1
+          raise ACON::Exceptions::InvalidArgument.new "An option shortcut must consist of the same character, got '#{s}'."
+        end
+      end
+
+      shortcut = shortcut.join '|'
 
       raise ACON::Exceptions::InvalidArgument.new "An option shortcut cannot be blank." if shortcut.blank?
     end


### PR DESCRIPTION
Fixes #163 