### PR TITLE
Bump newly release components to their next `-dev` version

### DIFF
--- a/src/components/console/shard.yml
+++ b/src/components/console/shard.yml
@@ -1,6 +1,6 @@
 name: athena-console
 
-version: 0.3.0
+version: 0.4.0-dev
 
 crystal: ~> 1.4
 

--- a/src/components/console/src/athena-console.cr
+++ b/src/components/console/src/athena-console.cr
@@ -91,7 +91,7 @@ alias ACONA = ACON::Annotations
 # From here you can then setup your entry point file talked about earlier, being sure to require the component via `require "athena-console"`.
 # Finally, create/require your `ACON::Command`s, and customize the `ACON::Application` as needed.
 module Athena::Console
-  VERSION = "0.3.0"
+  VERSION = "0.4.0-dev"
 
   # Contains all the `Athena::Console` based annotations.
   module Annotations; end

--- a/src/components/dependency_injection/shard.yml
+++ b/src/components/dependency_injection/shard.yml
@@ -19,4 +19,4 @@ authors:
 dependencies:
   athena-config:
     github: athena-framework/config
-    version: ~> 0.3.0
+    version: '>=0.3.0, <0.4.0'

--- a/src/components/dependency_injection/shard.yml
+++ b/src/components/dependency_injection/shard.yml
@@ -1,6 +1,6 @@
 name: athena-dependency_injection
 
-version: 0.3.4
+version: 0.4.0-dev
 
 crystal: ~> 1.4
 

--- a/src/components/dependency_injection/src/athena-dependency_injection.cr
+++ b/src/components/dependency_injection/src/athena-dependency_injection.cr
@@ -52,7 +52,7 @@ alias ADI = Athena::DependencyInjection
 # fiber is truly independent from one another, with them not being reused or sharing state external to the container. An example of this is how `HTTP::Server` reuses fibers
 # for `connection: keep-alive` requests. Because of this, or in cases similar to, you may want to manually reset the container via `Fiber.current.container = ADI::ServiceContainer.new`.
 module Athena::DependencyInjection
-  VERSION = "0.3.4"
+  VERSION = "0.4.0-dev"
 
   private BINDINGS            = {} of Nil => Nil
   private AUTO_CONFIGURATIONS = {} of Nil => Nil

--- a/src/components/event_dispatcher/shard.yml
+++ b/src/components/event_dispatcher/shard.yml
@@ -1,6 +1,6 @@
 name: athena-event_dispatcher
 
-version: 0.2.0
+version: 0.3.0-dev
 
 crystal: ~> 1.4
 

--- a/src/components/event_dispatcher/src/athena-event_dispatcher.cr
+++ b/src/components/event_dispatcher/src/athena-event_dispatcher.cr
@@ -93,7 +93,7 @@ alias AEDA = AED::Annotations
 # This ensures that one flow will not leak state to any other flow, while still allowing flow specific mutations to be used.
 # Consider pairing this component with the [Athena::DependencyInjection][Athena::DependencyInjection--getting-started] component as a way to handle this.
 module Athena::EventDispatcher
-  VERSION = "0.2.0"
+  VERSION = "0.3.0-dev"
 
   # Contains all the `Athena::EventDispatcher` based annotations.
   module Annotations; end

--- a/src/components/framework/shard.yml
+++ b/src/components/framework/shard.yml
@@ -22,25 +22,25 @@ libraries:
 dependencies:
   athena-event_dispatcher:
     github: athena-framework/event-dispatcher
-    version: ~> 0.2.0
+    version: '>=0.2.0, <0.3.0'
   athena-config:
     github: athena-framework/config
-    version: ~> 0.3.0
+    version: '>=0.3.0, <0.4.0'
   athena-console:
     github: athena-framework/console
-    version: ~> 0.3.0
+    version: '>=0.3.0, <0.4.0'
   athena-dependency_injection:
     github: athena-framework/dependency-injection
-    version: ~> 0.3.4
+    version: '>=0.3.4, <0.4.0'
   athena-negotiation:
     github: athena-framework/negotiation
-    version: ~> 0.1.0
+    version: '>=0.1.0, <0.2.0'
   athena-routing:
     github: athena-framework/routing
-    version: ~> 0.1.4
+    version: '>=0.1.4, <0.2.0'
   athena-serializer:
     github: athena-framework/serializer
-    version: ~> 0.3.0
+    version: '>=0.3.0, <0.4.0'
   athena-validator:
     github: athena-framework/validator
-    version: ~> 0.3.0
+    version: '>=0.3.0, <0.4.0'

--- a/src/components/routing/shard.yml
+++ b/src/components/routing/shard.yml
@@ -1,6 +1,6 @@
 name: athena-routing
 
-version: 0.1.4
+version: 0.2.0-dev
 
 crystal: ~> 1.4
 

--- a/src/components/routing/src/athena-routing.cr
+++ b/src/components/routing/src/athena-routing.cr
@@ -93,7 +93,7 @@ alias ARTA = ART::Annotations
 #
 # TIP: Consider using the annotations provided by the component within `ART::Annotations` to handle route registration.
 module Athena::Routing
-  VERSION = "0.1.4"
+  VERSION = "0.2.0-dev"
 
   {% if @top_level.has_constant?("Athena") && Athena.has_constant?("Framework") && Athena::Framework.has_constant?("Request") %}
     # Represents the type of the *request* parameter within an `ART::Route::Condition`.

--- a/src/components/serializer/shard.yml
+++ b/src/components/serializer/shard.yml
@@ -19,4 +19,4 @@ authors:
 dependencies:
   athena-config:
     github: athena-framework/config
-    version: '>= 0.2.0'
+    version: '>=0.2.0'

--- a/src/components/serializer/shard.yml
+++ b/src/components/serializer/shard.yml
@@ -1,6 +1,6 @@
 name: athena-serializer
 
-version: 0.3.2
+version: 0.4.0-dev
 
 crystal: ~> 1.4
 

--- a/src/components/serializer/src/athena-serializer.cr
+++ b/src/components/serializer/src/athena-serializer.cr
@@ -120,7 +120,7 @@ module YAML; end
 # ASR.serializer.serialize obj, :json, ASR::SerializationContext.new.groups = ["details"] # => {"name":"FIRST LAST","title":"title"}
 # ```
 module Athena::Serializer
-  VERSION = "0.3.2"
+  VERSION = "0.4.0-dev"
 
   # Returns an `ASR::SerializerInterface` instance for ad-hoc (de)serialization.
   #

--- a/src/components/spec/shard.yml
+++ b/src/components/spec/shard.yml
@@ -1,6 +1,6 @@
 name: athena-spec
 
-version: 0.3.1
+version: 0.4.0-dev
 
 crystal: ~> 1.4
 

--- a/src/components/spec/src/athena-spec.cr
+++ b/src/components/spec/src/athena-spec.cr
@@ -25,7 +25,7 @@ require "./test_case"
 #
 # If using the component with the framework, also checkout the [manual](/components/spec) for some additional information on how it is integrated.
 module Athena::Spec
-  VERSION = "0.3.1"
+  VERSION = "0.4.0-dev"
 
   # Runs all `ASPEC::TestCase`s.
   #

--- a/src/components/validator/shard.yml
+++ b/src/components/validator/shard.yml
@@ -19,4 +19,4 @@ authors:
 dependencies:
   athena-image_size:
     github: athena-framework/image-size
-    version: ~> 0.1.0
+    version: '>=0.1.0, <0.2.0'

--- a/src/components/validator/shard.yml
+++ b/src/components/validator/shard.yml
@@ -1,6 +1,6 @@
 name: athena-validator
 
-version: 0.3.0
+version: 0.4.0-dev
 
 crystal: ~> 1.6
 

--- a/src/components/validator/src/athena-validator.cr
+++ b/src/components/validator/src/athena-validator.cr
@@ -400,7 +400,7 @@ alias Assert = AVD::Annotations
 #
 # NOTE: See the related types for more detailed information.
 module Athena::Validator
-  VERSION = "0.3.0"
+  VERSION = "0.4.0-dev"
 
   # :nodoc:
   #


### PR DESCRIPTION
Are trying something new in how I handle component releases by following https://trunkbaseddevelopment.com/branch-for-release/.

This PR goes thru and updates the version of the newly released components to their next `*-dev` version such that if they're installed on the `master` branch you can tell its not the same release as whats currently live.

It also allows merging breaking changes in prep for the next minor version, while then being able to release backwards compatible changes as patch releases on the current `release/major.minor` branch. 