### PR TITLE
Validate IP addresses via dedicated `Socket::IPAddress` methods

### DIFF
--- a/src/components/framework/shard.yml
+++ b/src/components/framework/shard.yml
@@ -2,7 +2,7 @@ name: athena
 
 version: 0.17.1
 
-crystal: ~> 1.4
+crystal: ~> 1.6
 
 license: MIT
 

--- a/src/components/validator/shard.yml
+++ b/src/components/validator/shard.yml
@@ -2,7 +2,7 @@ name: athena-validator
 
 version: 0.2.1
 
-crystal: ~> 1.4
+crystal: ~> 1.6
 
 license: MIT
 


### PR DESCRIPTION
* Leverages the new `Socket::IPAddress` methods introduced in https://github.com/crystal-lang/crystal/pull/10492 instead of Regex matching
  * Is more readable and quite a bit more performant
* Make Crystal `1.6` the minimum supported Crystal version for Athena framework and validator

Resolves #196