### PR TITLE
Allow giving a descriptive name to `AED::Callable` instances

### DIFF
--- a/src/components/event_dispatcher/spec/callable_spec.cr
+++ b/src/components/event_dispatcher/spec/callable_spec.cr
@@ -1,0 +1,30 @@
+require "./spec_helper"
+
+private class TestListener
+  include AED::EventListenerInterface
+end
+
+describe AED::Callable do
+  describe "#name" do
+    it "defaults to a generic name if not supplied" do
+      callable = AED::Callable::Event(AED::GenericEvent(String, String)).new(
+        Proc(AED::GenericEvent(String, String), Nil).new { },
+        0,
+        nil,
+      )
+
+      callable.name.should eq "unknown callable"
+    end
+
+    it "EventListenerInstance defaults to a more useful name" do
+      callable = AED::Callable::EventListenerInstance(TestListener, AED::GenericEvent(String, String)).new(
+        Proc(AED::GenericEvent(String, String), Nil).new { },
+        TestListener.new,
+        0,
+        nil,
+      )
+
+      callable.name.should eq "unknown TestListener method"
+    end
+  end
+end

--- a/src/components/event_dispatcher/spec/event_dispatcher_spec.cr
+++ b/src/components/event_dispatcher/spec/event_dispatcher_spec.cr
@@ -49,6 +49,9 @@ struct EventDispatcherTest < ASPEC::TestCase
     @dispatcher.listener PreFoo do
     end
 
+    @dispatcher.listener PreFoo, name: "#2" do
+    end
+
     @dispatcher.listener PostFoo do
     end
 
@@ -57,7 +60,8 @@ struct EventDispatcherTest < ASPEC::TestCase
     @dispatcher.has_listeners?(PostFoo).should be_true
     @dispatcher.has_listeners?(PreBar).should be_false
 
-    @dispatcher.listeners(PreFoo).size.should eq 1
+    @dispatcher.listeners(PreFoo).size.should eq 2
+    @dispatcher.listeners(PreFoo).map(&.name).should eq ["unknown callable", "#2"]
     @dispatcher.listeners(PostFoo).size.should eq 1
     @dispatcher.listeners.size.should eq 2
   end
@@ -244,6 +248,7 @@ struct EventDispatcherTest < ASPEC::TestCase
 
     @dispatcher.has_listeners?(PreFoo).should be_true
     @dispatcher.listeners(PreFoo).size.should eq 2
+    @dispatcher.listeners(PreFoo).map(&.name).should eq ["TestListener#on_pre2", "TestListener#on_pre1"]
 
     @dispatcher.dispatch PreFoo.new
 

--- a/src/components/event_dispatcher/src/callable.cr
+++ b/src/components/event_dispatcher/src/callable.cr
@@ -6,19 +6,54 @@
 #
 # TIP: These types can be manually instantiated and added via the related `AED::EventDispatcherInterface#listener(callable)` overload.
 # This can be useful as a point of integration to other libraries, such as lazily instantiating a `AED::EventListenerInterface` instance.
+#
+# ### Name
+#
+# Each callable also has an optional *name* that can be useful for debugging to allow identifying a specific callable
+# since there would be no way to tell apart two listeners on the same event, with the same priority.
+#
+# ```
+# class MyEvent < AED::Event; end
+#
+# dispatcher = AED::EventDispatcher.new
+#
+# dispatcher.listener(MyEvent, name: "block-listener") { }
+#
+# class MyListener
+#   include AED::EventListenerInterface
+#
+#   @[AEDA::AsEventListener]
+#   def on_my_event(event : MyEvent) : Nil
+#   end
+# end
+#
+# dispatcher.listener MyListener.new
+#
+# dispatcher.listeners(MyEvent).map &.name # => ["block-listener", "MyListener#on_my_event"]
+# ```
+#
+# `AED::Callable::EventListenerInstance` instances registered via `AED::EventDispatcherInterface#listener(listener)` will automatically have a name including the
+# method and listener class names in the format of `ClassName#method_name`.
 abstract struct Athena::EventDispatcher::Callable
   include Comparable(self)
 
   # Returns what `AED::Event` class this callable represents.
   getter event_class : AED::Event.class
 
+  # Returns the name of this callable.
+  # Useful for debugging to identify a specific callable added from a block, or which method an `AED::Callable::EventListenerInstance` is associated with.
+  getter name : String
+
   # Returns the [listener priority][Athena::EventDispatcher::EventDispatcherInterface--listener-priority] of this callable.
   getter priority : Int32
 
   def initialize(
     @event_class : AED::Event.class,
+    name : String?,
     @priority : Int32
-  ); end
+  )
+    @name = name || "unknown callable"
+  end
 
   # :nodoc:
   def <=>(other : AED::Callable) : Int32?
@@ -39,9 +74,10 @@ abstract struct Athena::EventDispatcher::Callable
     def initialize(
       @callback : E -> Nil,
       priority : Int32 = 0,
+      name : String? = nil,
       event_class : E.class = E
     )
-      super event_class, priority
+      super event_class, name, priority
     end
 
     # :nodoc:
@@ -68,9 +104,10 @@ abstract struct Athena::EventDispatcher::Callable
     def initialize(
       @callback : E, AED::EventDispatcherInterface -> Nil,
       priority : Int32 = 0,
+      name : String? = nil,
       event_class : E.class = E
     )
-      super event_class, priority
+      super event_class, name, priority
     end
 
     # :nodoc:
@@ -100,9 +137,10 @@ abstract struct Athena::EventDispatcher::Callable
       @callback : Proc(E, Nil) | Proc(E, AED::EventDispatcherInterface, Nil),
       @instance : I,
       priority : Int32 = 0,
+      name : String? = nil,
       event_class : E.class = E
     )
-      super event_class, priority
+      super event_class, name || "unknown #{@instance.class} method", priority
     end
 
     # :nodoc:

--- a/src/components/event_dispatcher/src/callable.cr
+++ b/src/components/event_dispatcher/src/callable.cr
@@ -17,6 +17,7 @@
 #
 # dispatcher = AED::EventDispatcher.new
 #
+# dispatcher.listener(MyEvent) { }
 # dispatcher.listener(MyEvent, name: "block-listener") { }
 #
 # class MyListener
@@ -29,7 +30,7 @@
 #
 # dispatcher.listener MyListener.new
 #
-# dispatcher.listeners(MyEvent).map &.name # => ["block-listener", "MyListener#on_my_event"]
+# dispatcher.listeners(MyEvent).map &.name # => ["unknown callable", "block-listener", "MyListener#on_my_event"]
 # ```
 #
 # `AED::Callable::EventListenerInstance` instances registered via `AED::EventDispatcherInterface#listener(listener)` will automatically have a name including the

--- a/src/components/event_dispatcher/src/event.cr
+++ b/src/components/event_dispatcher/src/event.cr
@@ -67,7 +67,7 @@ abstract class Athena::EventDispatcher::Event
   include Athena::EventDispatcher::StoppableEvent
 
   # Returns an `AED::Callable` based on the event class the method was called on.
-  # Optionally allows customizing the *priority* of the listener.
+  # Optionally allows customizing the *priority* and *name* of the listener.
   #
   # ```
   # class MyEvent < AED::Event; end
@@ -80,7 +80,7 @@ abstract class Athena::EventDispatcher::Event
   # ```
   #
   # Essentially the same as using [AED::EventDispatcherInterface#listener(event_class,*,priority,&)][Athena::EventDispatcher::EventDispatcherInterface#listener(callable,*,priority)], but removes the need to pass the *event_class*.
-  def self.callable(*, priority : Int32 = 0, &block : self, AED::EventDispatcherInterface -> Nil) : AED::Callable
-    AED::Callable::EventDispatcher(self).new block, priority
+  def self.callable(*, priority : Int32 = 0, name : String? = nil, &block : self, AED::EventDispatcherInterface -> Nil) : AED::Callable
+    AED::Callable::EventDispatcher(self).new block, priority, name
   end
 end

--- a/src/components/event_dispatcher/src/event_dispatcher.cr
+++ b/src/components/event_dispatcher/src/event_dispatcher.cr
@@ -40,10 +40,10 @@ class Athena::EventDispatcher::EventDispatcher
   end
 
   # :inherit:
-  def listener(event_class : E.class, *, priority : Int32 = 0, &block : E, AED::EventDispatcherInterface -> Nil) : AED::Callable forall E
+  def listener(event_class : E.class, *, priority : Int32 = 0, name : String? = nil, &block : E, AED::EventDispatcherInterface -> Nil) : AED::Callable forall E
     {% @def.args[0].raise "expected argument #1 to '#{@def.name}' to be #{AED::Event.class}, not #{E}." unless E <= AED::Event %}
 
-    self.add_callable AED::Callable::EventDispatcher(E).new block, priority
+    self.add_callable AED::Callable::EventDispatcher(E).new block, priority, name
   end
 
   # :inherit:
@@ -99,7 +99,8 @@ class Athena::EventDispatcher::EventDispatcher
             AED::Callable::EventListenerInstance(T, {{event}}).new(
               ->listener.{{method}}({{event}}),
               listener,
-              {{priority}}
+              {{priority}},
+              "{{T}}##{{{method.stringify}}}"
             )
           )
         {% else %}
@@ -107,7 +108,8 @@ class Athena::EventDispatcher::EventDispatcher
             AED::Callable::EventListenerInstance(T, {{event}}).new(
               ->listener.{{method}}({{event}}, AED::EventDispatcherInterface),
               listener,
-              {{priority}}
+              {{priority}},
+              "{{T}}##{{{method.stringify}}}"
             )
           )
         {% end %}

--- a/src/components/event_dispatcher/src/event_dispatcher_interface.cr
+++ b/src/components/event_dispatcher/src/event_dispatcher_interface.cr
@@ -64,8 +64,8 @@ module Athena::EventDispatcher::EventDispatcherInterface
   # Registers the provided *callable* listener to this dispatcher, overriding its priority with that of the provided *priority*.
   abstract def listener(callable : AED::Callable, *, priority : Int32) : AED::Callable
 
-  # Registers the block as an `AED::Callable` on the provided *event_class*, optionally with the provided *priority*.
-  abstract def listener(event_class : E.class, *, priority : Int32 = 0, &block : E, AED::EventDispatcherInterface -> Nil) : AED::Callable forall E
+  # Registers the block as an `AED::Callable` on the provided *event_class*, optionally with the provided *priority* and/or *name*.
+  abstract def listener(event_class : E.class, *, priority : Int32 = 0, name : String? = nil, &block : E, AED::EventDispatcherInterface -> Nil) : AED::Callable forall E
 
   # Registers the provided *listener* instance to this dispatcher.
   abstract def listener(listener : AED::EventListenerInterface) : Nil


### PR DESCRIPTION
- Will help out with the `debug:event-dispatcher` name to allow exposing the listener class and method name each listeners is associated with