### PR TITLE
Ensure only `Indexable` values can be used with `Unique` constraint

### DIFF
--- a/src/components/validator/spec/constraints/unique_validator_spec.cr
+++ b/src/components/validator/spec/constraints/unique_validator_spec.cr
@@ -17,6 +17,12 @@ struct UniqueValidatorTest < AVD::Spec::ConstraintValidatorTestCase
     self.assert_violation "my_message", CONSTRAINT::IS_NOT_UNIQUE_ERROR, value
   end
 
+  def test_invalid_type : Nil
+    expect_raises AVD::Exceptions::UnexpectedValueError, "Expected argument of type 'Indexable', 'Int32' given." do
+      self.validator.validate 123, new_constraint message: "my_message"
+    end
+  end
+
   def valid_values : NamedTuple
     {
       nil:             {nil},

--- a/src/components/validator/src/constraints/unique.cr
+++ b/src/components/validator/src/constraints/unique.cr
@@ -57,7 +57,7 @@ class Athena::Validator::Constraints::Unique < Athena::Validator::Constraint
     end
 
     # :inherit:
-    def compare_values(actual : _, expected : _) : NoReturn
+    def validate(actual : _, expected : _) : NoReturn
       # TODO: Support checking if arbitrarily typed values are actually comparable once `#responds_to?` supports it.
       self.raise_invalid_type actual, "Indexable"
     end


### PR DESCRIPTION
Fixes #139