### PR TITLE
Support `codegen` in `assert_(error|success)` methods

### DIFF
--- a/src/components/spec/spec/methods_spec.cr
+++ b/src/components/spec/spec/methods_spec.cr
@@ -1,16 +1,50 @@
 require "./spec_helper"
 
 describe ASPEC::Methods do
-  describe "#assert_error" do
-    it do
-      assert_error "can't instantiate abstract class Foo", <<-CR
-        abstract class Foo; end
-        Foo.new
-      CR
+  describe ".assert_error" do
+    describe "no codegen" do
+      it do
+        assert_error "can't instantiate abstract class Foo", <<-CR
+          abstract class Foo; end
+          Foo.new
+        CR
+      end
+    end
+
+    describe "with codegen" do
+      it do
+        assert_error "Oh no", <<-CR, codegen: true
+          raise "Oh no"
+        CR
+      end
     end
   end
 
-  describe "#run_executable" do
+  describe ".assert_success" do
+    describe "no codegen" do
+      it do
+        assert_success <<-CR
+          pp 1 + 1
+        CR
+      end
+
+      it do
+        assert_success <<-CR
+          raise "Oh no"
+        CR
+      end
+    end
+
+    describe "with codegen" do
+      it do
+        assert_success <<-CR, codegen: true
+          pp 1 + 1
+        CR
+      end
+    end
+  end
+
+  describe ".run_executable" do
     it "without input" do
       run_executable "ls", ["./.github"] do |output, error, status|
         output.should eq %(workflows\n)


### PR DESCRIPTION
* Allows also testing runtime code
  * Can be used for testing code in isolation such that it doesn't conflict with other test cases. I.e. macro code generated correctly.