### PR TITLE
Introduce `AVD::Constraints::Email::Mode::HTML5_ALLOW_NO_TLD`

### DIFF
--- a/src/components/validator/spec/constraints/email_validator_spec.cr
+++ b/src/components/validator/spec/constraints/email_validator_spec.cr
@@ -23,13 +23,13 @@ struct EmailValidatorTest < AVD::Spec::ConstraintValidatorTestCase
     self.assert_no_violation
   end
 
-  @[DataProvider("valid_emails_html5")]
-  def test_valid_emails_html5(value : String) : Nil
-    self.validator.validate value, self.new_constraint mode: CONSTRAINT::Mode::HTML5
+  @[DataProvider("valid_emails")]
+  def test_valid_emails(value : String) : Nil
+    self.validator.validate value, self.new_constraint
     self.assert_no_violation
   end
 
-  def valid_emails_html5 : Tuple
+  def valid_emails : Tuple
     {
       {"blacksmoke16@dietrich.app"},
       {"example@example.co.uk"},
@@ -49,21 +49,6 @@ struct EmailValidatorTest < AVD::Spec::ConstraintValidatorTestCase
       {"example"},
       {"example@"},
       {"example@localhost"},
-      {"foo@example.com bar"},
-    }
-  end
-
-  @[DataProvider("invalid_emails_html5")]
-  def test_invalid_emails_html5(value : String) : Nil
-    self.validator.validate value, self.new_constraint mode: CONSTRAINT::Mode::HTML5, message: "my_message"
-    self.assert_violation "my_message", CONSTRAINT::INVALID_FORMAT_ERROR, value
-  end
-
-  def invalid_emails_html5 : Tuple
-    {
-      {"example"},
-      {"example@"},
-      {"example@localhost"},
       {"example@example.co..uk"},
       {"foo@example.com bar"},
       {"example@example."},
@@ -78,6 +63,27 @@ struct EmailValidatorTest < AVD::Spec::ConstraintValidatorTestCase
       {"example@-example.com"},
       {"example@#{"a"*64}.com"},
     }
+  end
+
+  @[DataProvider("invalid_emails_html5_allow_no_tld")]
+  def test_invalid_emails_html5_allow_no_tld(value : String) : Nil
+    self.validator.validate value, self.new_constraint mode: CONSTRAINT::Mode::HTML5_ALLOW_NO_TLD, message: "my_message"
+    self.assert_violation "my_message", CONSTRAINT::INVALID_FORMAT_ERROR, value
+  end
+
+  def invalid_emails_html5_allow_no_tld : Tuple
+    {
+      {"example bar"},
+      {"example@"},
+      {"example@ bar"},
+      {"example@localhost bar"},
+      {"foo@example.com bar"},
+    }
+  end
+
+  def test_valid_email_html5_allow_no_tld : Nil
+    self.validator.validate "example@example", self.new_constraint mode: CONSTRAINT::Mode::HTML5_ALLOW_NO_TLD
+    self.assert_no_violation
   end
 
   private def create_validator : AVD::ConstraintValidatorInterface

--- a/src/components/validator/src/constraints/email.cr
+++ b/src/components/validator/src/constraints/email.cr
@@ -10,7 +10,7 @@
 #
 # ### mode
 #
-# **Type:** `AVD::Constraints::Email::Mode` **Default:** `AVD::Constraints::Email::Mode::Loose`
+# **Type:** `AVD::Constraints::Email::Mode` **Default:** `AVD::Constraints::Email::Mode::HTML5`
 #
 # Defines the pattern that should be used to validate the email address.
 #
@@ -42,8 +42,11 @@
 class Athena::Validator::Constraints::Email < Athena::Validator::Constraint
   # Determines _how_ the email address should be validated.
   enum Mode
-    # Validates the email against the [HTML5 input pattern](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address).
+    # Validates the email against the [HTML5 input pattern](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address), but requires a [TLD](https://en.wikipedia.org/wiki/Top-level_domain) to be present.
     HTML5
+
+    # Same as `HTML5`, but follows the pattern exactly, allowing there to be no [TLD](https://en.wikipedia.org/wiki/Top-level_domain).
+    HTML5_ALLOW_NO_TLD
 
     # TODO: Implement this mode.
     # STRICT
@@ -51,7 +54,8 @@ class Athena::Validator::Constraints::Email < Athena::Validator::Constraint
     # Returns the `::Regex` pattern for `self`.
     def pattern : ::Regex
       case self
-      in .html5? then /^[a-zA-Z0-9.!\#$\%&\'*+\\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/
+      in .html5?              then /^[a-zA-Z0-9.!\#$\%&\'*+\\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/
+      in .html5_allow_no_tld? then /^[a-zA-Z0-9.!\#$\%&\'*+\\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
       end
     end
   end


### PR DESCRIPTION
* Introduce optional new email validation mode follows the `HTML5` pattern exactly, allowing for no TLD
  * Allows the HTML5 form to match backend validation exactly