### PR TITLE
Fix Typos + Spell Check CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
     - cron: '37 0 * * *' # Nightly at 00:37
 
 jobs:
+  check_spelling:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check Spelling
+        uses: crate-ci/typos@v1
   check_format:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Check Spelling
-        uses: crate-ci/typos@v1
+        uses: crate-ci/typos@v1.12.14
   check_format:
     runs-on: ubuntu-latest
     container:

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,4 @@
+[files]
+extend-exclude = [
+  "src/components/routing/spec/fixtures/route_provider/*"
+]

--- a/src/components/config/spec/athena_config_spec.cr
+++ b/src/components/config/spec/athena_config_spec.cr
@@ -29,7 +29,7 @@ describe Athena do
     end
 
     describe ".parameters" do
-      it "should return an ACF::Parmaeters instance" do
+      it "should return an ACF::Parameters instance" do
         ACF.parameters.username.should eq "fred"
       end
 

--- a/src/components/console/spec/application_spec.cr
+++ b/src/components/console/spec/application_spec.cr
@@ -161,7 +161,7 @@ struct ApplicationTest < ASPEC::TestCase
     app.find_namespace("foo").should eq "foo"
   end
 
-  def test_find_namespace_ambigous : Nil
+  def test_find_namespace_ambiguous : Nil
     app = ACON::Application.new "foo"
     app.add FooCommand.new
     app.add BarBucCommand.new
@@ -236,7 +236,7 @@ struct ApplicationTest < ASPEC::TestCase
 
     app.find("f:b").should be_a FooSameCaseLowercaseCommand
     app.find("f:B").should be_a FooSameCaseLowercaseCommand
-    app.find("foO:BaR").should be_a FooSameCaseLowercaseCommand
+    app.find("fOO:bar").should be_a FooSameCaseLowercaseCommand
   end
 
   def test_find_case_insensitive_ambiguous : Nil
@@ -244,8 +244,8 @@ struct ApplicationTest < ASPEC::TestCase
     app.add FooSameCaseUppercaseCommand.new
     app.add FooSameCaseLowercaseCommand.new
 
-    expect_raises ACON::Exceptions::CommandNotFound, "Command 'FoO:BaR' is ambiguous." do
-      app.find "FoO:BaR"
+    expect_raises ACON::Exceptions::CommandNotFound, "Command 'FOO:bar' is ambiguous." do
+      app.find "FOO:bar"
     end
   end
 
@@ -378,7 +378,7 @@ struct ApplicationTest < ASPEC::TestCase
 
     # Command + plural
     ex = expect_raises ACON::Exceptions::CommandNotFound do
-      app.find "foo:baR"
+      app.find "foo:BAR"
     end
 
     message = ex.message.should_not be_nil

--- a/src/components/console/spec/formatter/output_formatter_spec.cr
+++ b/src/components/console/spec/formatter/output_formatter_spec.cr
@@ -175,11 +175,11 @@ struct OutputFormatterTest < ASPEC::TestCase
   end
 
   def test_format_and_wrap : Nil
-    @formatter.format_and_wrap("foo<error>bar</error> baz", 2).should eq "fo\no\e[97;41mb\e[0m\n\e[97;41mar\e[0m\nba\nz"
+    @formatter.format_and_wrap("ooo<error>bar</error> bbz", 2).should eq "oo\no\e[97;41mb\e[0m\n\e[97;41mar\e[0m\nbb\nz"
     @formatter.format_and_wrap("pre <error>foo bar baz</error> post", 2).should eq "pr\ne \e[97;41m\e[0m\n\e[97;41mfo\e[0m\n\e[97;41mo \e[0m\n\e[97;41mba\e[0m\n\e[97;41mr \e[0m\n\e[97;41mba\e[0m\n\e[97;41mz\e[0m \npo\nst"
     @formatter.format_and_wrap("pre <error>foo bar baz</error> post", 3).should eq "pre\e[97;41m\e[0m\n\e[97;41mfoo\e[0m\n\e[97;41mbar\e[0m\n\e[97;41mbaz\e[0m\npos\nt"
     @formatter.format_and_wrap("pre <error>foo bar baz</error> post", 4).should eq "pre \e[97;41m\e[0m\n\e[97;41mfoo \e[0m\n\e[97;41mbar \e[0m\n\e[97;41mbaz\e[0m \npost"
-    @formatter.format_and_wrap("pre <error>foo bar baz</error> post", 5).should eq "pre \e[97;41mf\e[0m\n\e[97;41moo ba\e[0m\n\e[97;41mr baz\e[0m\npost"
+    @formatter.format_and_wrap("pre <error>foo bbr baz</error> post", 5).should eq "pre \e[97;41mf\e[0m\n\e[97;41moo bb\e[0m\n\e[97;41mr baz\e[0m\npost"
 
     @formatter.format_and_wrap("Lorem <error>ipsum</error> dolor <info>sit</info> amet", 4).should eq "Lore\nm \e[97;41mip\e[0m\n\e[97;41msum\e[0m \ndolo\nr \e[32msi\e[0m\n\e[32mt\e[0m am\net"
     @formatter.format_and_wrap("Lorem <error>ipsum</error> dolor <info>sit</info> amet", 8).should eq "Lorem \e[97;41mip\e[0m\n\e[97;41msum\e[0m dolo\nr \e[32msit\e[0m am\net"
@@ -189,11 +189,11 @@ struct OutputFormatterTest < ASPEC::TestCase
   def test_format_and_wrap_non_decorated : Nil
     @formatter = ACON::Formatter::Output.new
 
-    @formatter.format_and_wrap("foo<error>bar</error> baz", 2).should eq "fo\nob\nar\nba\nz"
-    @formatter.format_and_wrap("pre <error>foo bar baz</error> post", 2).should eq "pr\ne \nfo\no \nba\nr \nba\nz \npo\nst"
+    @formatter.format_and_wrap("ooo<error>bar</error> baz", 2).should eq "oo\nob\nar\nba\nz"
+    @formatter.format_and_wrap("pre <error>foo bbr baz</error> post", 2).should eq "pr\ne \nfo\no \nbb\nr \nba\nz \npo\nst"
     @formatter.format_and_wrap("pre <error>foo bar baz</error> post", 3).should eq "pre\nfoo\nbar\nbaz\npos\nt"
     @formatter.format_and_wrap("pre <error>foo bar baz</error> post", 4).should eq "pre \nfoo \nbar \nbaz \npost"
-    @formatter.format_and_wrap("pre <error>foo bar baz</error> post", 5).should eq "pre f\noo ba\nr baz\npost"
+    @formatter.format_and_wrap("pre <error>foo bbr baz</error> post", 5).should eq "pre f\noo bb\nr baz\npost"
 
     @formatter.format_and_wrap(nil, 5).should eq ""
 

--- a/src/components/console/spec/helper/athena_question_spec.cr
+++ b/src/components/console/spec/helper/athena_question_spec.cr
@@ -11,22 +11,22 @@ struct AthenaQuestionTest < AbstractQuestionHelperTest
   end
 
   def test_ask_choice_question : Nil
-    heros = ["Superman", "Batman", "Spiderman"]
+    heroes = ["Superman", "Batman", "Spiderman"]
     self.with_input "\n1\n  1  \nGeorge\n1\nGeorge" do |input|
-      question = ACON::Question::Choice.new "Who is your favorite superhero?", heros, 2
+      question = ACON::Question::Choice.new "Who is your favorite superhero?", heroes, 2
       question.max_attempts = 1
 
       # First answer is empty, so should use default
       @helper.ask(input, @output, question).should eq "Spiderman"
       self.assert_output_contains "Who is your favorite superhero? [Spiderman]"
 
-      question = ACON::Question::Choice.new "Who is your favorite superhero?", heros
+      question = ACON::Question::Choice.new "Who is your favorite superhero?", heroes
       question.max_attempts = 1
 
       @helper.ask(input, @output, question).should eq "Batman"
       @helper.ask(input, @output, question).should eq "Batman"
 
-      question = ACON::Question::Choice.new "Who is your favorite superhero?", heros
+      question = ACON::Question::Choice.new "Who is your favorite superhero?", heroes
       question.error_message = "Input '%s' is not a superhero!"
       question.max_attempts = 2
 
@@ -34,7 +34,7 @@ struct AthenaQuestionTest < AbstractQuestionHelperTest
       self.assert_output_contains "Input 'George' is not a superhero!"
 
       begin
-        question = ACON::Question::Choice.new "Who is your favorite superhero?", heros, 1
+        question = ACON::Question::Choice.new "Who is your favorite superhero?", heroes, 1
         question.max_attempts = 1
         @helper.ask input, @output, question
       rescue ex : ACON::Exceptions::InvalidArgument
@@ -44,23 +44,23 @@ struct AthenaQuestionTest < AbstractQuestionHelperTest
   end
 
   def test_ask_multiple_choice : Nil
-    heros = ["Superman", "Batman", "Spiderman"]
+    heroes = ["Superman", "Batman", "Spiderman"]
 
     self.with_input "1\n0,2\n 0 , 2  \n\n\n" do |input|
-      question = ACON::Question::MultipleChoice.new "Who is your favorite superhero?", heros
+      question = ACON::Question::MultipleChoice.new "Who is your favorite superhero?", heroes
       question.max_attempts = 1
 
       @helper.ask(input, @output, question).should eq ["Batman"]
       @helper.ask(input, @output, question).should eq ["Superman", "Spiderman"]
       @helper.ask(input, @output, question).should eq ["Superman", "Spiderman"]
 
-      question = ACON::Question::MultipleChoice.new "Who is your favorite superhero?", heros, "0,1"
+      question = ACON::Question::MultipleChoice.new "Who is your favorite superhero?", heroes, "0,1"
       question.max_attempts = 1
 
       @helper.ask(input, @output, question).should eq ["Superman", "Batman"]
       self.assert_output_contains "Who is your favorite superhero? [Superman, Batman]"
 
-      question = ACON::Question::MultipleChoice.new "Who is your favorite superhero?", heros, " 0 , 1 "
+      question = ACON::Question::MultipleChoice.new "Who is your favorite superhero?", heroes, " 0 , 1 "
       question.max_attempts = 1
 
       @helper.ask(input, @output, question).should eq ["Superman", "Batman"]

--- a/src/components/console/spec/helper/formatter_spec.cr
+++ b/src/components/console/spec/helper/formatter_spec.cr
@@ -43,11 +43,11 @@ describe ACON::Helper::Formatter do
   describe "#truncate" do
     it "with shorter length than message with suffix" do
       formatter = ACON::Helper::Formatter.new
-      message = "testing truncate"
+      message = "testing wrapping"
 
       formatter.truncate(message, 4).should eq "test..."
-      formatter.truncate(message, 15).should eq "testing truncat..."
-      formatter.truncate(message, 16).should eq "testing truncate..."
+      formatter.truncate(message, 15).should eq "testing wrappin..."
+      formatter.truncate(message, 16).should eq "testing wrapping..."
       formatter.truncate("zażółć gęślą jaźń", 12).should eq "zażółć gęślą..."
     end
 

--- a/src/components/console/spec/helper/question_spec.cr
+++ b/src/components/console/spec/helper/question_spec.cr
@@ -11,35 +11,35 @@ struct QuestionHelperTest < AbstractQuestionHelperTest
   end
 
   def test_ask_choice_question : Nil
-    heros = ["Superman", "Batman", "Spiderman"]
+    heroes = ["Superman", "Batman", "Spiderman"]
     self.with_input "\n1\n  1  \nGeorge\n1\nGeorge\n\n\n" do |input|
-      question = ACON::Question::Choice.new "Who is your favorite superhero?", heros, 2
+      question = ACON::Question::Choice.new "Who is your favorite superhero?", heroes, 2
       question.max_attempts = 1
 
       # First answer is empty, so should use default
       @helper.ask(input, @output, question).should eq "Spiderman"
 
-      question = ACON::Question::Choice.new "Who is your favorite superhero?", heros
+      question = ACON::Question::Choice.new "Who is your favorite superhero?", heroes
       question.max_attempts = 1
 
       @helper.ask(input, @output, question).should eq "Batman"
       @helper.ask(input, @output, question).should eq "Batman"
 
-      question = ACON::Question::Choice.new "Who is your favorite superhero?", heros
+      question = ACON::Question::Choice.new "Who is your favorite superhero?", heroes
       question.error_message = "Input '%s' is not a superhero!"
       question.max_attempts = 2
 
       @helper.ask(input, @output, question).should eq "Batman"
 
       begin
-        question = ACON::Question::Choice.new "Who is your favorite superhero?", heros, 1
+        question = ACON::Question::Choice.new "Who is your favorite superhero?", heroes, 1
         question.max_attempts = 1
         @helper.ask input, @output, question
       rescue ex : ACON::Exceptions::InvalidArgument
         ex.message.should eq "Value 'George' is invalid."
       end
 
-      question = ACON::Question::Choice.new "Who is your favorite superhero?", heros, "0"
+      question = ACON::Question::Choice.new "Who is your favorite superhero?", heroes, "0"
       question.max_attempts = 1
 
       @helper.ask(input, @output, question).should eq "Superman"
@@ -47,23 +47,23 @@ struct QuestionHelperTest < AbstractQuestionHelperTest
   end
 
   def test_ask_choice_question_non_interactive : Nil
-    heros = ["Superman", "Batman", "Spiderman"]
+    heroes = ["Superman", "Batman", "Spiderman"]
     self.with_input "\n1\n  1  \nGeorge\n1\nGeorge\n1\n", false do |input|
-      question = ACON::Question::Choice.new "Who is your favorite superhero?", heros, 0
+      question = ACON::Question::Choice.new "Who is your favorite superhero?", heroes, 0
       @helper.ask(input, @output, question).should eq "Superman"
 
-      question = ACON::Question::Choice.new "Who is your favorite superhero?", heros, "Batman"
+      question = ACON::Question::Choice.new "Who is your favorite superhero?", heroes, "Batman"
       @helper.ask(input, @output, question).should eq "Batman"
 
-      question = ACON::Question::Choice.new "Who is your favorite superhero?", heros
+      question = ACON::Question::Choice.new "Who is your favorite superhero?", heroes
       @helper.ask(input, @output, question).should be_nil
 
-      question = ACON::Question::Choice.new "Who is your favorite superhero?", heros, 0
+      question = ACON::Question::Choice.new "Who is your favorite superhero?", heroes, 0
       question.validator = nil
       @helper.ask(input, @output, question).should eq "Superman"
 
       begin
-        question = ACON::Question::Choice.new "Who is your favorite superhero?", heros
+        question = ACON::Question::Choice.new "Who is your favorite superhero?", heroes
         @helper.ask input, @output, question
       rescue ex : ACON::Exceptions::InvalidArgument
         ex.message.should eq "Value '' is invalid."
@@ -72,22 +72,22 @@ struct QuestionHelperTest < AbstractQuestionHelperTest
   end
 
   def test_ask_multiple_choice : Nil
-    heros = ["Superman", "Batman", "Spiderman"]
+    heroes = ["Superman", "Batman", "Spiderman"]
 
     self.with_input "1\n0,2\n 0 , 2  " do |input|
-      question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heros
+      question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heroes
       question.max_attempts = 1
 
       @helper.ask(input, @output, question).should eq ["Batman"]
       @helper.ask(input, @output, question).should eq ["Superman", "Spiderman"]
       @helper.ask(input, @output, question).should eq ["Superman", "Spiderman"]
 
-      question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heros, "0,1"
+      question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heroes, "0,1"
       question.max_attempts = 1
 
       @helper.ask(input, @output, question).should eq ["Superman", "Batman"]
 
-      question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heros, " 0 , 1 "
+      question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heroes, " 0 , 1 "
       question.max_attempts = 1
 
       @helper.ask(input, @output, question).should eq ["Superman", "Batman"]
@@ -95,27 +95,27 @@ struct QuestionHelperTest < AbstractQuestionHelperTest
   end
 
   def test_ask_multiple_choice_non_interactive : Nil
-    heros = ["Superman", "Batman", "Spiderman"]
+    heroes = ["Superman", "Batman", "Spiderman"]
 
     self.with_input "1\n0,2\n 0 , 2  ", false do |input|
-      question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heros, "0,1"
+      question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heroes, "0,1"
       @helper.ask(input, @output, question).should eq ["Superman", "Batman"]
 
-      question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heros, " 0 , 1 "
+      question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heroes, " 0 , 1 "
       question.validator = nil
       @helper.ask(input, @output, question).should eq ["Superman", "Batman"]
 
-      question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heros, "0,Batman"
+      question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heroes, "0,Batman"
       @helper.ask(input, @output, question).should eq ["Superman", "Batman"]
 
-      question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heros
+      question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heroes
       @helper.ask(input, @output, question).should be_nil
 
       question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", {"a" => "Batman", "b" => "Superman"}, "a"
       @helper.ask(input, @output, question).should eq ["Batman"]
 
       begin
-        question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heros, ""
+        question = ACON::Question::MultipleChoice.new "Who are your favorite superheros?", heroes, ""
         @helper.ask input, @output, question
       rescue ex : ACON::Exceptions::InvalidArgument
         ex.message.should eq "Value '' is invalid."

--- a/src/components/console/spec/input/option_spec.cr
+++ b/src/components/console/spec/input/option_spec.cr
@@ -40,8 +40,8 @@ describe ACON::Input::Option do
       end
 
       it "array with different characters" do
-        expect_raises ACON::Exceptions::InvalidArgument, "An option shortcut must consist of the same character, got 'ba'." do
-          ACON::Input::Option.new "foo", ["a", "ba"]
+        expect_raises ACON::Exceptions::InvalidArgument, "An option shortcut must consist of the same character, got 'ab'." do
+          ACON::Input::Option.new "foo", ["a", "ab"]
         end
       end
 

--- a/src/components/console/src/athena-console.cr
+++ b/src/components/console/src/athena-console.cr
@@ -102,6 +102,6 @@ module Athena::Console
   # Contains all custom exceptions defined within `Athena::Console`.
   module Exceptions; end
 
-  # Contains types realted to lazily loading commands.
+  # Contains types related to lazily loading commands.
   module Loader; end
 end

--- a/src/components/console/src/helper/formatter.cr
+++ b/src/components/console/src/helper/formatter.cr
@@ -70,7 +70,7 @@ class Athena::Console::Helper::Formatter < Athena::Console::Helper
   # ```
   # message = "This is a very long message, which should be truncated"
   # truncated_message = formatter.truncate message, -5
-  # output.puts truncated_message # => This is a very long message, which should be trun...
+  # output.puts truncated_message # => This is a very long message, which should be turn...
   # ```
   def truncate(message : String, length : Int, suffix : String = "...") : String
     computed_length = length - self.class.width suffix

--- a/src/components/console/src/helper/formatter.cr
+++ b/src/components/console/src/helper/formatter.cr
@@ -69,8 +69,8 @@ class Athena::Console::Helper::Formatter < Athena::Console::Helper
   #
   # ```
   # message = "This is a very long message, which should be truncated"
-  # truncated_message = formatter.truncate message, -5
-  # output.puts truncated_message # => This is a very long message, which should be turn...
+  # truncated_message = formatter.truncate message, -4
+  # output.puts truncated_message # => This is a very long message, which should be trunc...
   # ```
   def truncate(message : String, length : Int, suffix : String = "...") : String
     computed_length = length - self.class.width suffix

--- a/src/components/dependency_injection/spec/service_mocks.cr
+++ b/src/components/dependency_injection/spec/service_mocks.cr
@@ -480,7 +480,7 @@ class ServiceOne
 end
 
 ###############
-# PARAMETERES #
+# PARAMETERS #
 ###############
 ADI.bind password, "%db.password%"
 

--- a/src/components/event_dispatcher/CHANGELOG.md
+++ b/src/components/event_dispatcher/CHANGELOG.md
@@ -32,7 +32,7 @@ _First release a part of the monorepo._
 
 ### Added
 
-- Add the [AED::Spec](https://athenaframework.org/EventDispatcher/Spec/) module to provide helpful testing utilties ([#11](https://github.com/athena-framework/event-dispatcher/pull/11)) (George Dietrich)
+- Add the [AED::Spec](https://athenaframework.org/EventDispatcher/Spec/) module to provide helpful testing utilities ([#11](https://github.com/athena-framework/event-dispatcher/pull/11)) (George Dietrich)
 
 ## [0.1.0] - 2020-01-11
 

--- a/src/components/event_dispatcher/src/event_listener_interface.cr
+++ b/src/components/event_dispatcher/src/event_listener_interface.cr
@@ -36,7 +36,7 @@ module Athena::EventDispatcher::EventListenerInterface
   # Returns the `AED::Event`s that `self` is listening on, along with
   # the listener priority of each event.
   #
-  # Implementors should overide this with the events it should listen on.
+  # Implementors should override this with the events it should listen on.
   def self.subscribed_events : AED::SubscribedEvents
     AED::SubscribedEvents.new
   end

--- a/src/components/framework/CHANGELOG.md
+++ b/src/components/framework/CHANGELOG.md
@@ -52,7 +52,7 @@ _First release in the [athena-framework/framework](https://github.com/athena-fra
 
 ### Removed
 
-- **Breaking:** remove dependecy on [amberframework/amber-router](https://github.com/amberframework/amber-router) ([#141](https://github.com/athena-framework/athena/pull/141)) (George Dietrich)
+- **Breaking:** remove dependency on [amberframework/amber-router](https://github.com/amberframework/amber-router) ([#141](https://github.com/athena-framework/athena/pull/141)) (George Dietrich)
 
 ## [0.15.1] - 2021-12-13
 

--- a/src/components/framework/spec/binary_file_response_spec.cr
+++ b/src/components/framework/spec/binary_file_response_spec.cr
@@ -130,7 +130,7 @@ struct ATH::BinaryFileResponseTest < ASPEC::TestCase
     response.headers["accept-ranges"]?.should eq "none"
   end
 
-  def test_accept_range_not_overriden : Nil
+  def test_accept_range_not_overridden : Nil
     request = ATH::Request.new "POST", "/"
     response = ATH::BinaryFileResponse.new "#{__DIR__}/assets/test.gif", headers: HTTP::Headers{"accept-ranges" => "foo"}
 

--- a/src/components/framework/spec/params/param_fetcher_spec.cr
+++ b/src/components/framework/spec/params/param_fetcher_spec.cr
@@ -3,16 +3,16 @@ require "../spec_helper"
 struct ParamFetcherTest < ASPEC::TestCase
   @request_store : ATH::RequestStore
   @param_fetcher : ATH::Params::ParamFetcher
-  @valiator : AVD::Spec::MockValidator
+  @validator : AVD::Spec::MockValidator
 
   def initialize
     @expected_violations = AVD::Violation::ConstraintViolationList.new
 
     @request_store = ATH::RequestStore.new
     @request_store.request = new_request
-    @valiator = AVD::Spec::MockValidator.new @expected_violations
+    @validator = AVD::Spec::MockValidator.new @expected_violations
 
-    @param_fetcher = ATH::Params::ParamFetcher.new @request_store, @valiator
+    @param_fetcher = ATH::Params::ParamFetcher.new @request_store, @validator
   end
 
   def test_missing_param : Nil

--- a/src/components/framework/spec/redirect_response_spec.cr
+++ b/src/components/framework/spec/redirect_response_spec.cr
@@ -19,21 +19,21 @@ describe ATH::RedirectResponse do
 
   describe "#status" do
     it "defaults to 302" do
-      ATH::RedirectResponse.new("addresss").status.should eq HTTP::Status::FOUND
+      ATH::RedirectResponse.new("address").status.should eq HTTP::Status::FOUND
     end
 
     it "disallows non redirect codes" do
       expect_raises(ArgumentError, "'422' is not an HTTP redirect status code.") do
-        ATH::RedirectResponse.new("addresss", 422)
+        ATH::RedirectResponse.new("address", 422)
       end
     end
 
     it Int do
-      ATH::RedirectResponse.new("addresss", 301).status.should eq HTTP::Status::MOVED_PERMANENTLY
+      ATH::RedirectResponse.new("address", 301).status.should eq HTTP::Status::MOVED_PERMANENTLY
     end
 
     it HTTP::Status do
-      ATH::RedirectResponse.new("addresss", HTTP::Status::MOVED_PERMANENTLY).status.should eq HTTP::Status::MOVED_PERMANENTLY
+      ATH::RedirectResponse.new("address", HTTP::Status::MOVED_PERMANENTLY).status.should eq HTTP::Status::MOVED_PERMANENTLY
     end
   end
 
@@ -45,7 +45,7 @@ describe ATH::RedirectResponse do
     end
 
     it "adds the location header" do
-      ATH::RedirectResponse.new("addresss").headers["location"].should eq "addresss"
+      ATH::RedirectResponse.new("address").headers["location"].should eq "address"
     end
   end
 end

--- a/src/components/framework/spec/routing_spec.cr
+++ b/src/components/framework/spec/routing_spec.cr
@@ -31,6 +31,12 @@ struct RoutingTest < ATH::Spec::APITestCase
     response.body.should eq %({"code":404,"message":"No route found for 'GET /fake/route'."})
   end
 
+  def test_route_doesnt_exist_with_referrer : Nil
+    response = self.get "/fake/route", headers: HTTP::Headers{"referrer" => "somebody"}
+    response.status.should eq HTTP::Status::NOT_FOUND
+    response.body.should eq %({"code":404,"message":"No route found for 'GET /fake/route' (from: 'somebody')."})
+  end
+
   def test_invalid_method : Nil
     response = self.post "/art/response"
     response.status.should eq HTTP::Status::METHOD_NOT_ALLOWED

--- a/src/components/framework/spec/view/context_spec.cr
+++ b/src/components/framework/spec/view/context_spec.cr
@@ -63,10 +63,10 @@ struct ContextTest < ASPEC::TestCase
   def test_exclusion_strategies : Nil
     @context.exclusion_strategies.should be_empty
 
-    strat = IgnoreExclusionStrategy.new
+    strategy = IgnoreExclusionStrategy.new
 
-    @context.add_exclusion_strategy strat
+    @context.add_exclusion_strategy strategy
 
-    @context.exclusion_strategies.should eq [strat]
+    @context.exclusion_strategies.should eq [strategy]
   end
 end

--- a/src/components/framework/spec/view/view_handler_spec.cr
+++ b/src/components/framework/spec/view/view_handler_spec.cr
@@ -150,7 +150,7 @@ struct ViewHandlerTest < ASPEC::TestCase
     }
   end
 
-  def test_handle_unsuported_format : Nil
+  def test_handle_unsupported_format : Nil
     request = ATH::Request.new "GET", "/"
     request.request_format = "rss"
 

--- a/src/components/framework/src/ext/console/register_commands.cr
+++ b/src/components/framework/src/ext/console/register_commands.cr
@@ -15,7 +15,7 @@ module Athena::Framework::CompilerPasses::RegisterCommands
           (TAG_HASH["athena.console.command"] || [] of Nil).each do |service_id|
             metadata = SERVICE_HASH[service_id]
 
-            # TODO: Any benefit in allowing commmands to be configured via tags instead of the annotation?
+            # TODO: Any benefit in allowing commands to be configured via tags instead of the annotation?
 
             metadata[:visibility] = metadata[:visibility] != Visibility::PRIVATE ? metadata[:visibility] : Visibility::INTERNAL
 

--- a/src/components/framework/src/listeners/routing_listener.cr
+++ b/src/components/framework/src/listeners/routing_listener.cr
@@ -45,8 +45,8 @@ struct Athena::Framework::Listeners::Routing
     rescue ex : ART::Exception::ResourceNotFound
       message = "No route found for '#{request.method} #{request.resource}'"
 
-      if referer = request.headers["referer"]?
-        message += " (from: '#{referer}')"
+      if referrer = request.headers["referrer"]?
+        message += " (from: '#{referrer}')"
       end
 
       message += "."

--- a/src/components/framework/src/parameter_bag.cr
+++ b/src/components/framework/src/parameter_bag.cr
@@ -62,7 +62,7 @@ struct Athena::Framework::ParameterBag
     @parameters[name]?.try &.value
   end
 
-  # Returns the value of the parameter with the provided *name* casted to the provied *type* if it exists, otherwise `nil`.
+  # Returns the value of the parameter with the provided *name* casted to the provided *type* if it exists, otherwise `nil`.
   def get?(name : String, type : T?.class) : T? forall T
     self.get?(name).as T?
   end

--- a/src/components/framework/src/params/param_fetcher_interface.cr
+++ b/src/components/framework/src/params/param_fetcher_interface.cr
@@ -2,11 +2,11 @@
 module Athena::Framework::Params::ParamFetcherInterface
   # Returns the value of the parameter with the provided *name*.
   #
-  # Optionally allows determing if the params should be validated strictly. See the "Strict" section of `ATHA::QueryParam`.
+  # Optionally allows determining if the params should be validated strictly. See the "Strict" section of `ATHA::QueryParam`.
   abstract def get(name : String, strict : Bool? = nil)
 
   # Yields the name and value of each `ATH::Params::ParamInterface` related to the current `ATH::Action#params`.
   #
-  # Optionally allows determing if the params should be validated strictly. See the "Strict" section of `ATHA::QueryParam`.
+  # Optionally allows determining if the params should be validated strictly. See the "Strict" section of `ATHA::QueryParam`.
   abstract def each(strict : Bool? = nil, & : String, _ -> Nil) : Nil
 end

--- a/src/components/framework/src/view/view_handler.cr
+++ b/src/components/framework/src/view/view_handler.cr
@@ -189,7 +189,7 @@ class Athena::Framework::View::ViewHandler
       context.emit_nil = view_handler_emit_nil
     end
 
-    # TOOD: Set status code in context attributes if that's ever implemented.
+    # TODO: Set status code in context attributes if that's ever implemented.
 
     context
   end

--- a/src/components/negotiation/spec/negotiator_spec.cr
+++ b/src/components/negotiation/spec/negotiator_spec.cr
@@ -86,7 +86,7 @@ struct NegotiatorTest < NegotiatorTestCase
       {php_pear_header, {"audio/midi"}, {"audio/midi", nil}},
       {"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", {"application/rss+xml"}, {"application/rss+xml", nil}},
 
-      # Case sensitiviy
+      # Case sensitivity
       {"text/* ; q=0.3, TEXT/html ;Q=0.7, text/html ; level=1, texT/Html ;leVel = 2 ;q=0.4, */* ; q=0.5", {"text/html; level=2"}, {"text/html", {"level" => "2"}}},
       {"text/* ; q=0.3, text/html;Q=0.7, text/html ;level=1, text/html; level=2;q=0.4, */*;q=0.5", {"text/HTML; level=3"}, {"text/html", {"level" => "3"}}},
 

--- a/src/components/negotiation/src/negotiator.cr
+++ b/src/components/negotiation/src/negotiator.cr
@@ -12,7 +12,7 @@ class Athena::Negotiation::Negotiator < Athena::Negotiation::AbstractNegotiator(
     accept_sub_type = accept.sub_type
     priority_sub_type = priority.sub_type
 
-    intercection = accept.parameters.each_with_object({} of String => String) do |(k, v), params|
+    intersection = accept.parameters.each_with_object({} of String => String) do |(k, v), params|
       priority.parameters.tap do |pp|
         params[k] = v if pp.has_key?(k) && pp[k] == v
       end
@@ -24,9 +24,9 @@ class Athena::Negotiation::Negotiator < Athena::Negotiation::AbstractNegotiator(
     if (
          (accept_type == "*" || type_equals) &&
          (accept_sub_type == "*" || sub_type_equals) &&
-         intercection.size == accept.parameters.size
+         intersection.size == accept.parameters.size
        )
-      score = 100 * (type_equals ? 1 : 0) + 10 * (sub_type_equals ? 1 : 0) + intercection.size
+      score = 100 * (type_equals ? 1 : 0) + 10 * (sub_type_equals ? 1 : 0) + intersection.size
 
       return ANG::AcceptMatch.new accept.quality * priority.quality, score, index
     end
@@ -49,9 +49,9 @@ class Athena::Negotiation::Negotiator < Athena::Negotiation::AbstractNegotiator(
     if (
          (accept_sub_type == "*" || priority_sub_type == "*" || sub_type_equals) &&
          (accept_plus == "*" || priority_plus == '*' || plus_equals) &&
-         intercection.size == accept.parameters.size
+         intersection.size == accept.parameters.size
        )
-      score = 100 * (type_equals ? 1 : 0) + 10 * (sub_type_equals ? 1 : 0) + (plus_equals ? 1 : 0) + intercection.size
+      score = 100 * (type_equals ? 1 : 0) + 10 * (sub_type_equals ? 1 : 0) + (plus_equals ? 1 : 0) + intersection.size
       return ANG::AcceptMatch.new accept.quality * priority.quality, score, index
     end
 

--- a/src/components/routing/spec/generator/url_generator_spec.cr
+++ b/src/components/routing/spec/generator/url_generator_spec.cr
@@ -566,7 +566,7 @@ struct URLGeneratorTest < ASPEC::TestCase
   def test_generate_with_fragment : Nil
     generator = self.generator(self.routes(ART::Route.new("/")))
 
-    generator.generate("test", "_fragment": "frag ment").should eq "/base/#frag%20ment"
+    generator.generate("test", "_fragment": "some text").should eq "/base/#some%20text"
     generator.generate("test", "_fragment": "0").should eq "/base/#0"
   end
 

--- a/src/components/routing/spec/matcher/url_matcher_spec.cr
+++ b/src/components/routing/spec/matcher/url_matcher_spec.cr
@@ -764,7 +764,7 @@ struct URLMatcherTest < ASPEC::TestCase
 
     matcher = self.get_matcher routes
     matcher.match("/aa").should eq({"_route" => "c", "a" => "a"})
-    matcher.match("/ba").should eq({"_route" => "f", "a" => "a", "b" => "b"})
+    matcher.match("/be").should eq({"_route" => "f", "a" => "e", "b" => "b"})
   end
 
   def test_match_requirements_with_capture_groups : Nil

--- a/src/components/routing/spec/route_provider_spec.cr
+++ b/src/components/routing/spec/route_provider_spec.cr
@@ -8,7 +8,7 @@ struct RouteProviderTest < ASPEC::TestCase
     self.redirection_collection,
     self.root_prefix_collection,
     self.head_match_case_collection,
-    self.group_optmized_collection,
+    self.group_optimized_collection,
     self.trailing_slash_collection,
     self.trailing_slash_collection,
     self.host_tree_collection,
@@ -201,7 +201,7 @@ struct RouteProviderTest < ASPEC::TestCase
     collection
   end
 
-  def self.group_optmized_collection : ART::RouteCollection
+  def self.group_optimized_collection : ART::RouteCollection
     collection = ART::RouteCollection.new
 
     collection.add "a_first", ART::Route.new "/a/11"

--- a/src/components/routing/src/generator/url_generator.cr
+++ b/src/components/routing/src/generator/url_generator.cr
@@ -132,7 +132,7 @@ class Athena::Routing::Generator::URLGenerator
               raise ART::Exception::InvalidParameter.new message % {var_name, name, r, merged_params[var_name]}
             end
 
-            # TOOD: Add logger integration
+            # TODO: Add logger integration
 
             return ""
           end
@@ -180,7 +180,7 @@ class Athena::Routing::Generator::URLGenerator
               raise ART::Exception::InvalidParameter.new message % {token.var_name, name, r, merged_params[token.var_name]}
             end
 
-            # TOOD: Add logger integration
+            # TODO: Add logger integration
 
             return ""
           end

--- a/src/components/routing/src/route_collection.cr
+++ b/src/components/routing/src/route_collection.cr
@@ -91,8 +91,8 @@ class Athena::Routing::RouteCollection
     @routes.each do |name, route|
       prefixed_routes["#{prefix}#{name}"] = route
 
-      if cannonical_route = route.default "_canonical_route"
-        route.set_default "_canonical_route", "#{prefix}#{cannonical_route}"
+      if canonical_route = route.default "_canonical_route"
+        route.set_default "_canonical_route", "#{prefix}#{canonical_route}"
       end
 
       if priority = @priorities[name]?

--- a/src/components/routing/src/route_provider.cr
+++ b/src/components/routing/src/route_provider.cr
@@ -324,8 +324,8 @@ class Athena::Routing::RouteProvider
   private def self.compile_dynamic_route(route : ART::Route, name : String, vars : Set(String)?, has_trailing_slash : Bool, has_trailing_var : Bool, conditions : Array(Condition)) : DynamicRouteData
     defaults = route.defaults.dup
 
-    if cannonical_route = defaults["_canonical_route"]?
-      name = cannonical_route
+    if canonical_route = defaults["_canonical_route"]?
+      name = canonical_route
       defaults.delete "_canonical_route"
     end
 
@@ -347,8 +347,8 @@ class Athena::Routing::RouteProvider
   private def self.compile_static_route(route : ART::Route, name : String, host : String | Regex | Nil, has_trailing_slash : Bool, has_trailing_var : Bool, conditions : Array(Condition)) : StaticRouteData
     defaults = route.defaults.dup
 
-    if cannonical_route = defaults["_canonical_route"]?
-      name = cannonical_route
+    if canonical_route = defaults["_canonical_route"]?
+      name = canonical_route
       defaults.delete "_canonical_route"
     end
 

--- a/src/components/routing/src/router.cr
+++ b/src/components/routing/src/router.cr
@@ -11,7 +11,7 @@ class Athena::Routing::Router
   # :inherit:
   getter context : ART::RequestContext
 
-  # TOOD: Should the matcher/generator types be customizable?
+  # TODO: Should the matcher/generator types be customizable?
 
   getter matcher : ART::Matcher::URLMatcherInterface do
     ART::Matcher::URLMatcher.new(@context)

--- a/src/components/routing/src/routing_handler.cr
+++ b/src/components/routing/src/routing_handler.cr
@@ -43,7 +43,7 @@
 #   def call(context)
 #     call_next context
 #   rescue ex
-#     # Do something based on the ex, such as rendering the appropiate template, etc.
+#     # Do something based on the ex, such as rendering the appropriate template, etc.
 #   end
 # end
 #
@@ -53,7 +53,7 @@
 #
 # # Have the `ErrorHandler` run _before_ the routing handler.
 # server = HTTP::Server.new([
-#   ErrorHander.new,
+#   ErrorHandler.new,
 #   handler.compile,
 # ])
 #

--- a/src/components/serializer/spec/exclusion_strategies/custom_strategy_spec.cr
+++ b/src/components/serializer/spec/exclusion_strategies/custom_strategy_spec.cr
@@ -15,7 +15,7 @@ private struct ActivePropertyExclusionStrategy
   end
 end
 
-# Mainly testing `Athena::Config` integration in regards to custom annotations accessable via the property metadata.
+# Mainly testing `Athena::Config` integration in regards to custom annotations accessible via the property metadata.
 describe ActivePropertyExclusionStrategy do
   describe "#skip_property?" do
     describe :deserialization do

--- a/src/components/serializer/src/annotations.cr
+++ b/src/components/serializer/src/annotations.cr
@@ -434,12 +434,12 @@ module Athena::Serializer::Annotations
   #   property last_name : String = "Snow"
   #
   #   @[ASRA::PreSerialize]
-  #   private def pre_ser : Nil
+  #   private def pre_serialize : Nil
   #     @name = "#{first_name} #{last_name}"
   #   end
   #
   #   @[ASRA::PostSerialize]
-  #   private def post_ser : Nil
+  #   private def post_serialize : Nil
   #     @name = nil
   #   end
   # end
@@ -466,12 +466,12 @@ module Athena::Serializer::Annotations
   #   property last_name : String = "Snow"
   #
   #   @[ASRA::PreSerialize]
-  #   private def pre_ser : Nil
+  #   private def pre_serialize : Nil
   #     @name = "#{first_name} #{last_name}"
   #   end
   #
   #   @[ASRA::PostSerialize]
-  #   private def post_ser : Nil
+  #   private def post_serialize : Nil
   #     @name = nil
   #   end
   # end

--- a/src/components/spec/spec/athena-spec_spec.cr
+++ b/src/components/spec/spec/athena-spec_spec.cr
@@ -8,7 +8,7 @@ private class Calculator
     v1 + v2
   end
 
-  def substract(v1, v2)
+  def subtract(v1, v2)
     raise NotImplementedError.new "TODO"
   end
 end
@@ -26,7 +26,7 @@ struct ExampleSpec < ASPEC::TestCase
 
   # A pending test.
   def ptest_subtract : Nil
-    @target.substract(10, 5).should eq 5
+    @target.subtract(10, 5).should eq 5
   end
 
   test "with macro helper" do

--- a/src/components/spec/src/test_case.cr
+++ b/src/components/spec/src/test_case.cr
@@ -61,7 +61,7 @@
 #   end
 #
 #   # A pending test.
-#   def ptest_substract : Nil
+#   def ptest_subtract : Nil
 #     @target.subtract(10, 5).should eq 5
 #   end
 #
@@ -287,7 +287,7 @@ abstract struct Athena::Spec::TestCase
 
           {% unless test.annotations(DataProvider).empty? %}
             {% for data_provider in test.annotations DataProvider %}
-              {% data_provider_method_name = data_provider[0] || data_provider.raise "One or more data provider for test '#{@type}##{test.name.id}' is mising its name." %}
+              {% data_provider_method_name = data_provider[0] || data_provider.raise "One or more data provider for test '#{@type}##{test.name.id}' is missing its name." %}
               {% methods = @type.methods %}
 
               {% for ancestor in @type.ancestors.select &.<=(ASPEC::TestCase) %}

--- a/src/components/validator/CHANGELOG.md
+++ b/src/components/validator/CHANGELOG.md
@@ -93,7 +93,7 @@ _First release a part of the monorepo._
 
 ### Fixed
 
-- Fix compiler error due to less strict `abstract def` implemenations ([#6](https://github.com/athena-framework/validator/pull/6)) (George Dietrich)
+- Fix compiler error due to less strict `abstract def` implementations ([#6](https://github.com/athena-framework/validator/pull/6)) (George Dietrich)
 
 ## [0.1.0] - 2020-10-17
 

--- a/src/components/validator/spec/constraints/email_validator_spec.cr
+++ b/src/components/validator/spec/constraints/email_validator_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 private alias CONSTRAINT = AVD::Constraints::Email
 
-private class EmtpyEmailObject
+private class EmptyEmailObject
   def to_s(io : IO) : Nil
     io << ""
   end
@@ -19,7 +19,7 @@ struct EmailValidatorTest < AVD::Spec::ConstraintValidatorTestCase
   end
 
   def test_empty_string_from_object_is_valid : Nil
-    self.validator.validate EmtpyEmailObject.new, self.new_constraint
+    self.validator.validate EmptyEmailObject.new, self.new_constraint
     self.assert_no_violation
   end
 

--- a/src/components/validator/spec/constraints/issn_validator_spec.cr
+++ b/src/components/validator/spec/constraints/issn_validator_spec.cr
@@ -32,7 +32,7 @@ struct ISSNValidatorTest < AVD::Spec::ConstraintValidatorTestCase
 
   @[DataProvider("valid_non_hyphenated_issns")]
   def test_hyphen_required_issns(value : String) : Nil
-    self.validator.validate value, self.new_constraint message: "my_message", require_hypen: true
+    self.validator.validate value, self.new_constraint message: "my_message", require_hyphen: true
     self.assert_violation "my_message", CONSTRAINT::MISSING_HYPHEN_ERROR, value
   end
 

--- a/src/components/validator/src/constraints/issn.cr
+++ b/src/components/validator/src/constraints/issn.cr
@@ -15,7 +15,7 @@
 # The validator will allow ISSN values to end with a lowercase `x` by default.
 # When set to `true`, this requires an uppcase case `X`.
 #
-# ### require_hypen
+# ### require_hyphen
 #
 # **Type:** `Bool` **Default:** `false`
 #
@@ -65,11 +65,11 @@ class Athena::Validator::Constraints::ISSN < Athena::Validator::Constraint
   }
 
   getter? case_sensitive : Bool
-  getter? require_hypen : Bool
+  getter? require_hyphen : Bool
 
   def initialize(
     @case_sensitive : Bool = false,
-    @require_hypen : Bool = false,
+    @require_hyphen : Bool = false,
     message : String = "This value is not a valid International Standard Serial Number (ISSN).",
     groups : Array(String) | String | Nil = nil,
     payload : Hash(String, String)? = nil
@@ -88,7 +88,7 @@ class Athena::Validator::Constraints::ISSN < Athena::Validator::Constraint
 
       if canonical[4]? == '-'
         canonical = canonical.delete '-'
-      elsif constraint.require_hypen?
+      elsif constraint.require_hyphen?
         return self.context.add_violation constraint.message, MISSING_HYPHEN_ERROR, value
       end
 

--- a/src/components/validator/src/constraints/sequentially.cr
+++ b/src/components/validator/src/constraints/sequentially.cr
@@ -77,10 +77,10 @@ class Athena::Validator::Constraints::Sequentially < Athena::Validator::Constrai
     def validate(value : _, constraint : AVD::Constraints::Sequentially) : Nil
       validator = self.context.validator.in_context self.context
 
-      origional_count = validator.violations.size
+      original_count = validator.violations.size
 
       constraint.constraints.each do |c|
-        break if origional_count != validator.validate(value, c).violations.size
+        break if original_count != validator.validate(value, c).violations.size
       end
     end
   end

--- a/src/components/validator/src/metadata/cascading_strategy.cr
+++ b/src/components/validator/src/metadata/cascading_strategy.cr
@@ -1,6 +1,6 @@
 # Determines whether an object should be cascaded.
 #
-# If cascading is enabled, the validator will also validate embeded objects.
+# If cascading is enabled, the validator will also validate embedded objects.
 enum Athena::Validator::Metadata::CascadingStrategy
   None
   Cascade

--- a/src/components/validator/src/spec/constraint_validator_test_case.cr
+++ b/src/components/validator/src/spec/constraint_validator_test_case.cr
@@ -34,7 +34,7 @@
 #     # Validate an invalid value against a new instance of the constraint with a custom message.
 #     self.validator.validate nil, self.new_constraint message: "my_message"
 #
-#     # Asssert a violation with the expected message, code, and value parameter is added to the context.
+#     # Assert a violation with the expected message, code, and value parameter is added to the context.
 #     self
 #       .build_violation("my_message", CONSTRAINT::IS_NULL_ERROR, nil)
 #       .assert_violation
@@ -52,7 +52,7 @@
 # ```
 #
 # This type is an extension of `ASPEC::TestCase`, see that type for more information on this testing approach.
-# This approach also allows using `ASPEC::TestCase::DataProvider`s for reducing duplication withing your test.
+# This approach also allows using `ASPEC::TestCase::DataProvider`s for reducing duplication within your test.
 abstract struct Athena::Validator::Spec::ConstraintValidatorTestCase < ASPEC::TestCase
   # Used to assert that a violation added via the `AVD::ConstraintValidatorInterface` was built as expected.
   #

--- a/src/components/validator/src/spec/validator_test_case.cr
+++ b/src/components/validator/src/spec/validator_test_case.cr
@@ -272,7 +272,7 @@ abstract struct Athena::Validator::Spec::ValidatorTestCase < AVD::Spec::Abstract
     violation.code.should eq "CODE"
   end
 
-  def ptest_validate_no_dupliate_violations_if_class_constraint_is_in_multiple_groups : Nil
+  def ptest_validate_no_duplicate_violations_if_class_constraint_is_in_multiple_groups : Nil
     object = Entity.new
 
     callback = AVD::Constraints::Callback::CallbackProc.new do |_value, context|
@@ -284,7 +284,7 @@ abstract struct Athena::Validator::Spec::ValidatorTestCase < AVD::Spec::Abstract
     self.validate(object, AVD::Constraints::Valid.new, groups: ["group1", "group2"]).size.should eq 1
   end
 
-  def ptest_validate_no_dupliate_violations_if_property_constraint_is_in_multiple_groups : Nil
+  def ptest_validate_no_duplicate_violations_if_property_constraint_is_in_multiple_groups : Nil
     object = Entity.new
 
     callback = AVD::Constraints::Callback::CallbackProc.new do |_value, context|


### PR DESCRIPTION
- Fix typos in each component
  - [x] config
  - [x] console
  - [x] dependency_injection
  - [x] event_dispatcher
  - [x] framework
  - [x] image_size
  - [x] negotiation
  - [x] routing
  - [x] serializer
  - [x] spec
  - [x] validator
- [x] Setup https://github.com/crate-ci/typos GHA

* **(breaking)** - Renames `ISSN#require_hypen?` to `ISSN#require_hyphen?`
* Fix issue with `referrer` not being appended to 404'd requests if present