### PR TITLE
Populate `content-length` based on the response content's size

### DIFF
--- a/src/components/framework/spec/controllers/routing_controller.cr
+++ b/src/components/framework/spec/controllers/routing_controller.cr
@@ -22,6 +22,11 @@ class RoutingController < ATH::Controller
     "HEAD"
   end
 
+  @[ARTA::Head("/get-head")]
+  def get_head : ATH::View(String)
+    self.view "GET-HEAD", headers: HTTP::Headers{"FOO" => "BAR"}
+  end
+
   get "/cookies", return_type: ATH::Response do
     response = ATH::Response.new "FOO"
     response.headers << HTTP::Cookie.new "key", "value"

--- a/src/components/framework/spec/routing_spec.cr
+++ b/src/components/framework/spec/routing_spec.cr
@@ -13,6 +13,7 @@ struct RoutingTest < ATH::Spec::APITestCase
     response = self.request "HEAD", "/head"
     response.status.should eq HTTP::Status::OK
     response.body.should be_empty
+    response.headers["content-length"].should eq "6" # JSON encoding adds 2 extra `"` chars
   end
 
   def test_does_not_reuse_container_with_keep_alive_connections : Nil

--- a/src/components/framework/spec/routing_spec.cr
+++ b/src/components/framework/spec/routing_spec.cr
@@ -16,6 +16,14 @@ struct RoutingTest < ATH::Spec::APITestCase
     response.headers["content-length"].should eq "6" # JSON encoding adds 2 extra `"` chars
   end
 
+  def test_head_request_on_get_endpoint : Nil
+    response = self.request "HEAD", "/get-head"
+    response.status.should eq HTTP::Status::OK
+    response.body.should be_empty
+    response.headers["FOO"].should eq "BAR"           # Actually runs the controller action code
+    response.headers["content-length"].should eq "10" # JSON encoding adds 2 extra `"` chars
+  end
+
   def test_does_not_reuse_container_with_keep_alive_connections : Nil
     response1 = self.get("/container/id", headers: HTTP::Headers{"connection" => "keep-alive"}).body
 

--- a/src/components/framework/src/response.cr
+++ b/src/components/framework/src/response.cr
@@ -134,6 +134,9 @@ class Athena::Framework::Response
   #
   # ameba:disable Metrics/CyclomaticComplexity
   def prepare(request : ATH::Request) : Nil
+    # Set the content length if not already manually set
+    @headers["content-length"] = @content.size unless @headers.has_key? "content-length"
+
     if @status.informational? || @status.no_content? || @status.not_modified?
       self.content = nil
       @headers.delete "content-type"

--- a/src/components/framework/src/streamed_response.cr
+++ b/src/components/framework/src/streamed_response.cr
@@ -35,7 +35,8 @@ class Athena::Framework::StreamedResponse < Athena::Framework::Response
   #
   # The proc is called when `self` is being written to the response's `IO`.
   def initialize(@callback : Proc(IO, Nil), status : HTTP::Status | Int32 = HTTP::Status::OK, headers : HTTP::Headers | ATH::Response::Headers = ATH::Response::Headers.new)
-    super nil, status, headers
+    # Manually add `transfer-encoding: chunked` so `ART::Response#prepare` knows how to properly handle this type of response.
+    super nil, status, headers.merge!({"transfer-encoding" => "chunked"})
   end
 
   # Updates the callback of `self`.


### PR DESCRIPTION
- Ensures `HEAD` requests properly return the size that would have been returned had it been a `GET`