### PR TITLE
Enable the `preview_overload_order` flag in `scripts/test.sh`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check Spelling
-        uses: crate-ci/typos@v1.13.8
+        uses: crate-ci/typos@v1.13.18
   check_format:
     runs-on: ubuntu-latest
     container:
@@ -29,7 +29,7 @@ jobs:
   coding_standards:
     runs-on: ubuntu-latest
     container:
-      image: crystallang/crystal:latest-alpine
+      image: crystallang/crystal:latest
     steps:
       - uses: actions/checkout@v3
       - name: Install Dependencies
@@ -61,9 +61,6 @@ jobs:
         uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{ matrix.crystal }}
-      - name: Install pkg-config via brew
-        if: ${{ matrix.os == 'macos-latest' }}
-        run: brew install pkg-config
       - name: Install Dependencies
         run: shards install --skip-postinstall --skip-executables
         env:

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,17 +1,6 @@
 [default.extend-words]
 # Remove this once https://github.com/crate-ci/typos/issues/316 is resolved
 referer = "referer"
-copuling = "coupling"
-tigher = "tighter"
-neccessarly = "necessarily"
-arrises = "arises"
-moer = "more"
-annotaiotn = "annotation"
-comonents = "components"
-encapsulte = "encapsulate"
-proivded = "provided"
-beavior = "behavior"
-easisly = "easily"
 
 [files]
 extend-exclude = [

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 EXIT_CODE=0
-DEFAULT_OPTIONS=(-Dstrict_multi_assign --order=random --error-on-warnings)
+DEFAULT_OPTIONS=(-Dstrict_multi_assign -Dpreview_overload_order --order=random --error-on-warnings)
 CRYSTAL=${CRYSTAL:=crystal}
 
 # Runs the specs for all, or optionally a single component


### PR DESCRIPTION
- Add `preview_overload_order` flag
  - Will help ensure future Crystal compatibility
- Update typos version and remove now un-needed extended words due to https://github.com/crate-ci/typos/pull/674
- Skip installing `pkg-config` on mac now that https://github.com/actions/runner-images/issues/7128 is resolved
- Use the normal Crystal image instead of alpine to try and work around https://github.com/crystal-ameba/ameba/issues/354