### PR TITLE
Make `AVD::Constraints::Email::Mode::HTML5` the default validation mode

### DIFF
--- a/src/components/validator/spec/constraints/email_validator_spec.cr
+++ b/src/components/validator/spec/constraints/email_validator_spec.cr
@@ -23,25 +23,6 @@ struct EmailValidatorTest < AVD::Spec::ConstraintValidatorTestCase
     self.assert_no_violation
   end
 
-  @[DataProvider("valid_emails")]
-  def test_valid_emails(value : String) : Nil
-    self.validator.validate value, self.new_constraint
-    self.assert_no_violation
-  end
-
-  def valid_emails : Tuple
-    {
-      {"blacksmoke16@dietrich.app"},
-      {"example@example.co.uk"},
-      {"fabien_potencier@example.fr"},
-      {"example@example.co..uk"},
-      {"{}~!@!@£$%%^&*().!@£$%^&*()"},
-      {"example@example.co..uk"},
-      {"example@-example.com"},
-      {"example@#{"a"*64}.com"},
-    }
-  end
-
   @[DataProvider("valid_emails_html5")]
   def test_valid_emails_html5(value : String) : Nil
     self.validator.validate value, self.new_constraint mode: CONSTRAINT::Mode::HTML5

--- a/src/components/validator/src/constraints/email.cr
+++ b/src/components/validator/src/constraints/email.cr
@@ -42,9 +42,6 @@
 class Athena::Validator::Constraints::Email < Athena::Validator::Constraint
   # Determines _how_ the email address should be validated.
   enum Mode
-    # Validates the email against a simple `::Regex` that allows all values with an `@` symbol and a `.` in the host part of the email address.
-    Loose
-
     # Validates the email against the [HTML5 input pattern](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address).
     HTML5
 
@@ -55,7 +52,6 @@ class Athena::Validator::Constraints::Email < Athena::Validator::Constraint
     def pattern : ::Regex
       case self
       in .html5? then /^[a-zA-Z0-9.!\#$\%&\'*+\\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/
-      in .loose? then /^.+\@\S+\.\S+$/
       end
     end
   end
@@ -69,7 +65,7 @@ class Athena::Validator::Constraints::Email < Athena::Validator::Constraint
   getter mode : AVD::Constraints::Email::Mode
 
   def initialize(
-    @mode : AVD::Constraints::Email::Mode = :loose,
+    @mode : AVD::Constraints::Email::Mode = :html5,
     message : String = "This value is not a valid email address.",
     groups : Array(String) | String | Nil = nil,
     payload : Hash(String, String)? = nil


### PR DESCRIPTION
* **(breaking)** Drop `AVD::Constraints::Email::Mode::Loose`
  * `HTML5` mode is a more proper default