### PR TITLE
`shard.yml` cleanup

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -41,3 +41,6 @@ development_dependencies:
   ameba:
     github: crystal-ameba/ameba
     version: ~> 1.0
+  athena-spec:
+    github: athena-framework/spec
+    version: ~> 0.2.3

--- a/src/components/config/shard.yml
+++ b/src/components/config/shard.yml
@@ -15,11 +15,3 @@ description: |
 
 authors:
   - George Dietrich <george@dietrich.app>
-
-development_dependencies:
-  ameba:
-    github: crystal-ameba/ameba
-    version: ~> 1.0
-  athena-spec:
-    github: athena-framework/spec
-    version: ~> 0.2.3

--- a/src/components/console/shard.yml
+++ b/src/components/console/shard.yml
@@ -10,16 +10,8 @@ repository: https://github.com/athena-framework/console
 
 documentation: https://athenaframework.org/Console
 
-Allows the creation of CLI based commands.: |
+description: |
   Allows the creation of CLI based commands.
 
 authors:
   - George Dietrich <george@dietrich.app>
-
-development_dependencies:
-  ameba:
-    github: crystal-ameba/ameba
-    version: ~> 1.0
-  athena-spec:
-    github: athena-framework/spec
-    version: ~> 0.2.3

--- a/src/components/dependency_injection/shard.yml
+++ b/src/components/dependency_injection/shard.yml
@@ -20,11 +20,3 @@ dependencies:
   athena-config:
     github: athena-framework/config
     version: ~> 0.3.0
-
-development_dependencies:
-  ameba:
-    github: crystal-ameba/ameba
-    version: ~> 1.0
-  athena-spec:
-    github: athena-framework/spec
-    version: ~> 0.2.3

--- a/src/components/event_dispatcher/shard.yml
+++ b/src/components/event_dispatcher/shard.yml
@@ -15,8 +15,3 @@ description: |
 
 authors:
   - George Dietrich <george@dietrich.app>
-
-development_dependencies:
-  ameba:
-    github: crystal-ameba/ameba
-    version: ~> 1.0

--- a/src/components/framework/shard.yml
+++ b/src/components/framework/shard.yml
@@ -41,11 +41,3 @@ dependencies:
   athena-validator:
     github: athena-framework/validator
     version: ~> 0.1.3
-
-development_dependencies:
-  ameba:
-    github: crystal-ameba/ameba
-    version: ~> 1.0
-  athena-spec:
-    github: athena-framework/spec
-    version: ~> 0.2.3

--- a/src/components/image_size/shard.yml
+++ b/src/components/image_size/shard.yml
@@ -10,16 +10,8 @@ repository: https://github.com/athena-framework/image-size
 
 documentation: https://athenaframework.org/ImageSize
 
-Measures the size of various image formats: |
+description: |
   Measures the size of various image formats.
 
 authors:
   - George Dietrich <george@dietrich.app>
-
-development_dependencies:
-  ameba:
-    github: crystal-ameba/ameba
-    version: ~> 1.0
-  athena-spec:
-    github: athena-framework/spec
-    version: ~> 0.2.3

--- a/src/components/negotiation/shard.yml
+++ b/src/components/negotiation/shard.yml
@@ -15,11 +15,3 @@ description: |
 
 authors:
   - George Dietrich <george@dietrich.app>
-
-development_dependencies:
-  ameba:
-    github: crystal-ameba/ameba
-    version: ~> 1.0
-  athena-spec:
-    github: athena-framework/spec
-    version: ~> 0.2.3

--- a/src/components/routing/shard.yml
+++ b/src/components/routing/shard.yml
@@ -9,7 +9,7 @@ license: MIT
 repository: https://github.com/athena-framework/routing
 
 documentation: https://athenaframework.org/Routing
- 
+
 description: |
   HTTP based routing library/framework.
 
@@ -18,11 +18,3 @@ authors:
 
 libraries:
   libpcre2: '*'
-
-development_dependencies:
-  ameba:
-    github: crystal-ameba/ameba
-    version: ~> 1.0
-  athena-spec:
-    github: athena-framework/spec
-    version: ~> 0.2.3

--- a/src/components/serializer/shard.yml
+++ b/src/components/serializer/shard.yml
@@ -20,8 +20,3 @@ dependencies:
   athena-config:
     github: athena-framework/config
     version: '>= 0.2.0'
-
-development_dependencies:
-  ameba:
-    github: crystal-ameba/ameba
-    version: ~> 1.0

--- a/src/components/spec/shard.yml
+++ b/src/components/spec/shard.yml
@@ -15,8 +15,3 @@ description: |
 
 authors:
   - George Dietrich <george@dietrich.app>
-
-development_dependencies:
-  ameba:
-    github: crystal-ameba/ameba
-    version: ~> 1.0

--- a/src/components/validator/shard.yml
+++ b/src/components/validator/shard.yml
@@ -20,11 +20,3 @@ dependencies:
   athena-image_size:
     github: athena-framework/image-size
     version: ~> 0.1.0
-
-development_dependencies:
-  ameba:
-    github: crystal-ameba/ameba
-    version: ~> 1.0
-  athena-spec:
-    github: athena-framework/spec
-    version: ~> 0.2.3


### PR DESCRIPTION
* Add `athena-spec` as global dep and remove dev deps from each component
  * All dev will be done in the monorepo, so no reason for each component to have it and ameba as dependencies
* Fix `description` key of `shard.yml`