### PR TITLE
Bump `ameba` to `~> 1.0`

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -40,4 +40,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.0
+    version: ~> 1.0

--- a/src/components/config/shard.yml
+++ b/src/components/config/shard.yml
@@ -2,7 +2,7 @@ name: athena-config
 
 version: 0.3.0
 
-crystal: '>= 0.35.0'
+crystal: ~> 1.4
 
 license: MIT
 
@@ -19,7 +19,7 @@ authors:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.0
+    version: ~> 1.0
   athena-spec:
     github: athena-framework/spec
     version: ~> 0.2.3

--- a/src/components/console/shard.yml
+++ b/src/components/console/shard.yml
@@ -2,7 +2,7 @@ name: athena-console
 
 version: 0.1.1
 
-crystal: '>= 0.35.0'
+crystal: ~> 1.4
 
 license: MIT
 
@@ -19,7 +19,7 @@ authors:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.0
+    version: ~> 1.0
   athena-spec:
     github: athena-framework/spec
     version: ~> 0.2.3

--- a/src/components/dependency_injection/shard.yml
+++ b/src/components/dependency_injection/shard.yml
@@ -2,7 +2,7 @@ name: athena-dependency_injection
 
 version: 0.3.2
 
-crystal: '>= 0.35.0'
+crystal: ~> 1.4
 
 license: MIT
 
@@ -24,7 +24,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.0
+    version: ~> 1.0
   athena-spec:
     github: athena-framework/spec
     version: ~> 0.2.3

--- a/src/components/event_dispatcher/shard.yml
+++ b/src/components/event_dispatcher/shard.yml
@@ -19,4 +19,4 @@ authors:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.13.0
+    version: ~> 1.0

--- a/src/components/event_dispatcher/shard.yml
+++ b/src/components/event_dispatcher/shard.yml
@@ -2,7 +2,7 @@ name: athena-event_dispatcher
 
 version: 0.1.3
 
-crystal: '>= 0.35.0'
+crystal: ~> 1.4
 
 license: MIT
 

--- a/src/components/framework/shard.yml
+++ b/src/components/framework/shard.yml
@@ -2,7 +2,7 @@ name: athena
 
 version: 0.16.0
 
-crystal: '>= 1.2.0'
+crystal: ~> 1.4
 
 license: MIT
 
@@ -45,7 +45,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.0
+    version: ~> 1.0
   athena-spec:
     github: athena-framework/spec
     version: ~> 0.2.3

--- a/src/components/image_size/shard.yml
+++ b/src/components/image_size/shard.yml
@@ -2,7 +2,7 @@ name: athena-image_size
 
 version: 0.1.0
 
-crystal: '>= 0.36.0'
+crystal: ~> 1.4
 
 license: MIT
 
@@ -19,7 +19,7 @@ authors:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.0
+    version: ~> 1.0
   athena-spec:
     github: athena-framework/spec
     version: ~> 0.2.3

--- a/src/components/negotiation/shard.yml
+++ b/src/components/negotiation/shard.yml
@@ -19,7 +19,7 @@ authors:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.13.0
+    version: ~> 1.0
   athena-spec:
     github: athena-framework/spec
     version: ~> 0.2.3

--- a/src/components/negotiation/shard.yml
+++ b/src/components/negotiation/shard.yml
@@ -2,7 +2,7 @@ name: athena-negotiation
 
 version: 0.1.1
 
-crystal: '>= 0.35.0'
+crystal: ~> 1.4
 
 license: MIT
 

--- a/src/components/routing/shard.yml
+++ b/src/components/routing/shard.yml
@@ -2,7 +2,7 @@ name: athena-routing
 
 version: 0.1.1
 
-crystal: '>= 1.2.0'
+crystal: ~> 1.4
 
 license: MIT
 
@@ -22,7 +22,7 @@ libraries:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.0
+    version: ~> 1.0
   athena-spec:
     github: athena-framework/spec
     version: ~> 0.2.3

--- a/src/components/routing/src/static_prefix_collection.cr
+++ b/src/components/routing/src/static_prefix_collection.cr
@@ -71,7 +71,6 @@ class Athena::Routing::RouteProvider::StaticPrefixCollection
       return
     end
 
-    # ameba:disable Lint/UnreachableCode
     @static_prefixes << static_prefix
     @prefixes << prefix
     @items << route

--- a/src/components/serializer/shard.yml
+++ b/src/components/serializer/shard.yml
@@ -2,7 +2,7 @@ name: athena-serializer
 
 version: 0.2.10
 
-crystal: '>= 0.35.0'
+crystal: ~> 1.4
 
 license: MIT
 
@@ -24,4 +24,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.0
+    version: ~> 1.0

--- a/src/components/spec/shard.yml
+++ b/src/components/spec/shard.yml
@@ -2,7 +2,7 @@ name: athena-spec
 
 version: 0.2.6
 
-crystal: '>= 0.35.0'
+crystal: ~> 1.4
 
 license: MIT
 
@@ -19,4 +19,4 @@ authors:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.0
+    version: ~> 1.0

--- a/src/components/validator/shard.yml
+++ b/src/components/validator/shard.yml
@@ -2,7 +2,7 @@ name: athena-validator
 
 version: 0.1.7
 
-crystal: '>= 0.35.0'
+crystal: ~> 1.4
 
 license: MIT
 
@@ -24,7 +24,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.0
+    version: ~> 1.0
   athena-spec:
     github: athena-framework/spec
     version: ~> 0.2.3


### PR DESCRIPTION
* Bump min crystal version for all components to `~> 1.4`
  * Required to build `ameba` on install, but will also be required coming up anyway
* Remove now unneeded `ameba:disable`

Fixes CI error