### PR TITLE
Push back scheduled CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'master'
   schedule:
-    - cron: '37 0 * * *' # Nightly at 00:37
+    - cron: '15 1 * * *' # Nightly at 01:15
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
* Gives more time for the Crystal nightly CI job to finish before as it starts at `00:00` and takes ~50min