### PR TITLE
Ensure parameter names defined on interfaces, match the implementation

### DIFF
--- a/src/components/console/src/formatter/null_style.cr
+++ b/src/components/console/src/formatter/null_style.cr
@@ -3,7 +3,7 @@ class Athena::Console::Formatter::NullStyle
   include Athena::Console::Formatter::OutputStyleInterface
 
   # :inherit:
-  def foreground=(forground : Colorize::Color)
+  def foreground=(foreground : Colorize::Color)
   end
 
   # :inherit:

--- a/src/components/console/src/formatter/output_style.cr
+++ b/src/components/console/src/formatter/output_style.cr
@@ -48,13 +48,13 @@ struct Athena::Console::Formatter::OutputStyle
   end
 
   # :inherit:
-  def foreground=(color : String)
-    if hex_value = color.lchop? '#'
+  def foreground=(foreground : String)
+    if hex_value = foreground.lchop? '#'
       r, g, b = hex_value.hexbytes
       return @foreground = Colorize::ColorRGB.new r, g, b
     end
 
-    @foreground = Colorize::ColorANSI.parse color
+    @foreground = Colorize::ColorANSI.parse foreground
   end
 
   # :inherit:

--- a/src/components/console/src/formatter/output_style_interface.cr
+++ b/src/components/console/src/formatter/output_style_interface.cr
@@ -83,7 +83,7 @@ require "colorize"
 # the text and have it open in your default browser. Otherwise, you will see it as regular text.
 module Athena::Console::Formatter::OutputStyleInterface
   # Sets the foreground color of `self`.
-  abstract def foreground=(forground : Colorize::Color)
+  abstract def foreground=(foreground : Colorize::Color)
 
   # Sets the background color of `self`.
   abstract def background=(background : Colorize::Color)

--- a/src/components/console/src/output/console_output_interface.cr
+++ b/src/components/console/src/output/console_output_interface.cr
@@ -8,7 +8,7 @@ module Athena::Console::Output::ConsoleOutputInterface
   abstract def error_output : ACON::Output::Interface
 
   # Sets the `ACON::Output::Interface` that represents `STDERR`.
-  abstract def error_output=(error_output : ACON::Output::Interface) : Nil
+  abstract def error_output=(stderr : ACON::Output::Interface) : Nil
 
   abstract def section : ACON::Output::Section
 end

--- a/src/components/framework/spec/route_handler_spec.cr
+++ b/src/components/framework/spec/route_handler_spec.cr
@@ -5,7 +5,7 @@ private struct MockArgumentResolver
 
   def initialize(@exception : ::Exception? = nil); end
 
-  def get_arguments(request : ATH::Request, action : ATH::ActionBase) : Array
+  def get_arguments(request : ATH::Request, route : ATH::ActionBase) : Array
     if ex = @exception
       raise ex
     end

--- a/src/components/framework/src/view/view_handler.cr
+++ b/src/components/framework/src/view/view_handler.cr
@@ -43,7 +43,8 @@ class Athena::Framework::View::ViewHandler
   end
 
   # :inherit:
-  def serialization_version=(@serialization_version : SemanticVersion) : Nil
+  def serialization_version=(version : SemanticVersion) : Nil
+    @serialization_version = version
   end
 
   # :inherit:

--- a/src/components/routing/src/generator/url_generator.cr
+++ b/src/components/routing/src/generator/url_generator.cr
@@ -47,12 +47,16 @@ class Athena::Routing::Generator::URLGenerator
   property context : ART::RequestContext
 
   # :inherit:
-  property? strict_requirements : Bool? = true
+  getter? strict_requirements : Bool? = true
 
   def initialize(
     @context : ART::RequestContext,
     @default_locale : String? = nil
   )
+  end
+
+  def strict_requirements=(enabled : Bool?)
+    @strict_requirements = enabled
   end
 
   # :inherit:

--- a/src/components/serializer/src/any.cr
+++ b/src/components/serializer/src/any.cr
@@ -14,7 +14,7 @@ module Athena::Serializer::Any
   abstract def as_a
   abstract def as_a?
   abstract def is_nil? : Bool
-  abstract def dig(key_or_index : String | Int, *keys)
+  abstract def dig(index_or_key : String | Int, *keys)
 
   abstract def raw
 end

--- a/src/components/serializer/src/serializer.cr
+++ b/src/components/serializer/src/serializer.cr
@@ -28,7 +28,7 @@ struct Athena::Serializer::Serializer
   def initialize(@navigator_factory : ASR::Navigators::NavigatorFactoryInterface = ASR::Navigators::NavigatorFactory.new); end
 
   # :inherit:
-  def deserialize(type : _, input_data : String | IO, format : ASR::Format | String, context : ASR::DeserializationContext = ASR::DeserializationContext.new)
+  def deserialize(type : _, data : String | IO, format : ASR::Format | String, context : ASR::DeserializationContext = ASR::DeserializationContext.new)
     # Initialize the context.  Currently just used to apply default exclusion strategies
     context.init
 
@@ -37,7 +37,7 @@ struct Athena::Serializer::Serializer
 
     visitor.navigator = navigator
 
-    navigator.accept type, visitor.prepare input_data
+    navigator.accept type, visitor.prepare data
   end
 
   # :inherit:

--- a/src/components/serializer/src/visitors/json_deserialization_visitor.cr
+++ b/src/components/serializer/src/visitors/json_deserialization_visitor.cr
@@ -1,5 +1,5 @@
 class Athena::Serializer::Visitors::JSONDeserializationVisitor < Athena::Serializer::Visitors::DeserializationVisitor
-  def prepare(input : IO | String) : ASR::Any
-    JSON.parse input
+  def prepare(data : IO | String) : ASR::Any
+    JSON.parse data
   end
 end

--- a/src/components/serializer/src/visitors/json_serialization_visitor.cr
+++ b/src/components/serializer/src/visitors/json_serialization_visitor.cr
@@ -21,9 +21,9 @@ class Athena::Serializer::Visitors::JSONSerializationVisitor
   end
 
   # :inherit:
-  def visit(properties : Array(PropertyMetadataBase)) : Nil
+  def visit(data : Array(PropertyMetadataBase)) : Nil
     @builder.object do
-      properties.each do |prop|
+      data.each do |prop|
         @builder.field(prop.external_name) do
           visit prop.value
         end

--- a/src/components/serializer/src/visitors/serialization_visitor_interface.cr
+++ b/src/components/serializer/src/visitors/serialization_visitor_interface.cr
@@ -2,7 +2,7 @@ module Athena::Serializer::Visitors::SerializationVisitorInterface
   abstract def prepare : Nil
   abstract def finish : Nil
 
-  abstract def visit(data : Array(ASR::PropertyMetadataBase)) : Nil
+  abstract def visit(properties : Array(ASR::PropertyMetadataBase)) : Nil
   abstract def visit(data : Bool) : Nil
   abstract def visit(data : Enum) : Nil
   abstract def visit(data : Enumerable) : Nil

--- a/src/components/serializer/src/visitors/serialization_visitor_interface.cr
+++ b/src/components/serializer/src/visitors/serialization_visitor_interface.cr
@@ -2,7 +2,7 @@ module Athena::Serializer::Visitors::SerializationVisitorInterface
   abstract def prepare : Nil
   abstract def finish : Nil
 
-  abstract def visit(properties : Array(ASR::PropertyMetadataBase)) : Nil
+  abstract def visit(data : Array(ASR::PropertyMetadataBase)) : Nil
   abstract def visit(data : Bool) : Nil
   abstract def visit(data : Enum) : Nil
   abstract def visit(data : Enumerable) : Nil

--- a/src/components/serializer/src/visitors/yaml_deserialization_visitor.cr
+++ b/src/components/serializer/src/visitors/yaml_deserialization_visitor.cr
@@ -1,5 +1,5 @@
 class Athena::Serializer::Visitors::YAMLDeserializationVisitor < Athena::Serializer::Visitors::DeserializationVisitor
-  def prepare(input : IO | String) : ASR::Any
-    YAML.parse input
+  def prepare(data : IO | String) : ASR::Any
+    YAML.parse data
   end
 end

--- a/src/components/serializer/src/visitors/yaml_serialization_visitor.cr
+++ b/src/components/serializer/src/visitors/yaml_serialization_visitor.cr
@@ -18,9 +18,9 @@ class Athena::Serializer::Visitors::YAMLSerializationVisitor
   end
 
   # :inherit:
-  def visit(properties : Array(PropertyMetadataBase)) : Nil
+  def visit(data : Array(PropertyMetadataBase)) : Nil
     @builder.mapping do
-      properties.each do |prop|
+      data.each do |prop|
         @builder.scalar prop.external_name
         visit prop.value
       end

--- a/src/components/validator/src/constraint_validator_factory.cr
+++ b/src/components/validator/src/constraint_validator_factory.cr
@@ -19,12 +19,12 @@ struct Athena::Validator::ConstraintValidatorFactory
   #
   # NOTE: This overloaded is intended to be used for service based validators that are already
   # instantiated and were provided via DI.
-  def validator(validator_class : AVD::ServiceConstraintValidator.class) : AVD::ConstraintValidator
+  def validator(for validator_class : AVD::ServiceConstraintValidator.class) : AVD::ConstraintValidator
     @validators[validator_class]
   end
 
   # Returns an `AVD::ConstraintValidator` based on the provided *validator_class*.
-  def validator(validator_class : AVD::ConstraintValidator.class) : AVD::ConstraintValidator
+  def validator(for validator_class : AVD::ConstraintValidator.class) : AVD::ConstraintValidator
     if validator = @validators[validator_class]?
       return validator
     end

--- a/src/components/validator/src/constraint_validator_factory_interface.cr
+++ b/src/components/validator/src/constraint_validator_factory_interface.cr
@@ -3,5 +3,5 @@
 # `AVD::ServiceConstraintValidator`s are instantiated externally and injected into the factory.
 module Athena::Validator::ConstraintValidatorFactoryInterface
   # Returns an `AVD::ConstraintValidatorInterface` instance based on the provided *validator_class*.
-  abstract def validator(validator : AVD::ConstraintValidator.class) : AVD::ConstraintValidatorInterface
+  abstract def validator(for validator_class : AVD::ConstraintValidator.class) : AVD::ConstraintValidatorInterface
 end

--- a/src/components/validator/src/violation/constraint_violation_builder.cr
+++ b/src/components/validator/src/violation/constraint_violation_builder.cr
@@ -82,7 +82,8 @@ class Athena::Validator::Violation::ConstraintViolationBuilder
   end
 
   # :inherit:
-  def plural(@plural : Int32) : AVD::Violation::ConstraintViolationBuilderInterface
+  def plural(number : Int32) : AVD::Violation::ConstraintViolationBuilderInterface
+    @plural = number
     self
   end
 


### PR DESCRIPTION
Addresses warnings brought up by https://github.com/crystal-lang/crystal/pull/11915. Introduces some breaking changes by fixing typos and changes in the names of the parameters on the interfaces, so will version this accordingly.