### PR TITLE
Fix issue with duplicated constrains

### DIFF
--- a/src/components/validator/spec/validatable_spec.cr
+++ b/src/components/validator/spec/validatable_spec.cr
@@ -42,6 +42,13 @@ private class ClassCallbackClass
   end
 end
 
+private class ComparisonConstrained
+  include AVD::Validatable
+
+  @[Assert::LessThan(10)]
+  getter age : Int32 = 0
+end
+
 describe AVD::Validatable do
   describe ".load_metadata" do
     it "should manually add constraints to the metadata object" do
@@ -72,6 +79,10 @@ describe AVD::Validatable do
       constraints = ClassCallbackClass.validation_class_metadata.constraints
       constraints.size.should eq 1
       constraints.first.should be_a AVD::Constraints::Callback
+    end
+
+    it "does not duplicate property metadata for generic module constraints" do
+      ComparisonConstrained.validation_class_metadata.property_metadata("age").first.constraints.size.should eq 1
     end
   end
 end

--- a/src/components/validator/src/metadata/class_metadata.cr
+++ b/src/components/validator/src/metadata/class_metadata.cr
@@ -16,7 +16,7 @@ class Athena::Validator::Metadata::ClassMetadata(T)
     {% begin %}
       # Add property constraints
       {% for ivar, idx in T.instance_vars %}
-        {% for constraint in AVD::Constraint.all_subclasses.reject &.abstract? %}
+        {% for constraint in AVD::Constraint.all_subclasses.reject { |c| c.abstract? || (c.type_vars.size > 0 && c.type_vars.first.stringify != "ValueType") } %}
           {% ann_name = constraint.name(generic_args: false).split("::").last.id %}
 
           {% if ann = ivar.annotation Assert.constant(ann_name).resolve %}


### PR DESCRIPTION
Filters out unexpected constraint subclasses due to https://github.com/crystal-lang/crystal/issues/4035.