### PR TITLE
 `ATH::Listeners::CORS` improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
         uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{ matrix.crystal }}
+      - name: Install pkg-config via brew
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: brew install pkg-config
       - name: Install Dependencies
         run: shards install --skip-postinstall --skip-executables
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           crystal: ${{ matrix.crystal }}
       - name: Install Dependencies
-        run: shards install
+        run: shards install --skip-postinstall --skip-executables
         env:
           SHARDS_OVERRIDE: shard.dev.yml
       - name: Specs

--- a/src/components/framework/spec/listeners/cors_listener_spec.cr
+++ b/src/components/framework/spec/listeners/cors_listener_spec.cr
@@ -43,7 +43,7 @@ private CONFIG = ATH::Config::CORS.new(
   max_age: 123
 )
 
-describe ATH::Listeners::CORS, focus: true do
+describe ATH::Listeners::CORS do
   describe "#on_request - request" do
     it "without a configuration defined" do
       listener = ATH::Listeners::CORS.new nil

--- a/src/components/framework/spec/listeners/cors_listener_spec.cr
+++ b/src/components/framework/spec/listeners/cors_listener_spec.cr
@@ -43,7 +43,7 @@ private CONFIG = ATH::Config::CORS.new(
   max_age: 123
 )
 
-describe ATH::Listeners::CORS do
+describe ATH::Listeners::CORS, focus: true do
   describe "#on_request - request" do
     it "without a configuration defined" do
       listener = ATH::Listeners::CORS.new nil

--- a/src/components/framework/src/listeners/cors_listener.cr
+++ b/src/components/framework/src/listeners/cors_listener.cr
@@ -1,8 +1,10 @@
 @[ADI::Register]
-# Handles [Cross-Origin Resource Sharing](https://enable-cors.org) (CORS).
+# Supports [Cross-Origin Resource Sharing](https://enable-cors.org) (CORS) requests.
 #
 # Handles CORS preflight `OPTIONS` requests as well as adding CORS headers to each response.
 # See `ATH::Config::CORS` for information on configuring the listener.
+#
+# TIP: Set your [Log::Severity](https://crystal-lang.org/api/Log/Severity.html) to `TRACE` to help debug the listener.
 struct Athena::Framework::Listeners::CORS
   include AED::EventListenerInterface
 
@@ -46,7 +48,7 @@ struct Athena::Framework::Listeners::CORS
 
     # Return early if there is no configuration.
     unless @config
-      Log.debug { "#{self.class.name} is unconfigured, skipping CORS." }
+      Log.trace { "#{self.class.name} is unconfigured, skipping CORS." }
 
       return
     end
@@ -54,25 +56,25 @@ struct Athena::Framework::Listeners::CORS
     # Return early if not a CORS request.
     # TODO: optimize this by also checking if origin matches the request's host.
     unless request.headers.has_key? "origin"
-      Log.debug { "Request does not have an 'origin' header, skipping CORS." }
+      Log.trace { "Request does not have an 'origin' header, skipping CORS." }
 
       return
     end
 
     # If the request is a preflight, return the proper response.
     if request.method == "OPTIONS" && request.headers.has_key? REQUEST_METHOD_HEADER
-      Log.debug { "Request is a pre-flight request, creating response" }
+      Log.trace { "Request is a pre-flight request, creating response." }
 
       return event.response = set_preflight_response event.request
     end
 
     unless check_origin event.request
-      Log.debug { "Origin check failed." }
+      Log.trace { "Origin check failed." }
 
       return
     end
 
-    Log.debug { "Origin is allowed, proceed with adding CORS response headers." }
+    Log.trace { "Origin is allowed, proceed with adding CORS response headers." }
 
     event.request.attributes.set ALLOW_SET_ORIGIN, true, Bool
   end
@@ -81,27 +83,27 @@ struct Athena::Framework::Listeners::CORS
   def on_response(event : ATH::Events::Response) : Nil
     # Return early if the request shouldn't have CORS set.
     unless event.request.attributes.get? ALLOW_SET_ORIGIN
-      Log.debug { "The origin is not allowed, skipping CORS response headers." }
+      Log.trace { "The origin is not allowed, skipping CORS response headers." }
 
       return
     end
 
     # Return early if there is no configuration.
     unless @config
-      Log.debug { "#{self.class.name} is unconfigured, skipping CORS response headers." }
+      Log.trace { "#{self.class.name} is unconfigured, skipping CORS response headers." }
 
       return
     end
 
     origin = event.request.headers["origin"]
 
-    Log.debug { "Setting '#{ALLOW_ORIGIN_HEADER}' to '#{origin}'." }
+    Log.trace { "Setting '#{ALLOW_ORIGIN_HEADER}' to '#{origin}'." }
 
     # TODO: Add a configuration option to allow setting this explicitly
     event.response.headers[ALLOW_ORIGIN_HEADER] = origin
 
     if self.config.allow_credentials
-      Log.debug { "Setting '#{ALLOW_CREDENTIALS_HEADER}' to 'true'." }
+      Log.trace { "Setting '#{ALLOW_CREDENTIALS_HEADER}' to 'true'." }
 
       event.response.headers[ALLOW_CREDENTIALS_HEADER] = "true"
     end
@@ -109,7 +111,7 @@ struct Athena::Framework::Listeners::CORS
     unless self.config.expose_headers.empty?
       headers = self.config.expose_headers.join(", ")
 
-      Log.debug { "Settings '#{EXPOSE_HEADERS_HEADER}' to '#{headers}'." }
+      Log.trace { "Settings '#{EXPOSE_HEADERS_HEADER}' to '#{headers}'." }
 
       event.response.headers[EXPOSE_HEADERS_HEADER] = headers
     end
@@ -121,7 +123,7 @@ struct Athena::Framework::Listeners::CORS
     response.headers["vary"] = "origin"
 
     if self.config.allow_credentials
-      Log.debug { "Setting '#{ALLOW_CREDENTIALS_HEADER}' response header to 'true'." }
+      Log.trace { "Setting '#{ALLOW_CREDENTIALS_HEADER}' response header to 'true'." }
 
       response.headers[ALLOW_CREDENTIALS_HEADER] = "true"
     end
@@ -129,7 +131,7 @@ struct Athena::Framework::Listeners::CORS
     if self.config.max_age > 0
       max_age = self.config.max_age.to_s
 
-      Log.debug { "Setting '#{MAX_AGE_HEADER}' response header to '#{max_age}'." }
+      Log.trace { "Setting '#{MAX_AGE_HEADER}' response header to '#{max_age}'." }
 
       response.headers[MAX_AGE_HEADER] = max_age
     end
@@ -137,7 +139,7 @@ struct Athena::Framework::Listeners::CORS
     unless self.config.allow_methods.empty?
       allow_methods = self.config.allow_methods.join(", ")
 
-      Log.debug { "Setting '#{ALLOW_METHODS_HEADER}' response header to '#{allow_methods}'." }
+      Log.trace { "Setting '#{ALLOW_METHODS_HEADER}' response header to '#{allow_methods}'." }
 
       response.headers[ALLOW_METHODS_HEADER] = allow_methods
     end
@@ -148,14 +150,14 @@ struct Athena::Framework::Listeners::CORS
       unless headers.empty?
         allow_headers = headers.join(", ")
 
-        Log.debug { "Setting '#{ALLOW_HEADERS_HEADER}' response header to '#{allow_headers}'." }
+        Log.trace { "Setting '#{ALLOW_HEADERS_HEADER}' response header to '#{allow_headers}'." }
 
         response.headers[ALLOW_HEADERS_HEADER] = allow_headers
       end
     end
 
     unless check_origin request
-      Log.debug { "Removing '#{ALLOW_ORIGIN_HEADER}' response header." }
+      Log.trace { "Removing '#{ALLOW_ORIGIN_HEADER}' response header." }
 
       request.headers.delete ALLOW_ORIGIN_HEADER
 
@@ -164,11 +166,13 @@ struct Athena::Framework::Listeners::CORS
 
     origin = request.headers["origin"]
 
-    Log.debug { "Setting '#{ALLOW_ORIGIN_HEADER}' response header to '#{origin}'." }
+    Log.trace { "Setting '#{ALLOW_ORIGIN_HEADER}' response header to '#{origin}'." }
 
     response.headers[ALLOW_ORIGIN_HEADER] = origin
 
-    unless self.config.allow_methods.includes? request.headers[REQUEST_METHOD_HEADER].upcase
+    unless self.config.allow_methods.includes?(method = request.headers[REQUEST_METHOD_HEADER].upcase)
+      Log.trace { "Method '#{method}' is not allowed." }
+
       response.status = :method_not_allowed
 
       return response
@@ -179,7 +183,7 @@ struct Athena::Framework::Listeners::CORS
         next if SAFELISTED_HEADERS.includes? header
         next if self.config.allow_headers.includes? header
 
-        raise ATH::Exceptions::Forbidden.new "Unauthorized header: '#{header}'"
+        raise ATH::Exceptions::Forbidden.new "Unauthorized header: '#{header}'."
       end
     end
 
@@ -187,9 +191,27 @@ struct Athena::Framework::Listeners::CORS
   end
 
   private def check_origin(request : ATH::Request) : Bool
-    return true if self.config.allow_origin.includes?(WILDCARD)
+    origin = request.headers["origin"]
+
+    if self.config.allow_origin.includes?(WILDCARD)
+      Log.trace { "Origin is a wildcard." }
+
+      return true
+    end
 
     # Use case equality in case an origin is a Regex
-    self.config.allow_origin.any? &.===(request.headers["origin"])
+    self.config.allow_origin.each do |ao|
+      Log.trace { "Checking allowed origin '#{ao}' to origin '#{origin}'." }
+
+      if ao === origin
+        Log.trace { "Allowed origin '#{ao}' matches origin '#{origin}'." }
+
+        return true
+      end
+    end
+
+    Log.trace { "Origin '#{origin}' is not allowed." }
+
+    false
   end
 end

--- a/src/components/framework/src/listeners/cors_listener.cr
+++ b/src/components/framework/src/listeners/cors_listener.cr
@@ -6,69 +6,6 @@
 struct Athena::Framework::Listeners::CORS
   include AED::EventListenerInterface
 
-  # Encapsulates logic to set CORS response headers
-  private struct ResponseHeaders
-    def initialize(@headers : ATH::Response::Headers); end
-
-    {% for header in %w[allow-origin allow-methods allow-headers allow-credentials expose-headers] %}
-      {% method_name = header.tr("-", "_").id %}
-      def {{method_name}}=(value : String) : Nil
-        @headers[{{"access-control-#{header.id}"}}] = value
-      end
-
-      def {{method_name}}=(value : Bool) : Nil
-        return unless value
-        self.{{method_name}} = "true"
-      end
-
-      def {{method_name}}=(value : Array(String)) : Nil
-        return if value.empty?
-        self.{{method_name}} = value.join ", "
-      end
-
-      def {{method_name}}=(value : Nil) : Nil
-      end
-
-      def delete_{{method_name}} : Nil
-        @headers.delete({{"access-control-#{header.id}"}})
-      end
-    {% end %}
-
-    def max_age=(value : Int32) : Nil
-      return unless value > 0
-      @headers["access-control-max-age"] = value.to_s
-    end
-
-    def vary=(value : String) : Nil
-      @headers["vary"] = value
-    end
-  end
-
-  # Encapsulates logic to query CORS request headers
-  private struct RequestHeaders
-    def initialize(@headers : HTTP::Headers); end
-
-    def request_method : String?
-      @headers["access-control-request-method"]?.try &.upcase
-    end
-
-    def request_headers : Array(String)
-      @headers["access-control-request-headers"]?.try(&.split(/,\ ?/)) || [] of String
-    end
-
-    def origin : String?
-      @headers["origin"]?
-    end
-
-    def has_request_method? : Bool
-      @headers.has_key? "access-control-request-method"
-    end
-  end
-
-  # :nodoc:
-  ALLOW_SET_ORIGIN = "athena.routing.cors.allow_set_origin"
-  private WILDCARD         = "*"
-
   # The [CORS-safelisted request-headers](https://fetch.spec.whatwg.org/#cors-safelisted-request-header).
   SAFELISTED_HEADERS = [
     "accept",
@@ -85,28 +22,57 @@ struct Athena::Framework::Listeners::CORS
     "HEAD",
   ]
 
-  private getter! config : ATH::Config::CORS?
+  # :nodoc:
+  ALLOW_SET_ORIGIN = "athena.routing.cors.allow_set_origin"
+
+  private WILDCARD = "*"
+
+  private REQUEST_METHOD_HEADER    = "access-control-request-method"
+  private REQUEST_HEADERS_HEADER   = "access-control-request-headers"
+  private ALLOW_CREDENTIALS_HEADER = "access-control-allow-credentials"
+  private ALLOW_HEADERS_HEADER     = "access-control-allow-headers"
+  private ALLOW_METHODS_HEADER     = "access-control-allow-methods"
+  private ALLOW_ORIGIN_HEADER      = "access-control-allow-origin"
+  private EXPOSE_HEADERS_HEADER    = "access-control-expose-headers"
+  private MAX_AGE_HEADER           = "access-control-max-age"
+
+  private getter! config : ATH::Config::CORS
 
   def initialize(@config : ATH::Config::CORS?); end
 
   @[AEDA::AsEventListener(priority: 250)]
   def on_request(event : ATH::Events::Request) : Nil
     request = event.request
-    request_headers = RequestHeaders.new(request.headers)
 
     # Return early if there is no configuration.
-    return unless @config
+    unless @config
+      Log.debug { "#{self.class.name} is unconfigured, skipping CORS." }
+
+      return
+    end
 
     # Return early if not a CORS request.
     # TODO: optimize this by also checking if origin matches the request's host.
-    return unless request.headers.has_key? "origin"
+    unless request.headers.has_key? "origin"
+      Log.debug { "Request does not have an 'origin' header, skipping CORS." }
+
+      return
+    end
 
     # If the request is a preflight, return the proper response.
-    if request.method == "OPTIONS" && request_headers.has_request_method?
+    if request.method == "OPTIONS" && request.headers.has_key? REQUEST_METHOD_HEADER
+      Log.debug { "Request is a pre-flight request, creating response" }
+
       return event.response = set_preflight_response event.request
     end
 
-    return unless check_origin event.request
+    unless check_origin event.request
+      Log.debug { "Origin check failed." }
+
+      return
+    end
+
+    Log.debug { "Origin is allowed, proceed with adding CORS response headers." }
 
     event.request.attributes.set ALLOW_SET_ORIGIN, true, Bool
   end
@@ -114,50 +80,102 @@ struct Athena::Framework::Listeners::CORS
   @[AEDA::AsEventListener]
   def on_response(event : ATH::Events::Response) : Nil
     # Return early if the request shouldn't have CORS set.
-    return unless event.request.attributes.get? ALLOW_SET_ORIGIN
+    unless event.request.attributes.get? ALLOW_SET_ORIGIN
+      Log.debug { "The origin is not allowed, skipping CORS response headers." }
+
+      return
+    end
 
     # Return early if there is no configuration.
-    return unless @config
+    unless @config
+      Log.debug { "#{self.class.name} is unconfigured, skipping CORS response headers." }
 
-    request_headers = RequestHeaders.new(event.request.headers)
-    response_headers = ResponseHeaders.new(event.response.headers)
+      return
+    end
+
+    origin = event.request.headers["origin"]
+
+    Log.debug { "Setting '#{ALLOW_ORIGIN_HEADER}' to '#{origin}'." }
 
     # TODO: Add a configuration option to allow setting this explicitly
-    response_headers.allow_origin = request_headers.origin
-    response_headers.allow_credentials = self.config.allow_credentials
-    response_headers.expose_headers = self.config.expose_headers
+    event.response.headers[ALLOW_ORIGIN_HEADER] = origin
+
+    if self.config.allow_credentials
+      Log.debug { "Setting '#{ALLOW_CREDENTIALS_HEADER}' to 'true'." }
+
+      event.response.headers[ALLOW_CREDENTIALS_HEADER] = "true"
+    end
+
+    unless self.config.expose_headers.empty?
+      headers = self.config.expose_headers.join(", ")
+
+      Log.debug { "Settings '#{EXPOSE_HEADERS_HEADER}' to '#{headers}'." }
+
+      event.response.headers[EXPOSE_HEADERS_HEADER] = headers
+    end
   end
 
   # Configures the given *response* for CORS preflight
   private def set_preflight_response(request : ATH::Request) : ATH::Response
     response = ATH::Response.new
+    response.headers["vary"] = "origin"
 
-    response_headers = ResponseHeaders.new(response.headers)
-    request_headers = RequestHeaders.new(request.headers)
+    if self.config.allow_credentials
+      Log.debug { "Setting '#{ALLOW_CREDENTIALS_HEADER}' response header to 'true'." }
 
-    response_headers.vary = "origin"
-    response_headers.allow_credentials = self.config.allow_credentials
-    response_headers.max_age = self.config.max_age
-    response_headers.allow_methods = self.config.allow_methods
+      response.headers[ALLOW_CREDENTIALS_HEADER] = "true"
+    end
 
-    response_headers.allow_headers = self.config.allow_headers.includes?(WILDCARD) ? request_headers.request_headers : self.config.allow_headers
+    if self.config.max_age > 0
+      max_age = self.config.max_age.to_s
+
+      Log.debug { "Setting '#{MAX_AGE_HEADER}' response header to '#{max_age}'." }
+
+      response.headers[MAX_AGE_HEADER] = max_age
+    end
+
+    unless self.config.allow_methods.empty?
+      allow_methods = self.config.allow_methods.join(", ")
+
+      Log.debug { "Setting '#{ALLOW_METHODS_HEADER}' response header to '#{allow_methods}'." }
+
+      response.headers[ALLOW_METHODS_HEADER] = allow_methods
+    end
+
+    unless self.config.allow_headers.empty?
+      headers : Array(String) = self.config.allow_headers.includes?(WILDCARD) ? (request.headers[REQUEST_HEADERS_HEADER]?.try &.split(/,\ ?/) || [] of String) : self.config.allow_headers
+
+      unless headers.empty?
+        allow_headers = headers.join(", ")
+
+        Log.debug { "Setting '#{ALLOW_HEADERS_HEADER}' response header to '#{allow_headers}'." }
+
+        response.headers[ALLOW_HEADERS_HEADER] = allow_headers
+      end
+    end
 
     unless check_origin request
-      response_headers.delete_allow_origin
+      Log.debug { "Removing '#{ALLOW_ORIGIN_HEADER}' response header." }
+
+      request.headers.delete ALLOW_ORIGIN_HEADER
 
       return response
     end
 
-    response_headers.allow_origin = request_headers.origin
+    origin = request.headers["origin"]
 
-    unless self.config.allow_methods.includes? request_headers.request_method
+    Log.debug { "Setting '#{ALLOW_ORIGIN_HEADER}' response header to '#{origin}'." }
+
+    response.headers[ALLOW_ORIGIN_HEADER] = origin
+
+    unless self.config.allow_methods.includes? request.headers[REQUEST_METHOD_HEADER].upcase
       response.status = :method_not_allowed
 
       return response
     end
 
     unless self.config.allow_headers.includes? WILDCARD
-      request_headers.request_headers.each do |header|
+      ((rh = request.headers[REQUEST_HEADERS_HEADER]?) ? rh.split(/,\ ?/) : [] of String).each do |header|
         next if SAFELISTED_HEADERS.includes? header
         next if self.config.allow_headers.includes? header
 


### PR DESCRIPTION
- Add debug logging to help with figuring out issues with setting up CORS
- Refactor listener to be a bit simpler, essentially reverts part of 5035a90a7f2a13b55a11666e81685c57b05ef516
- Manually install `pkg-config` before running tests on mac to workaround https://github.com/actions/runner-images/issues/7128
- Skip installing executable when running tests via CI, saves like 30s/run

Resolves #263