### PR TITLE
Update logger name to `athena.framework`

### DIFF
--- a/src/components/framework/src/logging.cr
+++ b/src/components/framework/src/logging.cr
@@ -1,5 +1,5 @@
 require "log"
 
 module Athena::Framework
-  Log = ::Log.for "athena.routing"
+  Log = ::Log.for "athena.framework"
 end


### PR DESCRIPTION
* Was missed when the component was renamed