### PR TITLE
Prevent wildcard `expose_headers` value when `allow_credentials` is `true`

### DIFF
--- a/src/components/framework/spec/listeners/cors_listener_spec.cr
+++ b/src/components/framework/spec/listeners/cors_listener_spec.cr
@@ -19,7 +19,7 @@ private def assert_headers(response : ATH::Response, origin : String = "https://
 end
 
 private def assert_headers_with_wildcard_config_without_request_headers(response : ATH::Response) : Nil
-  response.headers["access-control-allow-credentials"].should eq "true"
+  response.headers["access-control-allow-credentials"]?.should be_nil
   response.headers["access-control-allow-headers"]?.should be_nil
   response.headers["access-control-allow-methods"].should eq "GET, POST, HEAD"
   response.headers["access-control-allow-origin"].should eq "https://example.com"
@@ -28,7 +28,7 @@ end
 
 private EMPTY_CONFIG    = ATH::Config::CORS.new
 private WILDCARD_CONFIG = ATH::Config::CORS.new(
-  allow_credentials: true,
+  allow_credentials: false,
   allow_headers: %w(*),
   allow_origin: %w(*),
   expose_headers: %w(*),

--- a/src/components/framework/src/config/cors.cr
+++ b/src/components/framework/src/config/cors.cr
@@ -69,6 +69,11 @@ struct Athena::Framework::Config::CORS
     @expose_headers : Array(String) = [] of String,
     @max_age : Int32 = 0
   )
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
+    if @allow_credentials && @expose_headers.includes? "*"
+      raise ArgumentError.new "expose_headers cannot contain a wildcard ('*') when allow_credentials is 'true'."
+    end
+
     @allow_origin = allow_origin.map &.as String | Regex
   end
 end


### PR DESCRIPTION
The [spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers) doesn't allow the `*` wildcard when credentials are allowed, so let's just prevent it.