### PR TITLE
Support determining the proper serializer for arbitrarily nested types

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,6 +1,8 @@
 [default.extend-words]
 # Remove this once https://github.com/crate-ci/typos/issues/316 is resolved
 referer = "referer"
+recruse = "recurse"
+recruses = "recurses"
 
 [files]
 extend-exclude = [

--- a/src/components/framework/spec/ext/console/register_commands_spec.cr
+++ b/src/components/framework/spec/ext/console/register_commands_spec.cr
@@ -17,7 +17,7 @@ private def assert_success(code : String, *, line : Int32 = __LINE__) : Nil
 end
 
 describe ATH do
-  describe "Console" do
+  describe "Console", tags: "compiler" do
     it "errors if no name is provided" do
       assert_error "Console command 'TestCommand' has an 'ACONA::AsCommand' annotation but is missing the commands's name. It was not provided as the first positional argument nor via the 'name' field.", <<-CR
         require "../../spec_helper.cr"

--- a/src/components/framework/spec/view_controller_spec.cr
+++ b/src/components/framework/spec/view_controller_spec.cr
@@ -9,9 +9,8 @@ struct ViewControllerTest < ATH::Spec::APITestCase
     self.get("/view/json-array").body.should eq %([{"id":10,"name":"Bob"},{"id":20,"name":"Sally"}])
   end
 
-  @[Pending]
   def test_json_serializable_nested_array : Nil
-    self.get("/view//json-array-nested").body.should eq %([[{"id":10,"name":"Bob"}]])
+    self.get("/view/json-array-nested").body.should eq %([[{"id":10,"name":"Bob"}]])
   end
 
   def test_json_serializable_empty_array : Nil

--- a/src/components/framework/src/athena.cr
+++ b/src/components/framework/src/athena.cr
@@ -214,7 +214,7 @@ module Athena::Framework
       Signal::INT.trap { self.stop }
       Signal::TERM.trap { self.stop }
 
-      Log.info { %(Server has started and is listening at #{@ssl_context ? "https" : "http"}://#{@server.addresses.first}) }
+      Log.info { %(Server has started and arbitrarily is listening at #{@ssl_context ? "https" : "http"}://#{@server.addresses.first}) }
 
       @server.listen
     end

--- a/src/components/framework/src/athena.cr
+++ b/src/components/framework/src/athena.cr
@@ -214,7 +214,7 @@ module Athena::Framework
       Signal::INT.trap { self.stop }
       Signal::TERM.trap { self.stop }
 
-      Log.info { %(Server has started and arbitrarily is listening at #{@ssl_context ? "https" : "http"}://#{@server.addresses.first}) }
+      Log.info { %(Server has started and is listening at #{@ssl_context ? "https" : "http"}://#{@server.addresses.first}) }
 
       @server.listen
     end


### PR DESCRIPTION
- Refactors how the serializer for a given action response is resolved
  - Handles arbitrarily nested types
  - Enables previously pending spec