### PR TITLE
Console command configuration improvements

### DIFF
--- a/src/components/console/spec/command_spec.cr
+++ b/src/components/console/spec/command_spec.cr
@@ -8,29 +8,54 @@ end
 
 describe ACON::Command do
   describe ".new" do
-    it "falls back on class vars" do
-      command = ClassVarConfiguredCommand.new
-      command.name.should eq "class:var:configured"
-      command.description.should eq "Command configured via annotation"
+    describe "when configured via annotation" do
+      it "sets name and description" do
+        command = AnnotationConfiguredCommand.new
+        command.name.should eq "annotation:configured"
+        command.description.should eq "Command configured via annotation"
+        command.hidden?.should be_false
+        command.aliases.should eq ["ac"]
+      end
+
+      it "sets the command as hidden if its name is an empty string" do
+        command = AnnotationConfiguredHiddenCommand.new
+        command.name.should eq "annotation:configured"
+        command.hidden?.should be_true
+        command.aliases.should be_empty
+      end
+
+      it "sets the command as hidden if that field is true" do
+        command = AnnotationConfiguredHiddenFieldCommand.new
+        command.name.should eq "annotation:configured"
+        command.hidden?.should be_true
+        command.aliases.should be_empty
+      end
+
+      it "sets aliases" do
+        command = AnnotationConfiguredAliasesCommand.new
+        command.name.should eq "annotation:configured"
+        command.hidden?.should be_false
+        command.aliases.should eq ["ac"]
+      end
     end
 
     it "prioritizes constructor args" do
-      command = ClassVarConfiguredCommand.new "cv"
+      command = AnnotationConfiguredCommand.new "cv"
       command.name.should eq "cv"
       command.description.should eq "Command configured via annotation"
     end
 
     it "raises on invalid name" do
       expect_raises ACON::Exceptions::InvalidArgument, "Command name '' is invalid." do
-        ClassVarConfiguredCommand.new ""
+        AnnotationConfiguredCommand.new ""
       end
 
       expect_raises ACON::Exceptions::InvalidArgument, "Command name '  ' is invalid." do
-        ClassVarConfiguredCommand.new "  "
+        AnnotationConfiguredCommand.new "  "
       end
 
       expect_raises ACON::Exceptions::InvalidArgument, "Command name 'foo:' is invalid." do
-        ClassVarConfiguredCommand.new "foo:"
+        AnnotationConfiguredCommand.new "foo:"
       end
     end
   end

--- a/src/components/console/spec/commands/lazy_spec.cr
+++ b/src/components/console/spec/commands/lazy_spec.cr
@@ -1,0 +1,49 @@
+require "../spec_helper"
+
+@[ACONA::AsCommand("blahhhh")]
+private class MockCommand < ACON::Command
+  protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
+    ACON::Command::Status::SUCCESS
+  end
+end
+
+describe ACON::Commands::Lazy do
+  it "applies metadata to the instantiated command" do
+    lazy_command = ACON::Commands::Lazy.new "cmd_name", ["foo", "bar"], "description", true, ->{ MockCommand.new.as ACON::Command }
+    command = lazy_command.command
+
+    command.should be_a MockCommand
+    command.name.should eq "cmd_name"
+    command.aliases.should eq ["foo", "bar"]
+    command.description.should eq "description"
+    command.hidden?.should be_true
+  end
+
+  it "forwards methods to the wrapped command instance" do
+    mock_command = MockCommand.new
+
+    lazy_command = ACON::Commands::Lazy.new "cmd_name", ["foo", "bar"], "description", true, ->{ mock_command.as ACON::Command }
+    command = lazy_command.command
+
+    command.helper_set = ACON::Helper::HelperSet.new ACON::Helper::Question.new
+    command.process_title "title"
+    command.usage "usages"
+    command.argument "name"
+    command.option "active"
+
+    command.definition.should eq mock_command.definition
+    command.help.should eq mock_command.help
+    command.processed_help.should eq mock_command.processed_help
+    command.synopsis.should eq mock_command.synopsis
+    command.usages.should eq mock_command.usages
+    command.helper(ACON::Helper::Question).should eq mock_command.helper(ACON::Helper::Question)
+  end
+
+  it "is runnable" do
+    command = MockCommand.new
+    command.application = ACON::Application.new "foo"
+
+    tester = ACON::Spec::CommandTester.new command
+    tester.execute.should eq ACON::Command::Status::SUCCESS
+  end
+end

--- a/src/components/console/spec/compiler_spec.cr
+++ b/src/components/console/spec/compiler_spec.cr
@@ -1,0 +1,37 @@
+require "./spec_helper"
+
+describe Athena::Console do
+  describe "compiler errors" do
+    describe "when a command configured via annotation doesn't have a name" do
+      it "non hidden no aliases" do
+        ASPEC::Methods.assert_error "Console command 'NoNameCommand' has an 'ACONA::AsCommand' annotation but is missing the commands's name. It was not provided as the first positional argument nor via the 'name' field.", <<-CR
+          require "./spec_helper.cr"
+
+          @[ACONA::AsCommand]
+          class NoNameCommand < ACON::Command
+            protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
+              ACON::Command::Status::SUCCESS
+            end
+          end
+
+          NoNameCommand.default_name
+        CR
+      end
+
+      it "hidden" do
+        ASPEC::Methods.assert_error "Console command 'NoNameCommand' has an 'ACONA::AsCommand' annotation but is missing the commands's name. It was not provided as the first positional argument nor via the 'name' field.", <<-CR
+          require "./spec_helper.cr"
+
+          @[ACONA::AsCommand(hidden: true)]
+          class NoNameCommand < ACON::Command
+            protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
+              ACON::Command::Status::SUCCESS
+            end
+          end
+
+          NoNameCommand.default_name
+        CR
+      end
+    end
+  end
+end

--- a/src/components/console/spec/fixtures/commands/annotation_configured.cr
+++ b/src/components/console/spec/fixtures/commands/annotation_configured.cr
@@ -1,0 +1,6 @@
+@[ACONA::AsCommand("annotation:configured", description: "Command configured via annotation", aliases: ["ac"])]
+class AnnotationConfiguredCommand < ACON::Command
+  protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
+    ACON::Command::Status::SUCCESS
+  end
+end

--- a/src/components/console/spec/fixtures/commands/annotation_configured_aliases.cr
+++ b/src/components/console/spec/fixtures/commands/annotation_configured_aliases.cr
@@ -1,0 +1,6 @@
+@[ACONA::AsCommand("annotation:configured|ac")]
+class AnnotationConfiguredAliasesCommand < ACON::Command
+  protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
+    ACON::Command::Status::SUCCESS
+  end
+end

--- a/src/components/console/spec/fixtures/commands/annotation_configured_hidden.cr
+++ b/src/components/console/spec/fixtures/commands/annotation_configured_hidden.cr
@@ -1,0 +1,6 @@
+@[ACONA::AsCommand("|annotation:configured")]
+class AnnotationConfiguredHiddenCommand < ACON::Command
+  protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
+    ACON::Command::Status::SUCCESS
+  end
+end

--- a/src/components/console/spec/fixtures/commands/annotation_configured_hidden_field.cr
+++ b/src/components/console/spec/fixtures/commands/annotation_configured_hidden_field.cr
@@ -1,5 +1,5 @@
-@[ACONA::AsCommand("class:var:configured", description: "Command configured via annotation")]
-class ClassVarConfiguredCommand < ACON::Command
+@[ACONA::AsCommand("annotation:configured", hidden: true)]
+class AnnotationConfiguredHiddenFieldCommand < ACON::Command
   protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
     ACON::Command::Status::SUCCESS
   end

--- a/src/components/console/src/annotations.cr
+++ b/src/components/console/src/annotations.cr
@@ -19,12 +19,29 @@ module Athena::Console::Annotations
   #
   # **Type:** `String` - **required**
   #
-  # The name of the command. May be provided as either an explicit named argument, or the first positional argument.
+  # The name of the command.
+  # May be provided as either an explicit named argument, or the first positional argument.
+  # See `ACON::Command#name`.
   #
   # ### description
   #
   # **Type:** `String`
   #
   # A short sentence describing the function of the command.
+  # See `ACON::Command#description`.
+  #
+  # ### hidden
+  #
+  # **Type:** `Bool`
+  #
+  # If this command should be hidden from the command list.
+  # See `ACON::Command#hidden?`.
+  #
+  # ### aliases
+  #
+  # **Type:** `String`
+  #
+  # Alternate names this command may be invoked by.
+  # See `ACON::Command#aliases`.
   annotation AsCommand; end
 end

--- a/src/components/console/src/annotations.cr
+++ b/src/components/console/src/annotations.cr
@@ -39,7 +39,7 @@ module Athena::Console::Annotations
   #
   # ### aliases
   #
-  # **Type:** `String`
+  # **Type:** `Enumerable(String)`
   #
   # Alternate names this command may be invoked by.
   # See `ACON::Command#aliases`.

--- a/src/components/console/src/application.cr
+++ b/src/components/console/src/application.cr
@@ -165,7 +165,9 @@ class Athena::Console::Application
       return nil
     end
 
-    # TODO: Do something about LazyCommands?
+    if !command.is_a? ACON::Commands::Lazy
+      command.definition
+    end
 
     @commands[command.name] = command
 

--- a/src/components/console/src/command.cr
+++ b/src/components/console/src/command.cr
@@ -169,10 +169,24 @@ abstract class Athena::Console::Command
     {% begin %}
       {% if ann = @type.annotation ACONA::AsCommand %}
         {% if !ann[:hidden] && !ann[:aliases] %}
-          {{ann[0] || ann[:name]}}
+          {%
+            name = (ann[0] || ann[:name])
+
+            unless name
+              ann.raise "Console command '#{@type}' has an 'ACONA::AsCommand' annotation but is missing the commands's name. It was not provided as the first positional argument nor via the 'name' field."
+            end
+          %}
+
+          {{name}}
         {% else %}
           {%
-            name = (ann[0] || ann[:name]).split '|'
+            name = (ann[0] || ann[:name])
+
+            unless name
+              ann.raise "Console command '#{@type}' has an 'ACONA::AsCommand' annotation but is missing the commands's name. It was not provided as the first positional argument nor via the 'name' field."
+            end
+
+            name = name.split '|'
             name = name + (ann[:aliases] || [] of Nil)
 
             if ann[:hidden] && "" != name[0]

--- a/src/components/console/src/command.cr
+++ b/src/components/console/src/command.cr
@@ -168,24 +168,18 @@ abstract class Athena::Console::Command
   def self.default_name : String?
     {% begin %}
       {% if ann = @type.annotation ACONA::AsCommand %}
+        {%
+          name = (ann[0] || ann[:name])
+
+          unless name
+            ann.raise "Console command '#{@type}' has an 'ACONA::AsCommand' annotation but is missing the commands's name. It was not provided as the first positional argument nor via the 'name' field."
+          end
+        %}
+        
         {% if !ann[:hidden] && !ann[:aliases] %}
-          {%
-            name = (ann[0] || ann[:name])
-
-            unless name
-              ann.raise "Console command '#{@type}' has an 'ACONA::AsCommand' annotation but is missing the commands's name. It was not provided as the first positional argument nor via the 'name' field."
-            end
-          %}
-
           {{name}}
         {% else %}
           {%
-            name = (ann[0] || ann[:name])
-
-            unless name
-              ann.raise "Console command '#{@type}' has an 'ACONA::AsCommand' annotation but is missing the commands's name. It was not provided as the first positional argument nor via the 'name' field."
-            end
-
             name = name.split '|'
             name = name + (ann[:aliases] || [] of Nil)
 

--- a/src/components/console/src/command.cr
+++ b/src/components/console/src/command.cr
@@ -175,7 +175,7 @@ abstract class Athena::Console::Command
             ann.raise "Console command '#{@type}' has an 'ACONA::AsCommand' annotation but is missing the commands's name. It was not provided as the first positional argument nor via the 'name' field."
           end
         %}
-        
+
         {% if !ann[:hidden] && !ann[:aliases] %}
           {{name}}
         {% else %}

--- a/src/components/console/src/commands/lazy.cr
+++ b/src/components/console/src/commands/lazy.cr
@@ -1,0 +1,85 @@
+# :nodoc:
+class Athena::Console::Commands::Lazy < Athena::Console::Command
+  @command : Proc(ACON::Command) | ACON::Command
+  @enabled : Bool
+
+  delegate :run,
+    :merge_application_definition,
+    :definition,
+    :native_definition,
+    :argument,
+    :option,
+    :process_title,
+    :help,
+    :processed_help,
+    :synopsis,
+    :usage,
+    :usages,
+    :helper,
+    to: self.command
+
+  def initialize(
+    name : String,
+    aliases : Enumerable(String),
+    description : String,
+    hidden : Bool,
+    @command : Proc(ACON::Command),
+    @enabled : Bool = true
+  )
+    self
+      .name(name)
+      .aliases(aliases)
+      .hidden(hidden)
+      .description(description)
+  end
+
+  # :inherit:
+  def application=(application : ACON::Application?) : Nil
+    if (cmd = @command).is_a? ACON::Command
+      cmd.application = application
+    end
+
+    super
+  end
+
+  # :inherit:
+  def helper_set=(helper_set : ACON::Helper::HelperSet) : Nil
+    if (cmd = @command).is_a? ACON::Command
+      cmd.helper_set = helper_set
+    end
+
+    super
+  end
+
+  # :inherit:
+  def enabled? : Bool
+    @enabled || self.command.enabled?
+  end
+
+  protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
+    raise NotImplementedError.new "Use #run instead."
+  end
+
+  def command : ACON::Command
+    if (cmd = @command).is_a? ACON::Command
+      return cmd
+    end
+
+    command = @command = cmd.call
+    command.application = self.application?
+
+    if hs = self.helper_set
+      command.helper_set = hs
+    end
+
+    command
+      .name(self.name)
+      .aliases(self.aliases)
+      .hidden(self.hidden?)
+      .description(self.description)
+
+    command.definition
+
+    command
+  end
+end


### PR DESCRIPTION
* **(internal)** Introduce a `Lazy` command wrapper class that can store command metadata before instantiating the actual command
  * Will be used in the framework integration to allow using the list command lazily
* **(breaking)** The `process_title` setter no longer allows `nil` and no longer uses `=` to follow pattern of existing methods
* **(breaking)** `ACON::Command#application=` no longer has a default value of `nil`, pass `nil` explicitly
* Support `aliases` and `hidden` fields within `ACONA::AsCommand`
* Support allowing hidden/aliases to be encoded into the command's name
  * `|` delimited, empty string as first value denotes hidden, otherwise first value is name and rest are aliases 