### PR TITLE
Move command metadata to an annotation versus class vars

### DIFF
--- a/src/components/console/spec/command_spec.cr
+++ b/src/components/console/spec/command_spec.cr
@@ -11,13 +11,13 @@ describe ACON::Command do
     it "falls back on class vars" do
       command = ClassVarConfiguredCommand.new
       command.name.should eq "class:var:configured"
-      command.description.should eq "Command configured via class vars"
+      command.description.should eq "Command configured via annotation"
     end
 
     it "prioritizes constructor args" do
       command = ClassVarConfiguredCommand.new "cv"
       command.name.should eq "cv"
-      command.description.should eq "Command configured via class vars"
+      command.description.should eq "Command configured via annotation"
     end
 
     it "raises on invalid name" do

--- a/src/components/console/spec/fixtures/commands/class_var_configured.cr
+++ b/src/components/console/spec/fixtures/commands/class_var_configured.cr
@@ -1,7 +1,5 @@
+@[ACONA::AsCommand("class:var:configured", description: "Command configured via annotation")]
 class ClassVarConfiguredCommand < ACON::Command
-  @@default_name = "class:var:configured"
-  @@default_description = "Command configured via class vars"
-
   protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
     ACON::Command::Status::SUCCESS
   end

--- a/src/components/console/src/annotations.cr
+++ b/src/components/console/src/annotations.cr
@@ -1,0 +1,30 @@
+module Athena::Console::Annotations
+  # Annotation containing metadata related to an `ACON::Command`.
+  # This is the preferred way of configuring a command as it enables lazy command instantiation when used within the Athena framework.
+  # Checkout the [external documentation](/components/console/) for more information.
+  #
+  # ```
+  # @[ACONA::AsCommand("add", description: "Sums two numbers, optionally making making the sum negative")]
+  # class AddCommand < ACON::Command
+  #   # ...
+  # end
+  # ```
+  #
+  # ## Configuration
+  #
+  # Various fields can be used within this annotation to control various aspects of the command.
+  # All fields are optional unless otherwise noted.
+  #
+  # ### name
+  #
+  # **Type:** `String` - **required**
+  #
+  # The name of the command. May be provided as either an explicit named argument, or the first positional argument.
+  #
+  # ### description
+  #
+  # **Type:** `String`
+  #
+  # A short sentence describing the function of the command.
+  annotation AsCommand; end
+end

--- a/src/components/console/src/athena-console.cr
+++ b/src/components/console/src/athena-console.cr
@@ -1,3 +1,4 @@
+require "./annotations"
 require "./application"
 require "./command"
 require "./cursor"
@@ -16,6 +17,9 @@ require "./style/*"
 
 # Convenience alias to make referencing `Athena::Console` types easier.
 alias ACON = Athena::Console
+
+# Convenience alias to make referencing `ACON::Annotations` types easier.
+alias ACONA = ACON::Annotations
 
 # Athena's Console component, `ACON` for short, allows for the creation of command-line based `ACON::Command`s.
 # These commands could be used for any reoccurring task such as cron jobs, imports, etc.
@@ -88,6 +92,9 @@ alias ACON = Athena::Console
 # Finally, create/require your `ACON::Command`s, and customize the `ACON::Application` as needed.
 module Athena::Console
   VERSION = "0.2.1"
+
+  # Contains all the `Athena::Console` based annotations.
+  module Annotations; end
 
   # Includes the commands that come bundled with `Athena::Console`.
   module Commands; end

--- a/src/components/console/src/command.cr
+++ b/src/components/console/src/command.cr
@@ -8,9 +8,8 @@
 # For example:
 #
 # ```
+# @[ACONA::AsCommand("app:create-user")]
 # class CreateUserCommand < ACON::Command
-#   @@default_name = "app:create-user"
-#
 #   protected def configure : Nil
 #     # ...
 #   end
@@ -34,9 +33,8 @@
 # 1. `execute` (required) - Contains the business logic for the command, returning the status of the invocation via `ACON::Command::Status`.
 #
 # ```
+# @[ACONA::AsCommand("app:create-user")]
 # class CreateUserCommand < ACON::Command
-#   @@default_name = "app:create-user"
-#
 #   protected def configure : Nil
 #     # ...
 #   end
@@ -72,8 +70,8 @@
 # end
 # ```
 #
-# INFO: The name and description can also be set via `@@default_name` and `@@default_description` class variables,
-# which is the preferred way of setting them.
+# TIP: The suggested way of setting the name and description of the command is via the `ACONA::AsCommand` annotation.
+# This enables lazy command instantiation when used within the Athena framework. Checkout the [external documentation](/components/console/) for more information.
 #
 # The `#configure` command is called automatically at the end of the constructor method.
 # If your command defines its own, be sure to call `super()` to also run the parent constructor.
@@ -167,10 +165,18 @@ abstract class Athena::Console::Command
   end
 
   # Returns the default name of `self`, or `nil` if it was not set.
-  class_getter default_name : String? = nil
+  def self.default_name : String?
+    {% if ann = @type.annotation ACONA::AsCommand %}
+      {{ann[0] || ann[:name]}}
+    {% end %}
+  end
 
   # Returns the default description of `self`, or `nil` if it was not set.
-  class_getter default_description : String? = nil
+  def self.default_description : String?
+    {% if ann = @type.annotation ACONA::AsCommand %}
+      {{ann[:description]}}
+    {% end %}
+  end
 
   # Returns the name of `self`.
   getter! name : String

--- a/src/components/console/src/cursor.cr
+++ b/src/components/console/src/cursor.cr
@@ -2,9 +2,8 @@
 # allows writing on any position of the output.
 #
 # ```
+# @[ACONA::AsCommand("cursor")]
 # class CursorCommand < ACON::Command
-#   @@default_name = "cursor"
-#
 #   protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
 #     cursor = ACON::Cursor.new output
 #

--- a/src/components/console/src/spec.cr
+++ b/src/components/console/src/spec.cr
@@ -145,10 +145,8 @@ module Athena::Console::Spec
   # Say we have the following command:
   #
   # ```
+  # @[ACONA::AsCommand("add", description: "Sums two numbers, optionally making making the sum negative")]
   # class AddCommand < ACON::Command
-  #   @@default_name = "add"
-  #   @@default_description = "Sums two numbers, optionally making making the sum negative"
-  #
   #   protected def configure : Nil
   #     self
   #       .argument("value1", :required, "The first value")
@@ -196,9 +194,8 @@ module Athena::Console::Spec
   # A command that are asking `ACON::Question`s can also be tested:
   #
   # ```
+  # @[ACONA::AsCommand("question")]
   # class QuestionCommand < ACON::Command
-  #   @@default_name = "question"
-  #
   #   protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
   #     helper = self.helper ACON::Helper::Question
   #


### PR DESCRIPTION
* Command name and description are now configured via the `ACONA::AsCommand` annotation
  * Allows for future improvements as the data is now available at compile time