### PR TITLE
Unfix spelling of `referer` header

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,7 @@
+[default.extend-words]
+# Remove this once https://github.com/crate-ci/typos/issues/316 is resolved
+referer = "referer"
+
 [files]
 extend-exclude = [
   "src/components/routing/spec/fixtures/route_provider/*"

--- a/src/components/framework/spec/routing_spec.cr
+++ b/src/components/framework/spec/routing_spec.cr
@@ -32,7 +32,8 @@ struct RoutingTest < ATH::Spec::APITestCase
   end
 
   def test_route_doesnt_exist_with_referrer : Nil
-    response = self.get "/fake/route", headers: HTTP::Headers{"referrer" => "somebody"}
+    # This is misspelled on purpose, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer.
+    response = self.get "/fake/route", headers: HTTP::Headers{"referer" => "somebody"}
     response.status.should eq HTTP::Status::NOT_FOUND
     response.body.should eq %({"code":404,"message":"No route found for 'GET /fake/route' (from: 'somebody')."})
   end

--- a/src/components/framework/src/listeners/routing_listener.cr
+++ b/src/components/framework/src/listeners/routing_listener.cr
@@ -40,7 +40,8 @@ struct Athena::Framework::Listeners::Routing
     rescue ex : ART::Exception::ResourceNotFound
       message = "No route found for '#{request.method} #{request.resource}'"
 
-      if referrer = request.headers["referrer"]?
+      # This is misspelled on purpose, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer.
+      if referrer = request.headers["referer"]?
         message += " (from: '#{referrer}')"
       end
 


### PR DESCRIPTION
* Reverts part of #222 since `referer` is misspelled on purpose