### PR TITLE
Resolve PCRE2 nightly CI errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           crystal: ${{ matrix.crystal }}
       - name: Install pkg-config via brew
         if: ${{ matrix.os == 'macos-latest' }}
-        run: brew install pkg-config
+        run: brew install pkg-config pcre2
       - name: Install Dependencies
         run: shards install --skip-postinstall --skip-executables
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           crystal: ${{ matrix.crystal }}
       - name: Install pkg-config via brew
         if: ${{ matrix.os == 'macos-latest' }}
-        run: brew install pkg-config pcre2
+        run: brew install pkg-config
       - name: Install Dependencies
         run: shards install --skip-postinstall --skip-executables
         env:

--- a/src/components/routing/src/athena-routing.cr
+++ b/src/components/routing/src/athena-routing.cr
@@ -1,4 +1,4 @@
-require "./ext/*"
+require "./ext/regex"
 
 require "http/request"
 

--- a/src/components/routing/src/ext/lib_pcre2.cr
+++ b/src/components/routing/src/ext/lib_pcre2.cr
@@ -1,34 +1,42 @@
-@[Link("pcre2-8")]
-lib LibPCRE2
-  ERROR_NOMATCH = -1
+{% if @top_level.has_constant? "LibPCRE2" %}
+  @[Link("pcre2-8")]
+  lib LibPCRE2
+    fun jit_match = pcre2_jit_match_8(code : Code*, subject : UInt8*, length : LibC::SizeT, startoffset : LibC::SizeT, options : UInt32, match_data : MatchData*, mcontext : MatchContext*) : Int
+    fun get_mark = pcre2_get_mark_8(match_data : MatchData*) : UInt8*
+  end
+{% else %}
+  @[Link("pcre2-8")]
+  lib LibPCRE2
+    alias Int = LibC::Int
 
-  JIT_COMPLETE = 0x00000001
+    NO_UTF_CHECK = 0x40000000
 
-  INFO_CAPTURECOUNT  =  4
-  INFO_NAMECOUNT     = 17
-  INFO_NAMEENTRYSIZE = 18
-  INFO_NAMETABLE     = 19
+    enum Error
+      NOMATCH = -1
+    end
 
-  type MatchData = Void*
+    JIT_COMPLETE = 0x00000001
 
-  alias Code = Void*
-  alias CompileContext = Void*
-  alias GeneralContext = Void*
-  alias MatchContext = Void*
+    INFO_CAPTURECOUNT  =  4
+    INFO_NAMECOUNT     = 17
+    INFO_NAMEENTRYSIZE = 18
+    INFO_NAMETABLE     = 19
 
-  alias UCHAR = LibC::UChar*
-  alias SPTR = UInt8*
-  alias SIZE = LibC::SizeT
-  alias UInt32T = LibC::UInt
+    type Code = Void
+    type CompileContext = Void
+    type GeneralContext = Void
+    type MatchContext = Void
+    type MatchData = Void
 
-  fun compile = pcre2_compile_8(pattern : SPTR, length : SIZE, options : UInt32T, error_code : LibC::Int*, error_offset : SIZE*, compile_context : CompileContext) : Code
-  fun jit_compile = pcre2_jit_compile_8(code : Code, options : UInt32T) : LibC::Int
-  fun create_match_data = pcre2_match_data_create_from_pattern_8(code : Code, general_context : GeneralContext) : MatchData
-  fun jit_match = pcre2_jit_match_8(code : Code, subject : SPTR, length : SIZE, start_offset : SIZE, options : UInt32T, match_data : MatchData, match_context : MatchContext) : LibC::Int
-  fun get_ovector = pcre2_get_ovector_pointer_8(match_data : MatchData) : SIZE*
+    fun compile = pcre2_compile_8(pattern : UInt8*, length : LibC::SizeT, options : UInt32, errorcode : Int*, erroroffset : LibC::SizeT*, ccontext : CompileContext*) : Code*
+    fun jit_compile = pcre2_jit_compile_8(code : Code*, options : UInt32) : Int
+    fun match_data_create_from_pattern = pcre2_match_data_create_from_pattern_8(code : Code*, gcontext : GeneralContext*) : MatchData*
+    fun jit_match = pcre2_jit_match_8(code : Code*, subject : UInt8*, length : LibC::SizeT, startoffset : LibC::SizeT, options : UInt32, match_data : MatchData*, mcontext : MatchContext*) : Int
+    fun get_ovector_pointer = pcre2_get_ovector_pointer_8(match_data : MatchData*) : LibC::SizeT*
 
-  fun pattern_info = pcre2_pattern_info_8(code : Code, what : UInt32T, where : LibC::Int*) : LibC::Int
-  fun get_mark = pcre2_get_mark_8(match_data : MatchData) : SPTR
+    fun pattern_info = pcre2_pattern_info_8(code : Code*, what : UInt32, where : Void*) : Int
+    fun get_mark = pcre2_get_mark_8(match_data : MatchData*) : LibC::Char*
 
-  fun get_error_message = pcre2_get_error_message_8(error_code : LibC::Int, buffer : UCHAR, buffer_length : SIZE) : LibC::Int
-end
+    fun get_error_message = pcre2_get_error_message_8(errorcode : Int, buffer : UInt8*, bufflen : LibC::SizeT) : Int
+  end
+{% end %}

--- a/src/components/routing/src/ext/lib_pcre2.cr
+++ b/src/components/routing/src/ext/lib_pcre2.cr
@@ -9,7 +9,9 @@
   lib LibPCRE2
     alias Int = LibC::Int
 
-    NO_UTF_CHECK = 0x40000000
+    NO_UTF_CHECK   = 0x40000000
+    DOLLAR_ENDONLY = 0x00000010
+    DOTALL         = 0x00000020
 
     enum Error
       NOMATCH = -1
@@ -32,6 +34,7 @@
     fun jit_compile = pcre2_jit_compile_8(code : Code*, options : UInt32) : Int
     fun match_data_create_from_pattern = pcre2_match_data_create_from_pattern_8(code : Code*, gcontext : GeneralContext*) : MatchData*
     fun jit_match = pcre2_jit_match_8(code : Code*, subject : UInt8*, length : LibC::SizeT, startoffset : LibC::SizeT, options : UInt32, match_data : MatchData*, mcontext : MatchContext*) : Int
+    fun match = pcre2_match_8(code : Code*, subject : UInt8*, length : LibC::SizeT, startoffset : LibC::SizeT, options : UInt32, match_data : MatchData*, mcontext : MatchContext*) : Int
     fun get_ovector_pointer = pcre2_get_ovector_pointer_8(match_data : MatchData*) : LibC::SizeT*
 
     fun pattern_info = pcre2_pattern_info_8(code : Code*, what : UInt32, where : Void*) : Int

--- a/src/components/routing/src/ext/regex.cr
+++ b/src/components/routing/src/ext/regex.cr
@@ -56,6 +56,7 @@ class Athena::Routing::FastRegex
   getter source : String
 
   @mark : UInt8* = Pointer(UInt8).null
+  @capture_count : Int32 = 0
 
   def initialize(@source : String)
     # Automatically apply `DOTALL` and `DOLLAR_ENDONLY` options.
@@ -66,9 +67,12 @@ class Athena::Routing::FastRegex
     end
 
     LibPCRE2.jit_compile @code, LibPCRE2::JIT_COMPLETE
-    LibPCRE2.pattern_info @code, LibPCRE2::INFO_CAPTURECOUNT, out @capture_count
 
-    @match_data = LibPCRE2.create_match_data @code, nil
+    capture_count = uninitialized UInt32
+    LibPCRE2.pattern_info @code, LibPCRE2::INFO_CAPTURECOUNT, pointerof(capture_count)
+    @capture_count = capture_count.to_i
+
+    @match_data = LibPCRE2.match_data_create_from_pattern @code, nil
   end
 
   def match(str, pos = 0) : MatchData?
@@ -82,7 +86,7 @@ class Athena::Routing::FastRegex
   def match_at_byte_index(str, byte_index = 0) : MatchData?
     return if byte_index > str.bytesize
     return unless internal_matches(str, byte_index)
-    Athena::Routing::FastRegex::MatchData.new(str, LibPCRE2.get_ovector(@match_data), @capture_count, ((mark = LibPCRE2.get_mark(@match_data)) ? String.new(mark) : nil))
+    Athena::Routing::FastRegex::MatchData.new(str, LibPCRE2.get_ovector_pointer(@match_data), @capture_count, ((mark = LibPCRE2.get_mark(@match_data)) ? String.new(mark) : nil))
   end
 
   def ==(other : FastRegex)
@@ -108,11 +112,15 @@ class Athena::Routing::FastRegex
   end
 
   private def internal_matches(str, byte_index) : Bool
-    unless (match = LibPCRE2.jit_match @code, str, str.bytesize, byte_index, 0, @match_data, nil) > 0
-      return false if match == LibPCRE2::ERROR_NOMATCH
-      bytes = Bytes.new 128
-      LibPCRE2.get_error_message(match, bytes, bytes.size)
-      raise ArgumentError.new String.new bytes
+    match_count = LibPCRE2.jit_match @code, str, str.bytesize, byte_index, LibPCRE2::NO_UTF_CHECK, @match_data, nil
+
+    if match_count < 0
+      case error = LibPCRE2::Error.new(match_count)
+      when .nomatch?
+        return false
+      else
+        raise ::Exception.new("Regex match error: #{error}")
+      end
     end
 
     true


### PR DESCRIPTION
* Can follow up with another PR for additional improvements later on
  * The routing component code still leverages the custom `ART::FastRegex` type on both PCRE and PCRE2. Depending on how https://github.com/crystal-lang/crystal/issues/13152 goes, can maybe look into leveraging the default `Regex` type, and just monkeypatch in the MARK feature. Will probably be the better solution longer term. Requires the two extra modifiers are properly supported.
  * If they end up being properly supported, can remove some of the hacks and leverage the regex engine more fully, e.g. in the case of the traceable url matcher.