### PR TITLE
Automatically make controller services public

### DIFF
--- a/src/components/framework/spec/compiler_spec.cr
+++ b/src/components/framework/spec/compiler_spec.cr
@@ -62,18 +62,6 @@ describe Athena::Framework do
       CODE
     end
 
-    it "when a controller type is registered as a service but is not public" do
-      assert_error "Controller service 'CompileController' must be declared as public.", <<-CODE
-        @[ADI::Register]
-        class CompileController < ATH::Controller
-          @[ARTA::Get(path: "/")]
-          def action : String
-            "foo"
-          end
-        end
-      CODE
-    end
-
     describe "when a controller action is mistakenly overridden" do
       it "within the same controller" do
         assert_error "A controller action named '#action' already exists within 'CompileController'.", <<-CODE

--- a/src/components/framework/spec/controllers/routing_controller.cr
+++ b/src/components/framework/spec/controllers/routing_controller.cr
@@ -1,6 +1,6 @@
 require "../spec_helper"
 
-@[ADI::Register(public: true)]
+@[ADI::Register]
 class RoutingController < ATH::Controller
   def initialize(@request_store : ATH::RequestStore); end
 

--- a/src/components/framework/src/athena.cr
+++ b/src/components/framework/src/athena.cr
@@ -30,6 +30,7 @@ require "./time_converter"
 
 require "./arguments/**"
 require "./config/*"
+require "./compiler_passes/*"
 require "./events/*"
 require "./exceptions/*"
 require "./listeners/*"
@@ -60,7 +61,7 @@ module Athena::Framework
   # Custom events can also be defined and dispatched within a controller, listener, or some other service.
   #
   # See each specific event and the [external documentation](/components/event_dispatcher/) for more information.
-  module Athena::Framework::Events; end
+  module Events; end
 
   # Exception handling in Athena is similar to exception handling in any Crystal program, with the addition of a new unique exception type, `ATH::Exceptions::HTTPException`.
   #
@@ -71,12 +72,12 @@ module Athena::Framework
   # To provide the best response to the client, non `ATH::Exceptions::HTTPException` should be rescued and converted into a corresponding `ATH::Exceptions::HTTPException`.
   # Custom HTTP errors can also be defined by inheriting from `ATH::Exceptions::HTTPException` or a child type. A use case for this could be allowing for additional data/context to be included
   # within the exception that ultimately could be used in a `ATH::Events::Exception` listener.
-  module Athena::Framework::Exceptions; end
+  module Exceptions; end
 
   # The `AED::EventListenerInterface` that act upon `ATH::Events` to handle a request. Custom listeners can also be defined, see `AED::EventListenerInterface`.
   #
   # See each listener and the [external documentation](/components/event_dispatcher/) for more information.
-  module Athena::Framework::Listeners
+  module Listeners
     # The tag name for Athena event listeners.
     TAG = "athena.event_dispatcher.listener"
 
@@ -87,7 +88,7 @@ module Athena::Framework
   # Namespace for types related to controller action arguments.
   #
   # See `ATH::Arguments::ArgumentMetadata`.
-  module Athena::Framework::Arguments; end
+  module Arguments; end
 
   # The default `ATH::Arguments::Resolvers::ArgumentValueResolverInterface`s that will handle resolving controller action arguments from a request (or other source).
   # Custom argument value resolvers can also be defined, see `ATH::Arguments::Resolvers::ArgumentValueResolverInterface`.
@@ -96,7 +97,7 @@ module Athena::Framework
   # A `priority` field can also be optionally included in the annotation, the higher the value the sooner in the array it'll be when injected.
   #
   # See each resolver for more detailed information.
-  module Athena::Framework::Arguments::Resolvers
+  module Arguments::Resolvers
     # The tag name for `ATH::Arguments::Resolvers::ArgumentValueResolverInterface`s.
     TAG = "athena.argument_value_resolver"
   end
@@ -104,7 +105,10 @@ module Athena::Framework
   # Namespace for types related to request parameter processing.
   #
   # See `ATHA::QueryParam` and `ATHA::RequestParam`.
-  module Athena::Framework::Params; end
+  module Params; end
+
+  # :nodoc:
+  module CompilerPasses; end
 
   # Runs an `HTTP::Server` listening on the given *port* and *host*.
   #

--- a/src/components/framework/src/compiler_passes/expose_controller_services.cr
+++ b/src/components/framework/src/compiler_passes/expose_controller_services.cr
@@ -1,0 +1,17 @@
+module Athena::Framework::CompilerPasses::MakeControllerServicesPublicPass
+  include Athena::DependencyInjection::PreArgumentsCompilerPass
+
+  macro included
+    macro finished
+      {% verbatim do %}
+        {%
+          SERVICE_HASH.each do |service_id, metadata|
+            if metadata[:service] <= ATH::Controller
+              metadata[:public] = true
+            end
+          end
+        %}
+      {% end %}
+    end
+  end
+end

--- a/src/components/framework/src/ext/routing/annotation_route_loader.cr
+++ b/src/components/framework/src/ext/routing/annotation_route_loader.cr
@@ -329,13 +329,9 @@ module Athena::Framework::Routing::AnnotationRouteLoader
           {% if base == nil %}
             @@actions[{{action_name}}] = ATH::Action.new(
               action: ->{
-                # If the controller is not registered as a service, simply new one up
-                # TODO: Replace this with a compiler pass after https://github.com/crystal-lang/crystal/pull/9091 is released
+                # If the controller is not registered as a service, simply new one up,
+                # otherwise fetch it directly from the SC.
                 {% if ann = klass.annotation(ADI::Register) %}
-                  {% unless ann[:public] %}
-                    {% klass.raise "Controller service '#{klass.id}' must be declared as public." %}
-                  {% end %}
-
                   %instance = ADI.container.get({{klass.id}})
                 {% else %}
                   %instance = {{klass.id}}.new


### PR DESCRIPTION
* **(internal)** First implementation of a #210 to make it so controller services no longer require the user to make them public manually
 