### PR TITLE
Handle exceptions raised in a test cases `initialize` method

### DIFF
--- a/src/components/spec/CHANGELOG.md
+++ b/src/components/spec/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.4] - 2023-03-19
+
+### Fixed
+
+- Fix exceptions not being counted as errors when raised within the `initialize` method of a test case ([#276](https://github.com/athena-framework/spec/pull/276)) (George Dietrich)
+- Fix a documentation typo in the `TestWith` example ([#269](https://github.com/athena-framework/spec/pull/269)) (George Dietrich)
+
 ## [0.3.3] - 2023-02-18
 
 ### Changed
@@ -42,7 +49,7 @@ _First release a part of the monorepo._
 
 ### Fixed
 
-- Fix `test` helper macro generating invalid method names by replacing all non alphanumeric chars with `_`  ([#12](https://github.com/athena-framework/spec/pull/12)) (George Dietrich
+- Fix `test` helper macro generating invalid method names by replacing all non alphanumeric chars with `_`  ([#12](https://github.com/athena-framework/spec/pull/12)) (George Dietrich)
 
 ## [0.2.5] - 2021-11-03
 
@@ -85,6 +92,7 @@ _First release a part of the monorepo._
 
 _Initial release._
 
+[0.3.4]: https://github.com/athena-framework/spec/releases/tag/v0.3.4
 [0.3.3]: https://github.com/athena-framework/spec/releases/tag/v0.3.3
 [0.3.2]: https://github.com/athena-framework/spec/releases/tag/v0.3.2
 [0.3.1]: https://github.com/athena-framework/spec/releases/tag/v0.3.1

--- a/src/components/spec/shard.yml
+++ b/src/components/spec/shard.yml
@@ -1,6 +1,6 @@
 name: athena-spec
 
-version: 0.3.3
+version: 0.3.4
 
 crystal: ~> 1.4
 

--- a/src/components/spec/spec/compiler_spec.cr
+++ b/src/components/spec/spec/compiler_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
-private def assert_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_error message, <<-CR, line: line
+private def assert_error(message : String, code : String, *, codegen : Bool = false, line : Int32 = __LINE__) : Nil
+  ASPEC::Methods.assert_error message, <<-CR, line: line, codegen: codegen
     require "./spec_helper.cr"
     #{code}
     TestTestCase.run
@@ -61,6 +61,36 @@ describe Athena::Spec do
             end
           CODE
         end
+      end
+    end
+
+    describe "exception during initialize" do
+      it "reports the errors once per test case" do
+        assert_error "oh noes", <<-CODE, codegen: true
+          struct TestTestCase < ASPEC::TestCase
+            def initialize
+              raise "oh noes"
+            end
+
+            def test_one
+              1.should eq 1
+            end
+
+            def test_two
+              2.should eq 2
+            end
+          end
+        CODE
+      end
+
+      it "reports actual failing tests" do
+        assert_error " Expected: 2\n            got: 1", <<-CODE, codegen: true
+          struct TestTestCase < ASPEC::TestCase
+            def test_one
+              1.should eq 2
+            end
+          end
+        CODE
       end
     end
   end

--- a/src/components/spec/src/athena-spec.cr
+++ b/src/components/spec/src/athena-spec.cr
@@ -25,7 +25,7 @@ require "./test_case"
 #
 # If using the component with the framework, also checkout the [manual](/architecture/spec) for some additional information on how it is integrated.
 module Athena::Spec
-  VERSION = "0.3.3"
+  VERSION = "0.3.4"
 
   # Runs all `ASPEC::TestCase`s.
   #


### PR DESCRIPTION
Fixes #275 