### PR TITLE
Better `scripts/diff.sh` formatting

### DIFF
--- a/scripts/diff.sh
+++ b/scripts/diff.sh
@@ -24,7 +24,7 @@ function diff()
     then
         echo "============"
         echo "$1: $LATEST_TAG"
-        git log --pretty="  %h %s%b" $LATEST_TAG..master | sed 's/^\*/    \*/'
+        git log --pretty="  %h %s%b" $LATEST_TAG..master | sed "s/)\*/)\n    \*/" | sed 's/^\*/    \*/'
     fi
 
     cd $OLDPWD


### PR DESCRIPTION
* Remove empty line if a commit doesn't have any sub-bullets
* Ensure all bullets are on their own line