### PR TITLE
Single element nested annotation array

### DIFF
--- a/src/components/validator/spec/constraints/composite_spec.cr
+++ b/src/components/validator/spec/constraints/composite_spec.cr
@@ -86,4 +86,13 @@ struct CompositeTest < ASPEC::TestCase
       ] of AVD::Constraint)
     end
   end
+
+  def test_single_element_inferred_type_array : Nil
+    constraint = ConcreteComposite.new([
+      AVD::Constraints::Positive.new,
+    ])
+
+    constraint.constraints.size.should eq 1
+    constraint.groups.should eq ["default"]
+  end
 end

--- a/src/components/validator/spec/validatable_spec.cr
+++ b/src/components/validator/spec/validatable_spec.cr
@@ -49,6 +49,15 @@ private class ComparisonConstrained
   getter age : Int32 = 0
 end
 
+private class NestedSingleAnnotationArray
+  include AVD::Validatable
+
+  @[Assert::All([
+    @[Assert::Positive(message: "A example value cannot be negative")],
+  ])]
+  getter values : Array(Int32) = [] of Int32
+end
+
 describe AVD::Validatable do
   describe ".load_metadata" do
     it "should manually add constraints to the metadata object" do
@@ -83,6 +92,14 @@ describe AVD::Validatable do
 
     it "does not duplicate property metadata for generic module constraints" do
       ComparisonConstrained.validation_class_metadata.property_metadata("age").first.constraints.size.should eq 1
+    end
+
+    it "handles a nested array of annotations with only a single element" do
+      constraints = NestedSingleAnnotationArray.validation_class_metadata.property_metadata("values").first.constraints
+      constraints.size.should eq 1
+
+      all_constraint = constraints[0].should be_a AVD::Constraints::All
+      all_constraint.constraints.size.should eq 1
     end
   end
 end

--- a/src/components/validator/spec/validatable_spec.cr
+++ b/src/components/validator/spec/validatable_spec.cr
@@ -49,15 +49,6 @@ private class ComparisonConstrained
   getter age : Int32 = 0
 end
 
-private class NestedSingleAnnotationArray
-  include AVD::Validatable
-
-  @[Assert::All([
-    @[Assert::Positive(message: "A example value cannot be negative")],
-  ])]
-  getter values : Array(Int32) = [] of Int32
-end
-
 describe AVD::Validatable do
   describe ".load_metadata" do
     it "should manually add constraints to the metadata object" do
@@ -92,14 +83,6 @@ describe AVD::Validatable do
 
     it "does not duplicate property metadata for generic module constraints" do
       ComparisonConstrained.validation_class_metadata.property_metadata("age").first.constraints.size.should eq 1
-    end
-
-    it "handles a nested array of annotations with only a single element" do
-      constraints = NestedSingleAnnotationArray.validation_class_metadata.property_metadata("values").first.constraints
-      constraints.size.should eq 1
-
-      all_constraint = constraints[0].should be_a AVD::Constraints::All
-      all_constraint.constraints.size.should eq 1
     end
   end
 end

--- a/src/components/validator/src/constraints/composite.cr
+++ b/src/components/validator/src/constraints/composite.cr
@@ -26,8 +26,15 @@ abstract class Athena::Validator::Constraints::Composite < Athena::Validator::Co
     super message, groups, payload
 
     constraints = case constraints
-                  when AVD::Constraint        then {0 => constraints} of String | Int32 => AVD::Constraint
-                  when Array(AVD::Constraint) then constraints.each_with_index.to_h { |v, k| {k.as(Int32 | String), v} }
+                  when AVD::Constraint then {0 => constraints} of String | Int32 => AVD::Constraint
+                  when Array
+                    hash = Hash(String | Int32, AVD::Constraint).new initial_capacity: constraints.size
+
+                    constraints.each_with_index do |v, k|
+                      hash[k] = v
+                    end
+
+                    hash
                   else
                     constraints.transform_keys(&.as(String | Int32))
                   end


### PR DESCRIPTION
* Fixes a compiler error when using a composite constraint with a single member with no `of AVD::Constraint`