### PR TITLE
Bump routing component

### DIFF
--- a/src/components/routing/CHANGELOG.md
+++ b/src/components/routing/CHANGELOG.md
@@ -70,6 +70,7 @@ _First release a part of the monorepo._
 
 _Initial release._
 
+[0.1.6]: https://github.com/athena-framework/routing/releases/tag/v0.1.6
 [0.1.5]: https://github.com/athena-framework/routing/releases/tag/v0.1.5
 [0.1.4]: https://github.com/athena-framework/routing/releases/tag/v0.1.4
 [0.1.3]: https://github.com/athena-framework/routing/releases/tag/v0.1.3

--- a/src/components/routing/CHANGELOG.md
+++ b/src/components/routing/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.6] - 2023-03-26
+
+### Fixed
+
+- Fix compatibility with Crystal `1.8.0-dev` ([#272](https://github.com/athena-framework/athena/pull/272)) (George Dietrich)
+
 ## [0.1.5] - 2023-02-18
 
 ### Changed

--- a/src/components/routing/shard.yml
+++ b/src/components/routing/shard.yml
@@ -1,6 +1,6 @@
 name: athena-routing
 
-version: 0.1.5
+version: 0.1.6
 
 crystal: ~> 1.4
 

--- a/src/components/routing/src/athena-routing.cr
+++ b/src/components/routing/src/athena-routing.cr
@@ -93,7 +93,7 @@ alias ARTA = ART::Annotations
 #
 # TIP: Consider using the annotations provided by the component within `ART::Annotations` to handle route registration.
 module Athena::Routing
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 
   {% if @top_level.has_constant?("Athena") && Athena.has_constant?("Framework") && Athena::Framework.has_constant?("Request") %}
     # Represents the type of the *request* parameter within an `ART::Route::Condition`.

--- a/src/components/spec/CHANGELOG.md
+++ b/src/components/spec/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixed
 
-- Fix exceptions not being counted as errors when raised within the `initialize` method of a test case ([#276](https://github.com/athena-framework/spec/pull/276)) (George Dietrich)
-- Fix a documentation typo in the `TestWith` example ([#269](https://github.com/athena-framework/spec/pull/269)) (George Dietrich)
+- Fix exceptions not being counted as errors when raised within the `initialize` method of a test case ([#276](https://github.com/athena-framework/athena/pull/276)) (George Dietrich)
+- Fix a documentation typo in the `TestWith` example ([#269](https://github.com/athena-framework/athena/pull/269)) (George Dietrich)
 
 ## [0.3.3] - 2023-02-18
 


### PR DESCRIPTION
- Fix broken PR link in `spec` component changelog