### PR TITLE
Handle multi-byte strings in non-streamed responses

### DIFF
--- a/src/components/framework/spec/response_spec.cr
+++ b/src/components/framework/spec/response_spec.cr
@@ -198,6 +198,20 @@ describe ATH::Response do
       response.headers.has_key?("content-length").should be_false
     end
 
+    it "handles multi-byte characters" do
+      request = ATH::Request.new "GET", "/"
+      response = ATH::Response.new str = "Añasco"
+
+      # Emulate sending the data over the wire
+      mem = IO::Memory.new
+      mem.print str
+      mem.rewind
+
+      response.prepare request
+
+      response.headers["content-length"].should eq mem.size.to_s
+    end
+
     it "removes content and preserves content-length for head requests" do
       response = ATH::Response.new "CONTENT"
       request = ATH::Request.new "HEAD", "/"

--- a/src/components/framework/src/response.cr
+++ b/src/components/framework/src/response.cr
@@ -135,7 +135,7 @@ class Athena::Framework::Response
   # ameba:disable Metrics/CyclomaticComplexity
   def prepare(request : ATH::Request) : Nil
     # Set the content length if not already manually set
-    @headers["content-length"] = @content.size unless @headers.has_key? "content-length"
+    @headers["content-length"] = @content.bytesize unless @headers.has_key? "content-length"
 
     if @status.informational? || @status.no_content? || @status.not_modified?
       self.content = nil


### PR DESCRIPTION
Fixes #287

Previously it was using `String#size` which represents the number of characters in the string, rather than the number of bytes which `content-length` expects. This previously hasn't been discovered due to there not being a difference between `#size` and `#bytesize` for the more common characters.