### PR TITLE
Handle `JSON::Serializable` values within `Hash`/`NamedTuple` controller action return types

### DIFF
--- a/src/components/framework/spec/controllers/view_controller.cr
+++ b/src/components/framework/spec/controllers/view_controller.cr
@@ -1,6 +1,6 @@
 require "../spec_helper"
 
-private record JSONSerializableModel, id : Int32, name : String do
+record JSONSerializableModel, id : Int32, name : String do
   include JSON::Serializable
 end
 
@@ -52,6 +52,16 @@ class ViewController < ATH::Controller
       BothSerializableModel.new(10, "Bob"),
       BothSerializableModel.new(20, "Sally"),
     ]
+  end
+
+  @[ARTA::Get("/json-nested-hash-collection")]
+  def nested_json_hash_collection : Hash(String, Int32 | JSONSerializableModel)
+    {"foo" => 10, "obj" => JSONSerializableModel.new(10, "Bob")}
+  end
+
+  @[ARTA::Get("/json-nested-nt-collection")]
+  def nested_json_nt_collection : {foo: Int32, obj: JSONSerializableModel}
+    {foo: 10, obj: JSONSerializableModel.new(10, "Bob")}
   end
 
   @[ARTA::Post("/status")]

--- a/src/components/framework/spec/controllers/view_controller.cr
+++ b/src/components/framework/spec/controllers/view_controller.cr
@@ -64,6 +64,16 @@ class ViewController < ATH::Controller
     {foo: 10, obj: JSONSerializableModel.new(10, "Bob")}
   end
 
+  @[ARTA::Get("/json-nested-hash-array-collection")]
+  def nested_json_hash_array_collection : Hash(String, Int32 | Array(JSONSerializableModel))
+    {"foo" => 10, "objs" => [JSONSerializableModel.new(10, "Bob")]}
+  end
+
+  @[ARTA::Get("/json-nested-nt-array-collection")]
+  def nested_json_nt_array_collection : {foo: Int32, objs: Array(JSONSerializableModel)}
+    {foo: 10, objs: [JSONSerializableModel.new(10, "Bob")]}
+  end
+
   @[ARTA::Post("/status")]
   @[ATHA::View(status: :accepted)]
   def custom_status_code : String

--- a/src/components/framework/spec/view_controller_spec.cr
+++ b/src/components/framework/spec/view_controller_spec.cr
@@ -18,6 +18,14 @@ struct ViewControllerTest < ATH::Spec::APITestCase
     self.get("/view/json-array-empty").body.should eq %([])
   end
 
+  def test_json_nested_hash_collection : Nil
+    self.get("/view/json-nested-hash-collection").body.should eq %({"foo":10,"obj":{"id":10,"name":"Bob"}})
+  end
+
+  def test_json_nested_nt_collection : Nil
+    self.get("/view/json-nested-nt-collection").body.should eq %({"foo":10,"obj":{"id":10,"name":"Bob"}})
+  end
+
   def test_asr_serializable_object : Nil
     self.get("/view/asr").body.should eq %({"id":20})
   end

--- a/src/components/framework/spec/view_controller_spec.cr
+++ b/src/components/framework/spec/view_controller_spec.cr
@@ -26,6 +26,14 @@ struct ViewControllerTest < ATH::Spec::APITestCase
     self.get("/view/json-nested-nt-collection").body.should eq %({"foo":10,"obj":{"id":10,"name":"Bob"}})
   end
 
+  def test_json_nested_hash_array_collection : Nil
+    self.get("/view/json-nested-hash-array-collection").body.should eq %({"foo":10,"objs":[{"id":10,"name":"Bob"}]})
+  end
+
+  def test_json_nested_nt_array_collection : Nil
+    self.get("/view/json-nested-nt-array-collection").body.should eq %({"foo":10,"objs":[{"id":10,"name":"Bob"}]})
+  end
+
   def test_asr_serializable_object : Nil
     self.get("/view/asr").body.should eq %({"id":20})
   end

--- a/src/components/framework/src/view/view.cr
+++ b/src/components/framework/src/view/view.cr
@@ -140,8 +140,11 @@ class Athena::Framework::View(T)
     {% if (T <= JSON::Serializable) && !(T <= ASR::Serializable) %}
       # Single JSON::Serializable object
       self.data
-    {% elsif (T <= Enumerable) && T.type_vars.any? { |t| (t <= JSON::Serializable) && !(t <= ASR::Serializable) } %}
-      # Array of JSON::Serializable
+    {% elsif (T <= NamedTuple) && (T.keys.any? { |k| ntt = T[k]; ((ntt <= JSON::Serializable) && !(ntt <= ASR::Serializable)) }) %}
+      # Namedtuple with a value of JSON::Serializable
+      self.data
+    {% elsif (T <= Enumerable) && T.type_vars.any? { |t| ((t <= JSON::Serializable) && !(t <= ASR::Serializable)) || (t.union? && t.union_types.any? { |ut| ((ut <= JSON::Serializable) && !(ut <= ASR::Serializable)) }) } %}
+      # Enumerable (Hash, Array, Set, ...) of JSON::Serializable
       self.data
     {% else %}
       nil

--- a/src/components/framework/src/view/view.cr
+++ b/src/components/framework/src/view/view.cr
@@ -140,10 +140,20 @@ class Athena::Framework::View(T)
     {% if (T <= JSON::Serializable) && !(T <= ASR::Serializable) %}
       # Single JSON::Serializable object
       self.data
-    {% elsif (T <= NamedTuple) && (T.keys.any? { |k| ntt = T[k]; ((ntt <= JSON::Serializable) && !(ntt <= ASR::Serializable)) }) %}
+    {% elsif (T <= NamedTuple) && (T.keys.any? do |k|
+               ntt = T[k]
+
+               ((ntt <= JSON::Serializable) && !(ntt <= ASR::Serializable)) ||
+                 (ntt.union? && ntt.union_types.any? { |ut| ((ut <= JSON::Serializable) && !(ut <= ASR::Serializable)) }) ||
+                 (ntt.type_vars.any? { |t| ((t <= JSON::Serializable) && !(t <= ASR::Serializable)) })
+             end) %}
       # Namedtuple with a value of JSON::Serializable
       self.data
-    {% elsif (T <= Enumerable) && T.type_vars.any? { |t| ((t <= JSON::Serializable) && !(t <= ASR::Serializable)) || (t.union? && t.union_types.any? { |ut| ((ut <= JSON::Serializable) && !(ut <= ASR::Serializable)) }) } %}
+    {% elsif (T <= Enumerable) && T.type_vars.any? do |t|
+               ((t <= JSON::Serializable) && !(t <= ASR::Serializable)) ||
+                 (t.union? && t.union_types.any? { |ut| ((ut <= JSON::Serializable) && !(ut <= ASR::Serializable)) ||
+                   (ut.type_vars.any? { |utt| ((utt <= JSON::Serializable) && !(utt <= ASR::Serializable)) }) })
+             end %}
       # Enumerable (Hash, Array, Set, ...) of JSON::Serializable
       self.data
     {% else %}


### PR DESCRIPTION
* Was incorrectly choosing `Athena::Serializer` for `JSON::Serializable` types nested within a hash/named tuple resulting in the value being `null`
  * NOTE: Only 1 level deep of the hash/nt value type is checked. I.e. `Hash(String, Hash(String, SomeJsonType))` would not work. Nested array values are supported however