### PR TITLE
Fix formatting issues from Crystal `1.8-dev`

### DIFF
--- a/src/components/console/src/helper/question.cr
+++ b/src/components/console/src/helper/question.cr
@@ -185,7 +185,7 @@ class Athena::Console::Helper::Question < Athena::Console::Helper
     end
   end
 
-  private def validate_attempts(output : ACON::Output::Interface, question : ACON::Question::Base)
+  private def validate_attempts(output : ACON::Output::Interface, question : ACON::Question::Base, &)
     error = nil
     attempts = question.max_attempts
 

--- a/src/components/routing/src/route_collection.cr
+++ b/src/components/routing/src/route_collection.cr
@@ -150,7 +150,7 @@ class Athena::Routing::RouteCollection
   end
 
   # Yields the name and `ART::Route` object for each registered route.
-  def each : Nil
+  def each(&) : Nil
     self.routes.each do |k, v|
       yield({k, v})
     end


### PR DESCRIPTION
* Gets ahead of Crystal `1.8` to avoid CI failures due to new formatter features
  * Ensures all yielding methods have a `&` in their method signature 
