### PR TITLE
Filter `AVD::Metadata::GetterMetadata` to only methods without parameters

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,6 +2,7 @@
 
 EXIT_CODE=0
 DEFAULT_OPTIONS=(-Dstrict_multi_assign --order=random --error-on-warnings)
+CRYSTAL=${CRYSTAL:=crystal}
 
 # Runs the specs for all, or optionally a single component
 #
@@ -9,13 +10,13 @@ DEFAULT_OPTIONS=(-Dstrict_multi_assign --order=random --error-on-warnings)
 
 if [ -n "$1" ]
 then
-  crystal spec "${DEFAULT_OPTIONS[@]}" "src/components/$1/spec"
+  $CRYSTAL spec "${DEFAULT_OPTIONS[@]}" "src/components/$1/spec"
   exit $?
 fi
 
 for component in $(find src/components/ -maxdepth 2 -type f -name shard.yml | xargs -I{} dirname {} | sort); do
   echo "::group::$component"
-  crystal spec "${DEFAULT_OPTIONS[@]}" $component/spec || EXIT_CODE=1
+  $CRYSTAL spec "${DEFAULT_OPTIONS[@]}" $component/spec || EXIT_CODE=1
   echo "::endgroup::"
 done
 

--- a/src/components/validator/spec/constraints/hash_like_object_collection_validator_spec.cr
+++ b/src/components/validator/spec/constraints/hash_like_object_collection_validator_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "./collection_validator_test_case"
 
 private struct HashLikeObject
   include Enumerable({String | Int32, Int32?})

--- a/src/components/validator/src/metadata/getter_metadata.cr
+++ b/src/components/validator/src/metadata/getter_metadata.cr
@@ -20,7 +20,7 @@ class Athena::Validator::Metadata::GetterMetadata(EntityType, MethodIdx)
         obj.{{EntityType.methods[MethodIdx].name.id}}
       {% else %}
         case @name
-          {% for m in EntityType.methods.reject &.name.ends_with? '=' %}
+          {% for m in EntityType.methods.select &.args.empty? %}
             when {{m.name.stringify}} then obj.{{m.name.id}}
           {% end %}
         else


### PR DESCRIPTION
* Improve `scripts/test.sh` to allow customizing the `crystal` binary used to run the specs
  * E.g. if nightly binary is also installed

Discovered via nightly CI: https://github.com/athena-framework/athena/actions/runs/3898430740/jobs/6657156700