### PR TITLE
Console tab-completion

### DIFF
--- a/src/components/console/console
+++ b/src/components/console/console
@@ -1,5 +1,0 @@
-#!/usr/bin/env crystal
-
-require "athena-console"
-
-ACON::Application.new("Athena").run

--- a/src/components/console/console
+++ b/src/components/console/console
@@ -1,0 +1,5 @@
+#!/usr/bin/env crystal
+
+require "athena-console"
+
+ACON::Application.new("Athena").run

--- a/src/components/console/spec/application_spec.cr
+++ b/src/components/console/spec/application_spec.cr
@@ -40,6 +40,7 @@ struct ApplicationTest < ASPEC::TestCase
     app = ACON::Application.new "foo"
     commands = app.commands
 
+    commands.keys.should eq ["help", "list", "_complete"]
     commands["help"].should be_a ACON::Commands::Help
     commands["list"].should be_a ACON::Commands::List
 

--- a/src/components/console/spec/application_spec.cr
+++ b/src/components/console/spec/application_spec.cr
@@ -40,7 +40,7 @@ struct ApplicationTest < ASPEC::TestCase
     app = ACON::Application.new "foo"
     commands = app.commands
 
-    commands.keys.should eq ["help", "list", "_complete"]
+    commands.keys.should eq ["help", "list", "completion", "_complete"]
     commands["help"].should be_a ACON::Commands::Help
     commands["list"].should be_a ACON::Commands::List
 

--- a/src/components/console/spec/command_spec.cr
+++ b/src/components/console/spec/command_spec.cr
@@ -87,16 +87,55 @@ describe ACON::Command do
     command.definition.has_option?("bar").should be_true
   end
 
-  it "#argument" do
-    command = TestCommand.new
-    command.argument "foo"
-    command.definition.has_argument?("foo").should be_true
+  describe "#argument" do
+    it "basic form" do
+      command = TestCommand.new
+      command.argument "foo"
+      command.definition.has_argument?("foo").should be_true
+    end
+    describe "suggested values" do
+      it "array" do
+        command = TestCommand.new
+        command.argument "foo", suggested_values: {"a", "b", "c"}
+        command.definition.has_argument?("foo").should be_true
+        command.definition.argument("foo").has_completion?.should be_true
+      end
+
+      it "block" do
+        command = TestCommand.new
+        command.argument "foo" do
+          ["a", "b"]
+        end
+        command.definition.has_argument?("foo").should be_true
+        command.definition.argument("foo").has_completion?.should be_true
+      end
+    end
   end
 
-  it "#option" do
-    command = TestCommand.new
-    command.option "bar"
-    command.definition.has_option?("bar").should be_true
+  describe "#option" do
+    it "basic form" do
+      command = TestCommand.new
+      command.option "bar"
+      command.definition.has_option?("bar").should be_true
+    end
+
+    describe "suggested values" do
+      it "array" do
+        command = TestCommand.new
+        command.option "foo", value_mode: :required, suggested_values: {"a", "b", "c"}
+        command.definition.has_option?("foo").should be_true
+        command.definition.option("foo").has_completion?.should be_true
+      end
+
+      it "block" do
+        command = TestCommand.new
+        command.option "foo", value_mode: :required do
+          ["a", "b"]
+        end
+        command.definition.has_option?("foo").should be_true
+        command.definition.option("foo").has_completion?.should be_true
+      end
+    end
   end
 
   describe "#processed_help" do

--- a/src/components/console/spec/commands/complete_spec.cr
+++ b/src/components/console/spec/commands/complete_spec.cr
@@ -96,8 +96,8 @@ struct CompleteCommandTest < ASPEC::TestCase
 
   def provide_complete_command_name_inputs : Hash
     {
-      "empty"                  => {[] of String, ["help", "list", "hello", "ahoy"]},
-      "partial"                => {["he"], ["help", "list", "hello", "ahoy"]},
+      "empty"                  => {[] of String, ["help", "list", "completion", "hello", "ahoy"]},
+      "partial"                => {["he"], ["help", "list", "completion", "hello", "ahoy"]},
       "complete shortcut name" => {["hell"], ["hello", "ahoy"]},
       "complete alias"         => {["ah"], ["hello", "ahoy"]},
     }

--- a/src/components/console/spec/commands/complete_spec.cr
+++ b/src/components/console/spec/commands/complete_spec.cr
@@ -47,7 +47,7 @@ struct CompleteCommandTest < ASPEC::TestCase
   end
 
   def test_additional_shell_support : Nil
-    @command = ACON::Commands::Complete.new({"supported" => ACON::Completion::Output::Bash} of String => ACON::Completion::OutputInterface.class)
+    @command = ACON::Commands::Complete.new({"supported" => ACON::Completion::Output::Bash} of String => ACON::Completion::Output::Interface.class)
     @command.application = @application
     @tester = ACON::Spec::CommandTester.new @command
 

--- a/src/components/console/spec/commands/complete_spec.cr
+++ b/src/components/console/spec/commands/complete_spec.cr
@@ -97,9 +97,9 @@ struct CompleteCommandTest < ASPEC::TestCase
   def provide_complete_command_name_inputs : Hash
     {
       "empty"                  => {[] of String, ["help", "list", "hello", "ahoy"]},
-      "partial"                => {["he"] of String, ["help", "list", "hello", "ahoy"]},
-      "complete shortcut name" => {["hell"] of String, ["hello", "ahoy"]},
-      "complete alias"         => {["ah"] of String, ["hello", "ahoy"]},
+      "partial"                => {["he"], ["help", "list", "hello", "ahoy"]},
+      "complete shortcut name" => {["hell"], ["hello", "ahoy"]},
+      "complete alias"         => {["ah"], ["hello", "ahoy"]},
     }
   end
 

--- a/src/components/console/spec/commands/complete_spec.cr
+++ b/src/components/console/spec/commands/complete_spec.cr
@@ -1,12 +1,9 @@
 require "../spec_helper"
 
-# @[ACONA::AsCommand("hello", description: "Hello test command")]
+@[ACONA::AsCommand("hello|ahoy", description: "Hello test command")]
 private class HelloCommand < ACON::Command
   protected def configure : Nil
     self
-      .name("hello")
-      .description("Hello test command")
-      .aliases("ahoy")
       .argument("name", :required)
   end
 
@@ -21,7 +18,6 @@ private class HelloCommand < ACON::Command
   end
 end
 
-# @[ASPEC::TestCase::Focus]
 struct CompleteCommandTest < ASPEC::TestCase
   @command : ACON::Commands::Complete
   @application : ACON::Application

--- a/src/components/console/spec/commands/complete_spec.cr
+++ b/src/components/console/spec/commands/complete_spec.cr
@@ -1,0 +1,128 @@
+require "../spec_helper"
+
+# @[ACONA::AsCommand("hello", description: "Hello test command")]
+private class HelloCommand < ACON::Command
+  protected def configure : Nil
+    self
+      .name("hello")
+      .description("Hello test command")
+      .aliases("ahoy")
+      .argument("name", :required)
+  end
+
+  def complete(input : ACON::Completion::Input, suggestions : ACON::Completion::Suggestions) : Nil
+    if input.must_suggest_argument_values_for? "name"
+      suggestions.suggest_values "Athena", "Crystal", "Ruby"
+    end
+  end
+
+  protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
+    ACON::Command::Status::SUCCESS
+  end
+end
+
+# @[ASPEC::TestCase::Focus]
+struct CompleteCommandTest < ASPEC::TestCase
+  @command : ACON::Commands::Complete
+  @application : ACON::Application
+  @tester : ACON::Spec::CommandTester
+
+  def initialize
+    @command = ACON::Commands::Complete.new
+
+    @application = ACON::Application.new "TEST"
+    @application.add HelloCommand.new
+
+    @command.application = @application
+
+    @tester = ACON::Spec::CommandTester.new @command
+  end
+
+  def test_required_shell_option : Nil
+    expect_raises ACON::Exceptions::RuntimeError, "The '--shell' option must be set." do
+      self.execute
+    end
+  end
+
+  def test_unsupported_shell_option : Nil
+    expect_raises ACON::Exceptions::RuntimeError, "Shell completion is not supported for your shell: 'unsupported' (supported: 'bash')." do
+      self.execute({"--shell" => "unsupported"})
+    end
+  end
+
+  def test_additional_shell_support : Nil
+    @command = ACON::Commands::Complete.new({"supported" => ACON::Completion::Output::Bash} of String => ACON::Completion::OutputInterface.class)
+    @command.application = @application
+    @tester = ACON::Spec::CommandTester.new @command
+
+    self.execute({"--shell" => "supported", "--current" => "0", "--input" => [] of String})
+
+    # Default shell should still be supported
+    self.execute({"--shell" => "bash", "--current" => "0", "--input" => [] of String})
+  end
+
+  @[DataProvider("input_and_current_option_provider")]
+  def test_input_and_current_option_validation(input : Hash(String, _), exception_message : String?) : Nil
+    if exception_message
+      expect_raises ::Exception, exception_message do
+        self.execute input.merge!({"--shell" => "bash"})
+      end
+
+      return
+    end
+
+    self.execute input.merge!({"--shell" => "bash"})
+
+    @tester.assert_command_is_successful
+  end
+
+  def input_and_current_option_provider : Tuple
+    {
+      {Hash(String, String).new, "The '--current' option must be set and it must be an integer"},
+      { {"--current" => "a"}, "The '--current' option must be set and it must be an integer" },
+      { {"--current" => "0", "--input" => [] of String}, nil },
+      { {"--current" => "2", "--input" => [] of String}, "Current index is invalid, it must be the number of input tokens." },
+      { {"--current" => "0", "--input" => [] of String}, nil },
+      { {"--current" => "1", "--input" => ["foo:bar"] of String}, nil },
+      { {"--current" => "2", "--input" => ["foo:bar", "bar"] of String}, nil },
+    }
+  end
+
+  @[DataProvider("provide_complete_command_name_inputs")]
+  def test_completion_command_name(input : Array(String), suggestions : Array(String)) : Nil
+    self.execute({"--current" => "0", "--input" => input})
+    @tester.display.should eq "#{suggestions.join("\n")}#{ACON::System::EOL}"
+  end
+
+  def provide_complete_command_name_inputs : Hash
+    {
+      "empty"                  => {[] of String, ["help", "list", "hello", "ahoy"]},
+      "partial"                => {["he"] of String, ["help", "list", "hello", "ahoy"]},
+      "complete shortcut name" => {["hell"] of String, ["hello", "ahoy"]},
+      "complete alias"         => {["ah"] of String, ["hello", "ahoy"]},
+    }
+  end
+
+  @[DataProvider("provide_input_definition_inputs")]
+  def test_completion_command_input_definitions(input : Array(String), suggestions : Array(String)) : Nil
+    self.execute({"--current" => "1", "--input" => input})
+    @tester.display.should eq "#{suggestions.join("\n")}#{ACON::System::EOL}"
+  end
+
+  def provide_input_definition_inputs : Hash
+    {
+      "definition"         => {["hello", "-"], ["--help", "--quiet", "--verbose", "--version", "--ansi", "--no-ansi", "--no-interaction"]},
+      "custom"             => {["hello"], ["Athena", "Crystal", "Ruby"]},
+      "aliased definition" => {["ahoy", "-"], ["--help", "--quiet", "--verbose", "--version", "--ansi", "--no-ansi", "--no-interaction"]},
+      "aliased custom"     => {["ahoy"], ["Athena", "Crystal", "Ruby"]},
+    }
+  end
+
+  private def execute(input : Hash(String, _) = {} of String => String) : Nil
+    # Run in verbose mode to assert exceptions
+    @tester.execute(
+      (!input.empty? ? {"--shell" => "bash", "--api-version" => ACON::Commands::Complete::API_VERSION.to_s}.merge(input) : input),
+      verbosity: ACON::Output::Verbosity::DEBUG
+    )
+  end
+end

--- a/src/components/console/spec/commands/list_spec.cr
+++ b/src/components/console/spec/commands/list_spec.cr
@@ -15,7 +15,7 @@ describe ACON::Commands::List do
       tester = ACON::Spec::CommandTester.new app.get("list")
       tester.execute command: "list", "--raw": true
 
-      tester.display.should eq "help   Display help for a command\nlist   List commands\n"
+      tester.display.should eq "completion   Dump the shell completion script\nhelp         Display help for a command\nlist         List commands\n"
     end
 
     it "with namespace argument" do
@@ -50,10 +50,11 @@ describe ACON::Commands::List do
         -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
       Available commands:
-        help      Display help for a command
-        list      List commands
+        completion  Dump the shell completion script
+        help        Display help for a command
+        list        List commands
        0foo
-        0foo:bar  0foo:bar command\n
+        0foo:bar    0foo:bar command\n
       OUTPUT
     end
 
@@ -64,7 +65,7 @@ describe ACON::Commands::List do
       tester = ACON::Spec::CommandTester.new app.get("list")
       tester.execute command: "list", "--raw": true
 
-      tester.display.should eq "help       Display help for a command\nlist       List commands\n0foo:bar   0foo:bar command\n"
+      tester.display.should eq "completion   Dump the shell completion script\nhelp         Display help for a command\nlist         List commands\n0foo:bar     0foo:bar command\n"
     end
   end
 end

--- a/src/components/console/spec/completion/input_spec.cr
+++ b/src/components/console/spec/completion/input_spec.cr
@@ -1,0 +1,34 @@
+require "../spec_helper"
+
+private alias Input = ACON::Completion::Input
+
+@[ASPEC::TestCase::Focus]
+struct CompletionInputTest < ASPEC::TestCase
+  @[DataProvider("bind_data_provider")]
+  def test_bind(input : Input, expected_type : Input::Type, expected_name : String?, expected_value : String) : Nil
+    definition = ACON::Input::Definition.new(
+      ACON::Input::Option.new("with-required-value", "r", :required),
+      ACON::Input::Option.new("with-optional-value", "o", :optional),
+      ACON::Input::Option.new("without-value", "n", :none),
+      ACON::Input::Argument.new("required-arg", :required),
+      ACON::Input::Argument.new("optional-arg", :optional),
+    )
+
+    input.bind definition
+
+    input.completion_type.should eq expected_type
+    input.completion_name.should eq expected_name
+    input.completion_value.should eq expected_value
+  end
+
+  def bind_data_provider : Hash
+    {
+      # Option names
+      "optname minimal input" => {Input.from_tokens(["bin/console", "-"], 1), Input::Type::OPTION_NAME, nil, "-"},
+      "optname partial"       => {Input.from_tokens(["bin/console", "--with"], 1), Input::Type::OPTION_NAME, nil, "--with"},
+
+      # Option values
+      "optvalue short" => {Input.from_tokens(["bin/console", "-r"], 1), Input::Type::OPTION_VALUE, "with-required-value", ""},
+    }
+  end
+end

--- a/src/components/console/spec/completion/input_spec.cr
+++ b/src/components/console/spec/completion/input_spec.cr
@@ -44,7 +44,15 @@ struct CompletionInputTest < ASPEC::TestCase
       "optvalue long space optional" => {Input.from_tokens(["--with-optional-value"], 1), Input::Type::OPTION_VALUE, "with-optional-value", ""},
 
       # Arguments
-      "arg minimal input" => {Input.from_tokens([] of String, 0), Input::Type::ARGUMENT_VALUE, "required-arg", ""},
+      "arg minimal input"         => {Input.from_tokens([] of String, 0), Input::Type::ARGUMENT_VALUE, "required-arg", ""},
+      "arg optional"              => {Input.from_tokens(["athena"], 1), Input::Type::ARGUMENT_VALUE, "optional-arg", ""},
+      "arg partial"               => {Input.from_tokens(["ath"], 0), Input::Type::ARGUMENT_VALUE, "required-arg", "ath"},
+      "arg optional partial"      => {Input.from_tokens(["athena", "cry"], 1), Input::Type::ARGUMENT_VALUE, "optional-arg", "cry"},
+      "arg after option"          => {Input.from_tokens(["--without-value"], 1), Input::Type::ARGUMENT_VALUE, "required-arg", ""},
+      "arg after optional option" => {Input.from_tokens(["--with-optional-value", "--"], 2), Input::Type::ARGUMENT_VALUE, "required-arg", ""},
+
+      # End of definition
+      "end" => {Input.from_tokens(["athena", "crystal"], 2), Input::Type::NONE, nil, ""},
     }
   end
 end

--- a/src/components/console/spec/completion/input_spec.cr
+++ b/src/components/console/spec/completion/input_spec.cr
@@ -2,7 +2,6 @@ require "../spec_helper"
 
 private alias Input = ACON::Completion::Input
 
-@[ASPEC::TestCase::Focus]
 struct CompletionInputTest < ASPEC::TestCase
   @[DataProvider("bind_data_provider")]
   def test_bind(input : Input, expected_type : Input::Type, expected_name : String?, expected_value : String) : Nil

--- a/src/components/console/spec/completion/input_spec.cr
+++ b/src/components/console/spec/completion/input_spec.cr
@@ -24,11 +24,27 @@ struct CompletionInputTest < ASPEC::TestCase
   def bind_data_provider : Hash
     {
       # Option names
-      "optname minimal input" => {Input.from_tokens(["bin/console", "-"], 1), Input::Type::OPTION_NAME, nil, "-"},
-      "optname partial"       => {Input.from_tokens(["bin/console", "--with"], 1), Input::Type::OPTION_NAME, nil, "--with"},
+      "optname minimal input" => {Input.from_tokens(["-"], 0), Input::Type::OPTION_NAME, nil, "-"},
+      "optname partial"       => {Input.from_tokens(["--with"], 0), Input::Type::OPTION_NAME, nil, "--with"},
 
       # Option values
-      "optvalue short" => {Input.from_tokens(["bin/console", "-r"], 1), Input::Type::OPTION_VALUE, "with-required-value", ""},
+      "optvalue short"                => {Input.from_tokens(["-r"], 0), Input::Type::OPTION_VALUE, "with-required-value", ""},
+      "optvalue short partial"        => {Input.from_tokens(["-rathe"], 0), Input::Type::OPTION_VALUE, "with-required-value", "athe"},
+      "optvalue short space"          => {Input.from_tokens(["-r"], 1), Input::Type::OPTION_VALUE, "with-required-value", ""},
+      "optvalue short space partial"  => {Input.from_tokens(["-r", "athe"], 1), Input::Type::OPTION_VALUE, "with-required-value", "athe"},
+      "optvalue short before arg"     => {Input.from_tokens(["-r", "athena"], 0), Input::Type::OPTION_VALUE, "with-required-value", ""},
+      "optvalue short optional"       => {Input.from_tokens(["-o"], 0), Input::Type::OPTION_VALUE, "with-optional-value", ""},
+      "optvalue short space optional" => {Input.from_tokens(["-o"], 1), Input::Type::OPTION_VALUE, "with-optional-value", ""},
+
+      "optvalue long"                => {Input.from_tokens(["--with-required-value="], 0), Input::Type::OPTION_VALUE, "with-required-value", ""},
+      "optvalue long partial"        => {Input.from_tokens(["--with-required-value=ath"], 0), Input::Type::OPTION_VALUE, "with-required-value", "ath"},
+      "optvalue long space"          => {Input.from_tokens(["--with-required-value"], 1), Input::Type::OPTION_VALUE, "with-required-value", ""},
+      "optvalue long space partial"  => {Input.from_tokens(["--with-required-value", "ath"], 1), Input::Type::OPTION_VALUE, "with-required-value", "ath"},
+      "optvalue long optional"       => {Input.from_tokens(["--with-optional-value="], 0), Input::Type::OPTION_VALUE, "with-optional-value", ""},
+      "optvalue long space optional" => {Input.from_tokens(["--with-optional-value"], 1), Input::Type::OPTION_VALUE, "with-optional-value", ""},
+
+      # Arguments
+      "arg minimal input" => {Input.from_tokens([] of String, 0), Input::Type::ARGUMENT_VALUE, "required-arg", ""},
     }
   end
 end

--- a/src/components/console/spec/fixtures/text/application_1.txt
+++ b/src/components/console/spec/fixtures/text/application_1.txt
@@ -12,5 +12,6 @@ foo <info>0.1.0</info>
   <info>-v|vv|vvv, --verbose</info>  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 <comment>Available commands:</comment>
-  <info>help</info>  Display help for a command
-  <info>list</info>  List commands
+  <info>completion</info>  Dump the shell completion script
+  <info>help</info>        Display help for a command
+  <info>list</info>        List commands

--- a/src/components/console/spec/fixtures/text/application_2.txt
+++ b/src/components/console/spec/fixtures/text/application_2.txt
@@ -12,6 +12,7 @@ My Athena application <info>1.0.0</info>
   <info>-v|vv|vvv, --verbose</info>  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 <comment>Available commands:</comment>
+  <info>completion</info>           Dump the shell completion script
   <info>help</info>                 Display help for a command
   <info>list</info>                 List commands
  <comment>descriptor</comment>

--- a/src/components/console/spec/fixtures/text/application_run1.txt
+++ b/src/components/console/spec/fixtures/text/application_run1.txt
@@ -12,5 +12,6 @@ Options:
   -v\|vv\|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 Available commands:
-  help  Display help for a command
-  list  List commands
+  completion  Dump the shell completion script
+  help        Display help for a command
+  list        List commands

--- a/src/components/console/spec/input/argument_spec.cr
+++ b/src/components/console/spec/input/argument_spec.cr
@@ -54,7 +54,7 @@ describe ACON::Input::Argument do
 
       argument.has_completion?.should be_true
 
-      argument.complete ACON::Completion::Input.new([] of String, 1), suggestions
+      argument.complete ACON::Completion::Input.new, suggestions
 
       suggestions.suggested_values.map(&.value).should eq ["foo", "bar"]
     end
@@ -68,7 +68,7 @@ describe ACON::Input::Argument do
 
       argument.has_completion?.should be_true
 
-      argument.complete ACON::Completion::Input.new([] of String, 1), suggestions
+      argument.complete ACON::Completion::Input.new, suggestions
 
       suggestions.suggested_values.map(&.value).should eq ["foo", "bar"]
     end

--- a/src/components/console/spec/input/argument_spec.cr
+++ b/src/components/console/spec/input/argument_spec.cr
@@ -44,4 +44,33 @@ describe ACON::Input::Argument do
       end
     end
   end
+
+  describe "#complete" do
+    it "with an array" do
+      values = ["foo", "bar"]
+      suggestions = ACON::Completion::Suggestions.new
+
+      argument = ACON::Input::Argument.new "foo", suggested_values: values
+
+      argument.has_completion?.should be_true
+
+      argument.complete ACON::Completion::Input.new([] of String, 1), suggestions
+
+      suggestions.suggested_values.map(&.value).should eq ["foo", "bar"]
+    end
+
+    it "with an block" do
+      values = ["foo", "bar"]
+      suggestions = ACON::Completion::Suggestions.new
+      callback = Proc(ACON::Completion::Input, Array(String)).new { values }
+
+      argument = ACON::Input::Argument.new "foo", suggested_values: callback
+
+      argument.has_completion?.should be_true
+
+      argument.complete ACON::Completion::Input.new([] of String, 1), suggestions
+
+      suggestions.suggested_values.map(&.value).should eq ["foo", "bar"]
+    end
+  end
 end

--- a/src/components/console/spec/input/option_spec.cr
+++ b/src/components/console/spec/input/option_spec.cr
@@ -98,4 +98,39 @@ describe ACON::Input::Option do
       end
     end
   end
+
+  describe "#complete" do
+    it "with an array" do
+      values = ["foo", "bar"]
+      suggestions = ACON::Completion::Suggestions.new
+
+      argument = ACON::Input::Option.new "foo", value_mode: :required, suggested_values: values
+
+      argument.has_completion?.should be_true
+
+      argument.complete ACON::Completion::Input.new([] of String, 1), suggestions
+
+      suggestions.suggested_values.map(&.value).should eq ["foo", "bar"]
+    end
+
+    it "with an block" do
+      values = ["foo", "bar"]
+      suggestions = ACON::Completion::Suggestions.new
+      callback = Proc(ACON::Completion::Input, Array(String)).new { values }
+
+      argument = ACON::Input::Option.new "foo", value_mode: :required, suggested_values: callback
+
+      argument.has_completion?.should be_true
+
+      argument.complete ACON::Completion::Input.new([] of String, 1), suggestions
+
+      suggestions.suggested_values.map(&.value).should eq ["foo", "bar"]
+    end
+
+    it "when option accepts no value" do
+      expect_raises ACON::Exceptions::InvalidArgument, "Cannot set suggested values if the option does not accept a value." do
+        argument = ACON::Input::Option.new "foo", suggested_values: ["foo"]
+      end
+    end
+  end
 end

--- a/src/components/console/spec/input/option_spec.cr
+++ b/src/components/console/spec/input/option_spec.cr
@@ -108,7 +108,7 @@ describe ACON::Input::Option do
 
       argument.has_completion?.should be_true
 
-      argument.complete ACON::Completion::Input.new([] of String, 1), suggestions
+      argument.complete ACON::Completion::Input.new, suggestions
 
       suggestions.suggested_values.map(&.value).should eq ["foo", "bar"]
     end
@@ -122,7 +122,7 @@ describe ACON::Input::Option do
 
       argument.has_completion?.should be_true
 
-      argument.complete ACON::Completion::Input.new([] of String, 1), suggestions
+      argument.complete ACON::Completion::Input.new, suggestions
 
       suggestions.suggested_values.map(&.value).should eq ["foo", "bar"]
     end

--- a/src/components/console/spec/input/option_spec.cr
+++ b/src/components/console/spec/input/option_spec.cr
@@ -129,7 +129,7 @@ describe ACON::Input::Option do
 
     it "when option accepts no value" do
       expect_raises ACON::Exceptions::InvalidArgument, "Cannot set suggested values if the option does not accept a value." do
-        argument = ACON::Input::Option.new "foo", suggested_values: ["foo"]
+        ACON::Input::Option.new "foo", suggested_values: ["foo"]
       end
     end
   end

--- a/src/components/console/src/application.cr
+++ b/src/components/console/src/application.cr
@@ -703,6 +703,7 @@ class Athena::Console::Application
       Athena::Console::Commands::Help.new,
       Athena::Console::Commands::List.new,
       Athena::Console::Commands::Complete.new,
+      Athena::Console::Commands::DumpCompletion.new,
     ]
   end
 

--- a/src/components/console/src/application.cr
+++ b/src/components/console/src/application.cr
@@ -296,6 +296,28 @@ class Athena::Console::Application
   def definition=(@definition : ACON::Input::Definition)
   end
 
+  def complete(completion_input : ACON::Completion::Input, suggestions : ACON::Completion::Suggestions) : Nil
+    if completion_input.completion_type.argument_value? && "command" == completion_input.completion_name
+      @commands.each do |name, command|
+        next if command.hidden? || command.name != name
+
+        suggestions.suggest_value name, command.description
+
+        command.aliases.each do |a|
+          suggestions.suggest_value a, command.description
+        end
+      end
+
+      return
+    end
+
+    if completion_input.completion_type.option_name?
+      suggestions.suggest_options self.definition.options
+
+      return
+    end
+  end
+
   # Yields each command within `self`, optionally only yields those within the provided *namespace*.
   def each_command(namespace : String? = nil, & : ACON::Command -> Nil) : Nil
     self.commands(namespace).each_value { |c| yield c }

--- a/src/components/console/src/application.cr
+++ b/src/components/console/src/application.cr
@@ -680,6 +680,7 @@ class Athena::Console::Application
     [
       Athena::Console::Commands::List.new,
       Athena::Console::Commands::Help.new,
+      Athena::Console::Commands::Complete.new,
     ]
   end
 

--- a/src/components/console/src/application.cr
+++ b/src/components/console/src/application.cr
@@ -296,8 +296,11 @@ class Athena::Console::Application
   def definition=(@definition : ACON::Input::Definition)
   end
 
-  def complete(completion_input : ACON::Completion::Input, suggestions : ACON::Completion::Suggestions) : Nil
-    if completion_input.completion_type.argument_value? && "command" == completion_input.completion_name
+  # Determines what values should be added to the possible *suggestions* based on the provided *input*.
+  #
+  # By default this handles completing commands and options, but can be overridden if needed.
+  def complete(input : ACON::Completion::Input, suggestions : ACON::Completion::Suggestions) : Nil
+    if input.completion_type.argument_value? && "command" == input.completion_name
       @commands.each do |name, command|
         next if command.hidden? || command.name != name
 
@@ -311,7 +314,7 @@ class Athena::Console::Application
       return
     end
 
-    if completion_input.completion_type.option_name?
+    if input.completion_type.option_name?
       suggestions.suggest_options self.definition.options
 
       return

--- a/src/components/console/src/application.cr
+++ b/src/components/console/src/application.cr
@@ -700,8 +700,8 @@ class Athena::Console::Application
 
   protected def default_commands : Array(ACON::Command)
     [
-      Athena::Console::Commands::List.new,
       Athena::Console::Commands::Help.new,
+      Athena::Console::Commands::List.new,
       Athena::Console::Commands::Complete.new,
     ]
   end

--- a/src/components/console/src/application.cr
+++ b/src/components/console/src/application.cr
@@ -702,8 +702,8 @@ class Athena::Console::Application
     [
       Athena::Console::Commands::Help.new,
       Athena::Console::Commands::List.new,
-      Athena::Console::Commands::Complete.new,
       Athena::Console::Commands::DumpCompletion.new,
+      Athena::Console::Commands::Complete.new,
     ]
   end
 

--- a/src/components/console/src/athena-console.cr
+++ b/src/components/console/src/athena-console.cr
@@ -108,4 +108,15 @@ module Athena::Console
 
   # Contains types related to lazily loading commands.
   module Loader; end
+
+  # :nodoc:
+  #
+  # TODO: Remove this in favor of `::System::EOL` when/if https://github.com/crystal-lang/crystal/pull/11303 is released.
+  module System
+    EOL = {% if flag? :windows %}
+            "\r\n"
+          {% else %}
+            "\n"
+          {% end %}
+  end
 end

--- a/src/components/console/src/athena-console.cr
+++ b/src/components/console/src/athena-console.cr
@@ -1,3 +1,5 @@
+require "ecr"
+
 require "./annotations"
 require "./application"
 require "./command"

--- a/src/components/console/src/athena-console.cr
+++ b/src/components/console/src/athena-console.cr
@@ -34,6 +34,7 @@ alias ACONA = ACON::Annotations
 # * Reusable output [styles][Athena::Console::Formatter::OutputStyleInterface]
 # * High level reusable formatting [styles][Athena::Console::Style::Interface]
 # * [Testing abstractions][Athena::Console::Spec]
+# * [Tab Completion][Athena::Console::Input::Interface--argumentoption-value-completion]
 #
 # The console component best works in conjunction with a dedicated Crystal file that'll be used as the entry point.
 # Ideally this file is compiled into a dedicated binary for use in production, but is invoked directly while developing.
@@ -96,6 +97,20 @@ alias ACONA = ACON::Annotations
 #
 # TIP: If using this component with the `Athena::DependencyInjection` component, `ACON::Command` that have the `ADI::Register` annotation will automatically
 # be registered as commands when using the `ADI::Console::Application` type.
+#
+# ### Console Completion
+#
+# Athena's completion script can be installed to provide auto tab completion out of the box for command and option names, and values in some cases.
+# The script currently supports the shells: `bash` (also requires the `bash-completion` package).
+# Run `./console completion --help` for installation instructions based on your shell.
+#
+# NOTE: The completion script only needs to be installed _once_, but is specific to the binary used to generate it.
+# E.g. `./console completion` would be scoped to the `console` binary, while `./myapp completion` would be scoped to `myapp`.
+#
+# Once installed, restart your terminal, and you should be good to go!
+#
+# WARNING: The completion script may only be used with real built binaries, not temporary ones such as `crystal run src/console.cr -- completion`.
+# This is to ensure the performance of the script is sufficient, and to avoid any issues with the naming of the temporary binary.
 module Athena::Console
   VERSION = "0.3.2"
 
@@ -104,6 +119,9 @@ module Athena::Console
 
   # Includes the commands that come bundled with `Athena::Console`.
   module Commands; end
+
+  # Includes types related to Athena's [tab completion][Athena::Console::Input::Interface--argumentoption-value-completion] features.
+  module Completion; end
 
   # Contains all custom exceptions defined within `Athena::Console`.
   module Exceptions; end

--- a/src/components/console/src/athena-console.cr
+++ b/src/components/console/src/athena-console.cr
@@ -5,6 +5,7 @@ require "./cursor"
 require "./terminal"
 
 require "./commands/*"
+require "./completion/**"
 require "./descriptor/*"
 require "./exceptions/*"
 require "./formatter/*"

--- a/src/components/console/src/command.cr
+++ b/src/components/console/src/command.cr
@@ -288,6 +288,8 @@ abstract class Athena::Console::Command
 
   # Adds an `ACON::Input::Argument` to `self` with the provided *name*.
   # Optionally supports setting its *mode*, *description*, *default* value, and *suggested_values*.
+  #
+  # Also checkout the [value completion][Athena::Console::Input::Interface--argumentoption-value-completion] for how argument values can be auto completed.
   def argument(
     name : String,
     mode : ACON::Input::Argument::Mode = :optional,
@@ -307,7 +309,8 @@ abstract class Athena::Console::Command
   # Adds an `ACON::Input::Argument` to this command with the provided *name*.
   # Optionally supports setting its *mode*, *description*, *default* value.
   #
-  # Also accepts a block to use to determine this argument's suggested values.
+  # Accepts a block to use to determine this argument's suggested values.
+  # Also checkout the [value completion][Athena::Console::Input::Interface--argumentoption-value-completion] for how argument values can be auto completed.
   def argument(
     name : String,
     mode : ACON::Input::Argument::Mode = :optional,
@@ -388,6 +391,8 @@ abstract class Athena::Console::Command
 
   # Adds an `ACON::Input::Option` to `self` with the provided *name*.
   # Optionally supports setting its *shortcut*, *value_mode*, *description*, and *default* value.
+  #
+  # Also checkout the [value completion][Athena::Console::Input::Interface--argumentoption-value-completion] for how option values can be auto completed.
   def option(
     name : String,
     shortcut : String? = nil,
@@ -408,7 +413,8 @@ abstract class Athena::Console::Command
   # Adds an `ACON::Input::Option` to `self` with the provided *name*.
   # Optionally supports setting its *shortcut*, *value_mode*, *description*, and *default* value.
   #
-  # Also accepts a block to use to determine this argument's suggested values.
+  # Accepts a block to use to determine this argument's suggested values.
+  # Also checkout the [value completion][Athena::Console::Input::Interface--argumentoption-value-completion] for how option values can be auto completed.
   def option(
     name : String,
     shortcut : String? = nil,

--- a/src/components/console/src/command.cr
+++ b/src/components/console/src/command.cr
@@ -287,12 +287,38 @@ abstract class Athena::Console::Command
   end
 
   # Adds an `ACON::Input::Argument` to `self` with the provided *name*.
-  # Optionally supports setting its *mode*, *description*, and *default* value.
-  def argument(name : String, mode : ACON::Input::Argument::Mode = :optional, description : String = "", default = nil) : self
-    @definition << ACON::Input::Argument.new name, mode, description, default
+  # Optionally supports setting its *mode*, *description*, *default* value, and *suggested_values*.
+  def argument(
+    name : String,
+    mode : ACON::Input::Argument::Mode = :optional,
+    description : String = "",
+    default = nil,
+    suggested_values : Enumerable(String)? = nil
+  ) : self
+    @definition << ACON::Input::Argument.new name, mode, description, default, suggested_values.try &.to_a
 
     if full_definition = @full_definition
-      full_definition << ACON::Input::Argument.new name, mode, description, default
+      full_definition << ACON::Input::Argument.new name, mode, description, default, suggested_values.try &.to_a
+    end
+
+    self
+  end
+
+  # Adds an `ACON::Input::Argument` to this command with the provided *name*.
+  # Optionally supports setting its *mode*, *description*, *default* value.
+  #
+  # Also accepts a block to use to determine this argument's suggested values.
+  def argument(
+    name : String,
+    mode : ACON::Input::Argument::Mode = :optional,
+    description : String = "",
+    default = nil,
+    &suggested_values : ACON::Completion::Input -> Array(String)
+  ) : self
+    @definition << ACON::Input::Argument.new name, mode, description, default, suggested_values
+
+    if full_definition = @full_definition
+      full_definition << ACON::Input::Argument.new name, mode, description, default, suggested_values
     end
 
     self
@@ -362,11 +388,39 @@ abstract class Athena::Console::Command
 
   # Adds an `ACON::Input::Option` to `self` with the provided *name*.
   # Optionally supports setting its *shortcut*, *value_mode*, *description*, and *default* value.
-  def option(name : String, shortcut : String? = nil, value_mode : ACON::Input::Option::Value = :none, description : String = "", default = nil) : self
-    @definition << ACON::Input::Option.new name, shortcut, value_mode, description, default
+  def option(
+    name : String,
+    shortcut : String? = nil,
+    value_mode : ACON::Input::Option::Value = :none,
+    description : String = "",
+    default = nil,
+    suggested_values : Enumerable(String)? = nil
+  ) : self
+    @definition << ACON::Input::Option.new name, shortcut, value_mode, description, default, suggested_values.try &.to_a
 
     if full_definition = @full_definition
-      full_definition << ACON::Input::Option.new name, shortcut, value_mode, description, default
+      full_definition << ACON::Input::Option.new name, shortcut, value_mode, description, default, suggested_values.try &.to_a
+    end
+
+    self
+  end
+
+  # Adds an `ACON::Input::Option` to `self` with the provided *name*.
+  # Optionally supports setting its *shortcut*, *value_mode*, *description*, and *default* value.
+  #
+  # Also accepts a block to use to determine this argument's suggested values.
+  def option(
+    name : String,
+    shortcut : String? = nil,
+    value_mode : ACON::Input::Option::Value = :none,
+    description : String = "",
+    default = nil,
+    &suggested_values : ACON::Completion::Input -> Array(String)
+  ) : self
+    @definition << ACON::Input::Option.new name, shortcut, value_mode, description, default, suggested_values
+
+    if full_definition = @full_definition
+      full_definition << ACON::Input::Option.new name, shortcut, value_mode, description, default, suggested_values
     end
 
     self

--- a/src/components/console/src/command.cr
+++ b/src/components/console/src/command.cr
@@ -455,6 +455,16 @@ abstract class Athena::Console::Command
     self.execute input, output
   end
 
+  def complete(input : ACON::Completion::Input, suggestions : ACON::Completion::Suggestions) : Nil
+    definition = self.definition
+
+    if input.completion_type.option_value? && (option = definition.options[input.completion_name]?)
+      option.complete input, suggestions
+    elsif input.completion_type.argument_value? && (argument = definition.arguments[input.completion_name]?)
+      argument.complete input, suggestions
+    end
+  end
+
   protected def merge_application_definition(merge_args : Bool = true) : Nil
     return unless application = @application
 

--- a/src/components/console/src/command.cr
+++ b/src/components/console/src/command.cr
@@ -515,6 +515,9 @@ abstract class Athena::Console::Command
     self.execute input, output
   end
 
+  # Determines what values should be added to the possible *suggestions* based on the provided *input*.
+  #
+  # By default this will fall back on completion of the related input argument/option, but can be overridden if needed.
   def complete(input : ACON::Completion::Input, suggestions : ACON::Completion::Suggestions) : Nil
     definition = self.definition
 

--- a/src/components/console/src/commands/complete.cr
+++ b/src/components/console/src/commands/complete.cr
@@ -1,0 +1,87 @@
+require "semantic_version"
+
+@[Athena::Console::Annotations::AsCommand("|_complete", description: "Internal command to provide shell completion suggestions")]
+class Athena::Console::Commands::Complete < Athena::Console::Command
+  COMPLETION_API_VERSION = 1
+
+  @completion_outputs : Hash(String, ACON::Completion::OutputInterface.class)
+
+  @debug : Bool = false
+
+  def initialize(completion_outputs : Hash(String, ACON::Completion::OutputInterface.class) = Hash(String, ACON::Completion::OutputInterface.class).new)
+    @completion_outputs = completion_outputs.merge!({
+      "bash" => ACON::Completion::Output::Bash,
+    } of String => ACON::Completion::OutputInterface.class)
+
+    super()
+  end
+
+  protected def configure : Nil
+    self
+      .definition(
+        ACON::Input::Option.new("shell", "s", :required, "The shell type ('#{@completion_outputs.keys.join "', '"}')"),
+        ACON::Input::Option.new("input", "i", ACON::Input::Option::Value[:required, :is_array], "An array of input tokens (e.g. COMP_WORDS or argv)"),
+        ACON::Input::Option.new("current", "c", :required, "The index of the 'input' array that the cursor is in (e.g. COMP_CWORD)"),
+        ACON::Input::Option.new("api-version", "a", :required, "The API version of the completion script")
+      )
+  end
+
+  protected def setup(input : ACON::Input::Interface, output : ACON::Output::Interface) : Nil
+    @debug = ENV["ATHENA_DEBUG_COMPLETION"]? == "true"
+    @debug = true
+  end
+
+  protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
+    if (major_version = input.option("api-version"))
+      version = SemanticVersion.new major_version.to_i, 0, 0
+
+      if version < SemanticVersion.new(COMPLETION_API_VERSION, 0, 0)
+        message = "Completion script version is not supported ('#{version.major}' given, >=#{COMPLETION_API_VERSION} required)."
+
+        self.log message
+
+        output.puts "#{message} Install the Athena completion script again byusing the 'completion' command."
+
+        return ACON::Command::Status.new 126
+      end
+    end
+
+    unless shell = input.option "shell"
+      raise ACON::Exceptions::RuntimeError.new "The '--shell' option must be set."
+    end
+
+    unless completion_output = @completion_outputs[shell]?
+      raise ACON::Exceptions::RuntimeError.new %(Shell completion is not supported for your shell: '#{shell}' (supported: '#{@completion_outputs.keys.join "', '"}'))
+    end
+
+    completion_input = self.create_completion_input input
+    suggestions = ACON::Completion::Suggestions.new
+
+    ACON::Command::Status::SUCCESS
+  end
+
+  private def create_completion_input(input : ACON::Input::Interface) : ACON::Completion::Input
+    current_index = input.option "current"
+
+    if current_index.nil? || !(index = current_index.to_i?)
+      raise ACON::Exceptions::RuntimeError.new "The '--current' option must be set and it must be an integer."
+    end
+
+    completion_input = ACON::Completion::Input.from_tokens input.option("input", Array(String)), index
+
+    begin
+      completion_input.bind self.application.definition
+    rescue ex : ACON::Exceptions::ConsoleException
+    end
+
+    completion_input
+  end
+
+  private def log(messages : String | Enumerable(String)) : Nil
+    return unless @debug
+
+    messages = messages.is_a?(String) ? {messages} : messages
+
+    pp messages
+  end
+end

--- a/src/components/console/src/commands/complete.cr
+++ b/src/components/console/src/commands/complete.cr
@@ -1,17 +1,18 @@
 require "semantic_version"
 
 @[Athena::Console::Annotations::AsCommand("|_complete", description: "Internal command to provide shell completion suggestions")]
+# :nodoc:
 class Athena::Console::Commands::Complete < Athena::Console::Command
   API_VERSION = 1
 
-  @completion_outputs : Hash(String, ACON::Completion::OutputInterface.class)
+  @completion_outputs : Hash(String, ACON::Completion::Output::Interface.class)
 
   @debug : Bool = false
 
-  def initialize(completion_outputs : Hash(String, ACON::Completion::OutputInterface.class) = Hash(String, ACON::Completion::OutputInterface.class).new)
+  def initialize(completion_outputs : Hash(String, ACON::Completion::Output::Interface.class) = Hash(String, ACON::Completion::Output::Interface.class).new)
     @completion_outputs = completion_outputs.merge!({
       "bash" => ACON::Completion::Output::Bash,
-    } of String => ACON::Completion::OutputInterface.class)
+    } of String => ACON::Completion::Output::Interface.class)
 
     super()
   end

--- a/src/components/console/src/commands/complete.cr
+++ b/src/components/console/src/commands/complete.cr
@@ -28,7 +28,6 @@ class Athena::Console::Commands::Complete < Athena::Console::Command
 
   protected def setup(input : ACON::Input::Interface, output : ACON::Output::Interface) : Nil
     @debug = ENV["ATHENA_DEBUG_COMPLETION"]? == "true"
-    @debug = true
   end
 
   protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status

--- a/src/components/console/src/commands/complete.cr
+++ b/src/components/console/src/commands/complete.cr
@@ -82,6 +82,12 @@ class Athena::Console::Commands::Complete < Athena::Console::Command
     completion_output.write suggestions, output
 
     ACON::Command::Status::SUCCESS
+  rescue ex : ::Exception
+    self.log({"<error>Error!</>", ex.to_s})
+
+    raise ex if output.verbosity.debug?
+
+    return ACON::Command::Status::INVALID
   end
 
   private def create_completion_input(input : ACON::Input::Interface) : ACON::Completion::Input

--- a/src/components/console/src/commands/completion.cr
+++ b/src/components/console/src/commands/completion.cr
@@ -1,0 +1,88 @@
+@[Athena::Console::Annotations::AsCommand("completion", description: "Dump the shell completion script")]
+class Athena::Console::Commands::DumpCompletion < Athena::Console::Command
+  private SUPPORTED_SHELLS = {{ Athena::Console::Completion::OutputInterface.subclasses.map { |s| s.name.split("::").last.downcase } }}
+
+  protected def self.guess_shell : String
+    File.basename ENV["SHELL"]? || ""
+  end
+
+  protected def configure : Nil
+    # `Process.executable_path` already resolves symlinks
+    full_command = Process.executable_path || ""
+
+    command_name = File.basename full_command
+
+    shell = self.class.guess_shell
+
+    rc_file, completion_file = case shell
+                               else
+                                 {"~/.bashrc", "/etc/bash_completion.d/#{command_name}"}
+                               end
+
+    supported_shells = SUPPORTED_SHELLS.join ", "
+
+    self
+      .argument("shell", description: "The shell type (e.g. 'bash'), the value of the '$SHELL' env var will be used if not provided", suggested_values: SUPPORTED_SHELLS)
+      .help(<<-TEXT
+The <info>%command.name%</> command dumps the shell completion script required
+to use shell autocompletion (currently, #{supported_shells} completion are supported).
+
+<comment>Static installation
+-------------------</>
+
+Dump the script to a global completion file and restart your shell:
+
+    <info>%command.full_name% #{shell} | sudo tee #{completion_file}</>
+
+Or dump the script to a local file and source it:
+
+    <info>%command.full_name% #{shell} > completion.sh</>
+
+    <comment># source the file whenever you use the project</>
+    <info>source completion.sh</>
+
+    <comment># or add this line at the end of your "#{rc_file}" file:</>
+    <info>source /path/to/completion.sh</>
+
+<comment>Dynamic installation
+--------------------</>
+
+Add this to the end of your shell configuration file (e.g. <info>"#{rc_file}"</>):
+
+    <info>eval "$(#{full_command} completion #{shell})"</>
+TEXT
+      )
+  end
+
+  protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
+    command_name = File.basename Process.executable_path || ""
+
+    # Prevent generating the file for *.tmp files.
+    # It'll not only run slow, but probably not even valid bash syntax.
+    if command_name.ends_with? ".tmp"
+      raise ACON::Exceptions::RuntimeError.new "The shell completion file may only be generated non-temporary binaries.\n\nTry to `crystal build` your application first and try again."
+    end
+
+    shell = input.argument("shell") || self.class.guess_shell
+
+    complection_script = case shell
+                         when "bash" then ACON::Completion::Output::Bash::Script.new command_name, ACON::Commands::Complete::API_VERSION
+                         else
+                           if output.is_a? ACON::Output::ConsoleOutputInterface
+                             output = output.error_output
+                           end
+
+                           if shell
+                             output.puts %(<error>Detected shell '#{shell}', which is not supported by Athena shell completion (supported shells: '#{SUPPORTED_SHELLS.join("', '")}'.))
+                           else
+                             output.puts %(<error>Shell not detected, Athena shell completion only supports '#{SUPPORTED_SHELLS.join("', '")}'.)
+                           end
+
+                           return ACON::Command::Status::INVALID
+                         end
+
+    output.print complection_script
+
+    ACON::Command::Status::SUCCESS
+  end
+end

--- a/src/components/console/src/commands/completion.cr
+++ b/src/components/console/src/commands/completion.cr
@@ -1,6 +1,9 @@
 @[Athena::Console::Annotations::AsCommand("completion", description: "Dump the shell completion script")]
+# Can be used to generate the [completion script][Athena::Console--console-completion] to enable [argument/option value completion][Athena::Console::Input::Interface--argumentoption-value-completion].
+#
+# See the related docs for more information.
 class Athena::Console::Commands::DumpCompletion < Athena::Console::Command
-  private SUPPORTED_SHELLS = {{ Athena::Console::Completion::OutputInterface.subclasses.map(&.name.split("::").last.downcase) }}
+  private SUPPORTED_SHELLS = {{ Athena::Console::Completion::Output::Interface.subclasses.map(&.name.split("::").last.downcase) }}
 
   protected def self.guess_shell : String
     File.basename ENV["SHELL"]? || ""

--- a/src/components/console/src/commands/completion.cr
+++ b/src/components/console/src/commands/completion.cr
@@ -1,6 +1,6 @@
 @[Athena::Console::Annotations::AsCommand("completion", description: "Dump the shell completion script")]
 class Athena::Console::Commands::DumpCompletion < Athena::Console::Command
-  private SUPPORTED_SHELLS = {{ Athena::Console::Completion::OutputInterface.subclasses.map { |s| s.name.split("::").last.downcase } }}
+  private SUPPORTED_SHELLS = {{ Athena::Console::Completion::OutputInterface.subclasses.map(&.name.split("::").last.downcase) }}
 
   protected def self.guess_shell : String
     File.basename ENV["SHELL"]? || ""
@@ -65,23 +65,23 @@ TEXT
 
     shell = input.argument("shell") || self.class.guess_shell
 
-    complection_script = case shell
-                         when "bash" then ACON::Completion::Output::Bash::Script.new command_name, ACON::Commands::Complete::API_VERSION
-                         else
-                           if output.is_a? ACON::Output::ConsoleOutputInterface
-                             output = output.error_output
-                           end
+    completion_script = case shell
+                        when "bash" then ACON::Completion::Output::Bash::Script.new command_name, ACON::Commands::Complete::API_VERSION
+                        else
+                          if output.is_a? ACON::Output::ConsoleOutputInterface
+                            output = output.error_output
+                          end
 
-                           if shell
-                             output.puts %(<error>Detected shell '#{shell}', which is not supported by Athena shell completion (supported shells: '#{SUPPORTED_SHELLS.join("', '")}'.))
-                           else
-                             output.puts %(<error>Shell not detected, Athena shell completion only supports '#{SUPPORTED_SHELLS.join("', '")}'.)
-                           end
+                          if shell
+                            output.puts %(<error>Detected shell '#{shell}', which is not supported by Athena shell completion (supported shells: '#{SUPPORTED_SHELLS.join("', '")}'.))
+                          else
+                            output.puts %(<error>Shell not detected, Athena shell completion only supports '#{SUPPORTED_SHELLS.join("', '")}'.)
+                          end
 
-                           return ACON::Command::Status::INVALID
-                         end
+                          return ACON::Command::Status::INVALID
+                        end
 
-    output.print complection_script
+    output.print completion_script
 
     ACON::Command::Status::SUCCESS
   end

--- a/src/components/console/src/commands/lazy.cr
+++ b/src/components/console/src/commands/lazy.cr
@@ -82,4 +82,8 @@ class Athena::Console::Commands::Lazy < Athena::Console::Command
 
     command
   end
+
+  def complete(input : ACON::Completion::Input, suggestions : ACON::Completion::Suggestions) : Nil
+    self.command.complete input, suggestions
+  end
 end

--- a/src/components/console/src/completion/input.cr
+++ b/src/components/console/src/completion/input.cr
@@ -109,6 +109,10 @@ class Athena::Console::Completion::Input < Athena::Console::Input::ARGV
     @completion_type.option_value? && option_name == @completion_name
   end
 
+  def must_suggest_argument_values_for?(argument_name : String) : Bool
+    @completion_type.argument_value? && argument_name == @completion_name
+  end
+
   # The token of the cursor, or last token if the cursor is at the end of the input
   def relevant_token : String
     @tokens[self.is_cursor_free? ? @current_index - 1 : @current_index]? || ""
@@ -142,7 +146,7 @@ class Athena::Console::Completion::Input < Athena::Console::Input::ARGV
     number_of_tokens = @tokens.size
 
     if @current_index > number_of_tokens
-      raise ACON::Exceptions::Logic.new "Current index is invalid, it must be the number of input tokens or one more."
+      raise "Current index is invalid, it must be the number of input tokens."
     end
 
     @current_index >= number_of_tokens

--- a/src/components/console/src/completion/input.cr
+++ b/src/components/console/src/completion/input.cr
@@ -17,19 +17,19 @@ class Athena::Console::Completion::Input < Athena::Console::Input::ARGV
   end
 
   def self.from_tokens(tokens : Array(String), current_index : Int32) : self
-    new tokens, current_index
+    input = new tokens
+    input.current_index = current_index
+    input.tokens = tokens
+
+    input
   end
 
   getter completion_type : ACON::Completion::Input::Type = :none
   getter completion_name : String? = nil
   getter completion_value : String = ""
 
-  @current_index : Int32 = 1
-
-  def initialize(tokens : Array(String), @current_index : Int32)
-    super tokens
-    @tokens = tokens
-  end
+  protected setter current_index : Int32 = 1
+  protected setter tokens : Array(String)
 
   def bind(definition : ACON::Input::Definition) : Nil
     super definition

--- a/src/components/console/src/completion/input.cr
+++ b/src/components/console/src/completion/input.cr
@@ -1,0 +1,36 @@
+abstract class Athena::Console::Input; end
+
+require "../input/argv"
+
+class Athena::Console::Completion::Input < Athena::Console::Input::ARGV
+  enum Type
+    ARGUMENT_VALUE
+    OPTION_VALUE
+    ARGUMENT_NAME
+  end
+
+  def self.from_string(input : String, current_index : Int32) : self
+    tokens = input.match!(/(?<=^|\s)(['"]?)(.+?)(?<!\\\\)\1(?=$|\s)/)
+
+    self.from_tokens tokens[0], current_index
+  end
+
+  def self.from_tokens(tokens : Array(String), current_index : Int32) : self
+    new tokens, current_index
+  end
+
+  getter completion_type : ACON::Completion::Input::Type? = nil
+  getter completion_name : String? = nil
+  getter completion_value : String = ""
+
+  @current_index : Int32 = 1
+
+  def initialize(tokens : Array(String), @current_index : Int32)
+    super tokens
+    @tokens = tokens
+  end
+
+  def must_suggest_values_for?(option_name : String) : Bool
+    @completion_type.option_value? && option_name == @completion_name
+  end
+end

--- a/src/components/console/src/completion/input.cr
+++ b/src/components/console/src/completion/input.cr
@@ -4,9 +4,10 @@ require "../input/argv"
 
 class Athena::Console::Completion::Input < Athena::Console::Input::ARGV
   enum Type
+    NONE
     ARGUMENT_VALUE
     OPTION_VALUE
-    ARGUMENT_NAME
+    OPTION_NAME
   end
 
   def self.from_string(input : String, current_index : Int32) : self
@@ -19,7 +20,7 @@ class Athena::Console::Completion::Input < Athena::Console::Input::ARGV
     new tokens, current_index
   end
 
-  getter completion_type : ACON::Completion::Input::Type? = nil
+  getter completion_type : ACON::Completion::Input::Type = :none
   getter completion_name : String? = nil
   getter completion_value : String = ""
 

--- a/src/components/console/src/completion/input.cr
+++ b/src/components/console/src/completion/input.cr
@@ -52,7 +52,7 @@ class Athena::Console::Completion::Input < Athena::Console::Input::ARGV
       if option && option.accepts_value?
         @completion_type = :option_value
         @completion_name = option.name
-        @completion_value = option_value
+        @completion_value = option_value.presence || (!option_token.starts_with?("--") ? option_token[2..] : "")
 
         return
       end
@@ -61,6 +61,16 @@ class Athena::Console::Completion::Input < Athena::Console::Input::ARGV
     previous_token = @tokens[@current_index - 1]
 
     if '-' == previous_token[0] && !previous_token.strip("-").empty?
+      # Did the previous option accept a value?
+      previous_option = self.option_from_token previous_token
+
+      if previous_option && previous_option.accepts_value?
+        @completion_type = :option_value
+        @completion_name = previous_option.name
+        @completion_value = relevant_token
+
+        return
+      end
     end
 
     # Complete argument value
@@ -107,7 +117,7 @@ class Athena::Console::Completion::Input < Athena::Console::Input::ARGV
 
     return nil if option_name.empty?
 
-    if '-' == option_token[1]? || ""
+    if '-' == (option_token[1]? || " ")
       # Long option name
       return @definition.options[option_name]?
     end

--- a/src/components/console/src/completion/input.cr
+++ b/src/components/console/src/completion/input.cr
@@ -11,9 +11,9 @@ class Athena::Console::Completion::Input < Athena::Console::Input::ARGV
   end
 
   def self.from_string(input : String, current_index : Int32) : self
-    tokens = input.match!(/(?<=^|\s)(['"]?)(.+?)(?<!\\\\)\1(?=$|\s)/)
+    tokens = input.scan(/(?<=^|\s)(['"]?)(.+?)(?<!\\\\)\1(?=$|\s)/).map &.[0]
 
-    self.from_tokens tokens[0], current_index
+    self.from_tokens tokens, current_index
   end
 
   def self.from_tokens(tokens : Array(String), current_index : Int32) : self

--- a/src/components/console/src/completion/input.cr
+++ b/src/components/console/src/completion/input.cr
@@ -2,11 +2,20 @@ abstract class Athena::Console::Input; end
 
 require "../input/argv"
 
+# A specialization of `ACON::Input::ARGV` that allows for unfinished name/values.
+# Exposes information about the name, type, and value of the value/name being completed.
 class Athena::Console::Completion::Input < Athena::Console::Input::ARGV
   enum Type
+    # Nothing should be completed.
     NONE
+
+    # Completing the value of an argument.
     ARGUMENT_VALUE
+
+    # Completing the value of an option.
     OPTION_VALUE
+
+    # Completing the name of an option.
     OPTION_NAME
   end
 
@@ -24,13 +33,20 @@ class Athena::Console::Completion::Input < Athena::Console::Input::ARGV
     input
   end
 
+  # Returns which [type][ACON::Completion::Input::Type] of completion is required.
   getter completion_type : ACON::Completion::Input::Type = :none
+
+  # Returns the name of the argument/option when completing a value.
   getter completion_name : String? = nil
+
+  # Returns the value typed by the user, or empty string.
   getter completion_value : String = ""
 
   protected setter current_index : Int32 = 1
   protected setter tokens : Array(String)
 
+  # :inherit:
+  #
   # ameba:disable Metrics/CyclomaticComplexity
   def bind(definition : ACON::Input::Definition) : Nil
     super definition
@@ -106,19 +122,22 @@ class Athena::Console::Completion::Input < Athena::Console::Input::ARGV
     end
   end
 
+  # Returns `true` if this input is able to suggest values for the provided *option_name*.
   def must_suggest_values_for?(option_name : String) : Bool
     @completion_type.option_value? && option_name == @completion_name
   end
 
+  # Returns `true` if this input is able to suggest values for the provided *argument_name*.
   def must_suggest_argument_values_for?(argument_name : String) : Bool
     @completion_type.argument_value? && argument_name == @completion_name
   end
 
-  # The token of the cursor, or last token if the cursor is at the end of the input
+  # Returns the current token of the cursor, or last token if the cursor is at the end of the input.
   def relevant_token : String
     @tokens[self.free_cursor? ? @current_index - 1 : @current_index]? || ""
   end
 
+  # :nodoc:
   def to_s(io : IO) : Nil
     i = 0
     @tokens.each_with_index do |token, idx|

--- a/src/components/console/src/completion/output/bash.cr
+++ b/src/components/console/src/completion/output/bash.cr
@@ -1,4 +1,15 @@
 struct Athena::Console::Completion::Output::Bash < Athena::Console::Completion::OutputInterface
   def write(suggestions : ACON::Completion::Suggestions, output : ACON::Output::Interface) : Nil
+    values = suggestions.suggested_values.map &.to_s
+
+    suggestions.suggested_options.each do |option|
+      values << "--#{option.name}"
+
+      if option.negatable?
+        values << "--no-#{option.name}"
+      end
+    end
+
+    output.puts values.join "\n"
   end
 end

--- a/src/components/console/src/completion/output/bash.cr
+++ b/src/components/console/src/completion/output/bash.cr
@@ -1,4 +1,7 @@
-struct Athena::Console::Completion::Output::Bash < Athena::Console::Completion::OutputInterface
+require "./interface"
+
+# :nodoc:
+struct Athena::Console::Completion::Output::Bash < Athena::Console::Completion::Output::Interface
   # :nodoc:
   record Script, command_name : String, version : Int32 do
     ECR.def_to_s "#{__DIR__}/completion.bash"

--- a/src/components/console/src/completion/output/bash.cr
+++ b/src/components/console/src/completion/output/bash.cr
@@ -1,4 +1,9 @@
 struct Athena::Console::Completion::Output::Bash < Athena::Console::Completion::OutputInterface
+  # :nodoc:
+  record Script, command_name : String, version : Int32 do
+    ECR.def_to_s "#{__DIR__}/completion.bash"
+  end
+
   def write(suggestions : ACON::Completion::Suggestions, output : ACON::Output::Interface) : Nil
     values = suggestions.suggested_values.map &.to_s
 

--- a/src/components/console/src/completion/output/bash.cr
+++ b/src/components/console/src/completion/output/bash.cr
@@ -1,0 +1,4 @@
+struct Athena::Console::Completion::Output::Bash < Athena::Console::Completion::OutputInterface
+  def write(suggestions : ACON::Completion::Suggestions, output : ACON::Output::Interface) : Nil
+  end
+end

--- a/src/components/console/src/completion/output/completion.bash
+++ b/src/components/console/src/completion/output/completion.bash
@@ -1,0 +1,92 @@
+# Adapted from https://github.com/symfony/symfony/blob/503a7b3cb62fb6de70176b07bd1c4242e3addc5b/src/Symfony/Component/Console/Resources/completion.bash
+
+_athena_<%= @command_name %>() {
+    # Use the default completion for shell redirect operators.
+    for w in '>' '>>' '&>' '<'; do
+        if [[ $w = "${COMP_WORDS[COMP_CWORD-1]}" ]]; then
+            compopt -o filenames
+            COMPREPLY=($(compgen -f -- "${COMP_WORDS[COMP_CWORD]}"))
+            return 0
+        fi
+    done
+
+    # Use newline as only separator to allow space in completion values
+    IFS=$'\n'
+    local completion_cmd="${COMP_WORDS[0]}"
+
+    # for an alias, get the real script behind it
+    completion_cmd_type=$(type -t $completion_cmd)
+    if [[ $completion_cmd_type == "alias" ]]; then
+        completion_cmd=$(alias $completion_cmd | sed -E "s/alias $completion_cmd='(.*)'/\1/")
+    elif [[ $completion_cmd_type == "file" ]]; then
+        completion_cmd=$(type -p $completion_cmd)
+    fi
+
+    if [[ $completion_cmd_type != "function" && ! -x $completion_cmd ]]; then
+        return 1
+    fi
+
+    local cur prev words cword
+    _get_comp_words_by_ref -n := cur prev words cword
+
+    # Crystal doesn't get the script as the first arg, so remove it and decrement cword by 1 to compensate
+    cword=$(expr $cword - 1)
+    words=("${words[@]:1}")
+
+    local completecmd=("$completion_cmd" "_complete" "--no-interaction" "-sbash" "-c$cword" "-a<%= @version %>")
+    for w in ${words[@]}; do
+        w=$(printf -- '%b' "$w")
+        # remove quotes from typed values
+        quote="${w:0:1}"
+        if [ "$quote" == \' ]; then
+            w="${w%\'}"
+            w="${w#\'}"
+        elif [ "$quote" == \" ]; then
+            w="${w%\"}"
+            w="${w#\"}"
+        fi
+        # empty values are ignored
+        if [ ! -z "$w" ]; then
+            completecmd+=("-i$w")
+        fi
+    done
+
+    local sfcomplete
+    if sfcomplete=$(${completecmd[@]} 2>&1); then
+        local quote suggestions
+        quote=${cur:0:1}
+
+        # Use single quotes by default if suggestions contains backslash (FQCN)
+        if [ "$quote" == '' ] && [[ "$sfcomplete" =~ \\ ]]; then
+            quote=\'
+        fi
+
+        if [ "$quote" == \' ]; then
+            # single quotes: no additional escaping (does not accept ' in values)
+            suggestions=$(for s in $sfcomplete; do printf $'%q%q%q\n' "$quote" "$s" "$quote"; done)
+        elif [ "$quote" == \" ]; then
+            # double quotes: double escaping for \ $ ` "
+            suggestions=$(for s in $sfcomplete; do
+                s=${s//\\/\\\\}
+                s=${s//\$/\\\$}
+                s=${s//\`/\\\`}
+                s=${s//\"/\\\"}
+                printf $'%q%q%q\n' "$quote" "$s" "$quote";
+            done)
+        else
+            # no quotes: double escaping
+            suggestions=$(for s in $sfcomplete; do printf $'%q\n' $(printf '%q' "$s"); done)
+        fi
+        COMPREPLY=($(IFS=$'\n' compgen -W "$suggestions" -- $(printf -- "%q" "$cur")))
+        __ltrim_colon_completions "$cur"
+    else
+        if [[ "$sfcomplete" != *"Command \"_complete\" is not defined."* ]]; then
+            >&2 echo
+            >&2 echo $sfcomplete
+        fi
+
+        return 1
+    fi
+}
+
+complete -F _athena_<%= @command_name %> <%= @command_name %> ./<%= @command_name %>

--- a/src/components/console/src/completion/output/interface.cr
+++ b/src/components/console/src/completion/output/interface.cr
@@ -1,0 +1,9 @@
+require "../suggestions"
+
+# :nodoc:
+module Athena::Console::Completion::Output
+  abstract struct Interface
+    # Returns a string representation of the args passed to the command.
+    abstract def write(suggestions : ACON::Completion::Suggestions, output : ACON::Output::Interface) : Nil
+  end
+end

--- a/src/components/console/src/completion/output_interface.cr
+++ b/src/components/console/src/completion/output_interface.cr
@@ -1,6 +1,0 @@
-require "./suggestions"
-
-abstract struct Athena::Console::Completion::OutputInterface
-  # Returns a string representation of the args passed to the command.
-  abstract def write(suggestions : ACON::Completion::Suggestions, output : ACON::Output::Interface) : Nil
-end

--- a/src/components/console/src/completion/output_interface.cr
+++ b/src/components/console/src/completion/output_interface.cr
@@ -1,0 +1,6 @@
+require "./suggestions"
+
+abstract struct Athena::Console::Completion::OutputInterface
+  # Returns a string representation of the args passed to the command.
+  abstract def write(suggestions : ACON::Completion::Suggestions, output : ACON::Output::Interface) : Nil
+end

--- a/src/components/console/src/completion/suggestions.cr
+++ b/src/components/console/src/completion/suggestions.cr
@@ -8,6 +8,18 @@ class Athena::Console::Completion::Suggestions
   getter suggested_options = [] of ACON::Input::Option
   getter suggested_values = [] of SuggestedValue
 
+  def suggest_values(*values : String) : self
+    self.suggest_values values
+  end
+
+  def suggest_values(values : Enumerable(String)) : self
+    values.each do |option|
+      self.suggest_value option
+    end
+
+    self
+  end
+
   def suggest_value(value : String, description : String = "") : self
     self.suggest_value SuggestedValue.new value, description
   end

--- a/src/components/console/src/completion/suggestions.cr
+++ b/src/components/console/src/completion/suggestions.cr
@@ -1,2 +1,34 @@
 class Athena::Console::Completion::Suggestions
+  record SuggestedValue, value : String, description : String = "" do
+    def to_s(io : IO) : Nil
+      @value.to_s io
+    end
+  end
+
+  getter suggested_options = [] of ACON::Input::Option
+  getter suggested_values = [] of SuggestedValue
+
+  def suggest_value(value : String, description : String = "") : self
+    self.suggest_value SuggestedValue.new value, description
+  end
+
+  def suggest_value(value : ACON::Completion::Suggestions::SuggestedValue) : self
+    @suggested_values << value
+
+    self
+  end
+
+  def suggest_option(option : ACON::Input::Option) : self
+    @suggested_options << option
+
+    self
+  end
+
+  def suggest_options(options : ::Hash(String, ACON::Input::Option)) : self
+    options.each_value do |option|
+      self.suggest_option option
+    end
+
+    self
+  end
 end

--- a/src/components/console/src/completion/suggestions.cr
+++ b/src/components/console/src/completion/suggestions.cr
@@ -1,17 +1,24 @@
+# Stores all the suggested values/options for the current `ACON::Completion::Input`.
 class Athena::Console::Completion::Suggestions
+  # Represents a single suggested values, plus optional description.
   record SuggestedValue, value : String, description : String = "" do
     def to_s(io : IO) : Nil
       @value.to_s io
     end
   end
 
+  # Returns an array of the suggested `ACON::Input::Option`s.
   getter suggested_options = [] of ACON::Input::Option
-  getter suggested_values = [] of SuggestedValue
 
+  # Returns an array of the `ACON::Completion::Suggestions::SuggestedValue`s.
+  getter suggested_values = [] of ACON::Completion::Suggestions::SuggestedValue
+
+  # Adds each of the provided *values* to `#suggested_values`.
   def suggest_values(*values : String) : self
     self.suggest_values values
   end
 
+  # Adds each of the provided *values* to `#suggested_values`.
   def suggest_values(values : Enumerable(String)) : self
     values.each do |option|
       self.suggest_value option
@@ -20,26 +27,30 @@ class Athena::Console::Completion::Suggestions
     self
   end
 
+  # Adds the provided *value*, and optional *description* to `#suggested_values`.
   def suggest_value(value : String, description : String = "") : self
     self.suggest_value SuggestedValue.new value, description
   end
 
+  # Adds the provided *value* to `#suggested_values`.
   def suggest_value(value : ACON::Completion::Suggestions::SuggestedValue) : self
     @suggested_values << value
 
     self
   end
 
-  def suggest_option(option : ACON::Input::Option) : self
-    @suggested_options << option
-
-    self
-  end
-
+  # Adds each of the provided *options* to `#suggested_options`.
   def suggest_options(options : ::Hash(String, ACON::Input::Option)) : self
     options.each_value do |option|
       self.suggest_option option
     end
+
+    self
+  end
+
+  # Adds the provided *option* to `#suggested_options`.
+  def suggest_option(option : ACON::Input::Option) : self
+    @suggested_options << option
 
     self
   end

--- a/src/components/console/src/completion/suggestions.cr
+++ b/src/components/console/src/completion/suggestions.cr
@@ -1,0 +1,2 @@
+class Athena::Console::Completion::Suggestions
+end

--- a/src/components/console/src/input/argument.cr
+++ b/src/components/console/src/input/argument.cr
@@ -1,5 +1,3 @@
-abstract class Athena::Console::Input; end
-
 # Represents a value (or array of values) provided to a command as a ordered positional argument,
 # that can either be required or optional, optionally with a default value and/or description.
 #

--- a/src/components/console/src/input/argument.cr
+++ b/src/components/console/src/input/argument.cr
@@ -89,10 +89,12 @@ class Athena::Console::Input::Argument
     @default = ACON::Input::Value.from_value default
   end
 
+  # Returns `true` if this argument is able to suggest values, otherwise `false`
   def has_completion? : Bool
     !@suggested_values.nil?
   end
 
+  # Determines what values should be added to the possible *suggestions* based on the provided *input*.
   def complete(input : ACON::Completion::Input, suggestions : ACON::Completion::Suggestions) : Nil
     return unless values = @suggested_values
 

--- a/src/components/console/src/input/argument.cr
+++ b/src/components/console/src/input/argument.cr
@@ -39,12 +39,14 @@ class Athena::Console::Input::Argument
   getter description : String
 
   @default : ACON::Input::Value? = nil
+  @suggested_values : Array(String) | Proc(ACON::Completion::Input, Array(String)) | Nil
 
   def initialize(
     @name : String,
     @mode : ACON::Input::Argument::Mode = :optional,
     @description : String = "",
-    default = nil
+    default = nil,
+    @suggested_values : Array(String) | Proc(ACON::Completion::Input, Array(String)) | Nil = nil
   )
     raise ACON::Exceptions::InvalidArgument.new "An argument name cannot be blank." if name.blank?
 
@@ -85,6 +87,20 @@ class Athena::Console::Input::Argument
     end
 
     @default = ACON::Input::Value.from_value default
+  end
+
+  def has_completion? : Bool
+    !@suggested_values.nil?
+  end
+
+  def complete(input : ACON::Completion::Input, suggestions : ACON::Completion::Suggestions) : Nil
+    return unless values = @suggested_values
+
+    if values.is_a?(Proc)
+      values = values.call input
+    end
+
+    suggestions.suggest_values values
   end
 
   # Returns `true` if `self` is a required argument, otherwise `false`.

--- a/src/components/console/src/input/argv.cr
+++ b/src/components/console/src/input/argv.cr
@@ -89,7 +89,6 @@ class Athena::Console::Input::ARGV < Athena::Console::Input
     end
   end
 
-  # ameba:disable Metrics/CyclomaticComplexity
   protected def parse : Nil
     parse_options = true
     @parsed = @tokens.dup
@@ -103,7 +102,7 @@ class Athena::Console::Input::ARGV < Athena::Console::Input
     if parse_options && token.empty?
       self.parse_argument token
     elsif parse_options && "--" == token
-      parse_options = false
+      return false
     elsif parse_options && token.starts_with? "--"
       self.parse_long_option token
     elsif parse_options && token.starts_with?('-') && "-" != token

--- a/src/components/console/src/input/argv.cr
+++ b/src/components/console/src/input/argv.cr
@@ -95,18 +95,24 @@ class Athena::Console::Input::ARGV < Athena::Console::Input
     @parsed = @tokens.dup
 
     while token = @parsed.shift?
-      if parse_options && token.empty?
-        self.parse_argument token
-      elsif parse_options && "--" == token
-        parse_options = false
-      elsif parse_options && token.starts_with? "--"
-        self.parse_long_option token
-      elsif parse_options && token.starts_with?('-') && "-" != token
-        self.parse_short_option token
-      else
-        self.parse_argument token
-      end
+      parse_options = self.parse_token token, parse_options
     end
+  end
+
+  protected def parse_token(token : String, parse_options : Bool) : Bool
+    if parse_options && token.empty?
+      self.parse_argument token
+    elsif parse_options && "--" == token
+      parse_options = false
+    elsif parse_options && token.starts_with? "--"
+      self.parse_long_option token
+    elsif parse_options && token.starts_with?('-') && "-" != token
+      self.parse_short_option token
+    else
+      self.parse_argument token
+    end
+
+    parse_options
   end
 
   private def parse_argument(token : String) : Nil

--- a/src/components/console/src/input/interface.cr
+++ b/src/components/console/src/input/interface.cr
@@ -99,6 +99,55 @@ require "./definition"
 # |  `--bar Hello --baz World`   |    `"Hello"`    | `"World"` |   `nil`   |
 # | `--bar Hello --baz -- World` |    `"Hello"`    |   `nil`   | `"World"` |
 # |     `-b Hello -z World`      |    `"Hello"`    | `"World"` |   `nil`   |
+#
+# ## Argument/Option Value Completion
+#
+# If the [completion script][Athena::Console--console-completion] is installed, command and option names will be auto completed by the shell.
+# However, value completion may also be implemented in custom commands by providing the suggested values for a particular option/argument.
+#
+# ```
+# @[ACONA::AsCommand("greet")]
+# class GreetCommand < ACON::Command
+#   protected def configure : Nil
+#     # The suggested values do not need to be a static array,
+#     # they could be sourced via a class/instance method, a constant, etc.
+#     self
+#       .argument("name", suggested_values: ["Jim", "Bob", "Sally"])
+#   end
+#
+#   # ...
+# end
+# ```
+#
+# Additionally, a block version of `ACON::Command#argument(name,mode,description,default,&)` and `ACON::Command#option(name,shortcut,value_mode,description,default,&)` may be used if more complex logic is required.
+#
+# ```
+# @[ACONA::AsCommand("greet")]
+# class GreetCommand < ACON::Command
+#   protected def configure : Nil
+#     self
+#       .argument("name") do |input|
+#         # The value the user already typed, e.g. the value the user already typed,
+#         # e.g. when typing "greet Ge" before pressing Tab, this will contain "Ge".
+#         current_value = input.completion_value
+#
+#         # Get the list of username names from somewhere (e.g. the database)
+#         # you may use current_value to filter down the names
+#         available_usernames = ...
+#
+#         # then suggested the usernames as values
+#         return available_usernames
+#       end
+#   end
+#
+#   # ...
+# end
+# ```
+#
+# TIP: The shell completion script is able to handle huge amounts of suggestions and will automatically filter
+# the values based on existing input from the user.
+# You do not have to implement any filter logic in the command.
+# `input.completion_value` can still be used to filter if it helps with performance, such as reducing amount of rows the DB returns.
 module Athena::Console::Input::Interface
   # Returns the first argument from the raw un-parsed input.
   # Mainly used to get the command that should be executed.

--- a/src/components/console/src/input/option.cr
+++ b/src/components/console/src/input/option.cr
@@ -63,13 +63,15 @@ class Athena::Console::Input::Option
   getter description : String
 
   @default : ACON::Input::Value? = nil
+  @suggested_values : Array(String) | Proc(ACON::Completion::Input, Array(String)) | Nil
 
   def initialize(
     name : String,
     shortcut : String | Enumerable(String) | Nil = nil,
     @value_mode : ACON::Input::Option::Value = :none,
     @description : String = "",
-    default = nil
+    default = nil,
+    @suggested_values : Array(String) | Proc(ACON::Completion::Input, Array(String)) | Nil = nil
   )
     @name = name.lchop "--"
 
@@ -95,6 +97,10 @@ class Athena::Console::Input::Option
     end
 
     @shortcut = shortcut
+
+    if @suggested_values && !self.accepts_value?
+      raise ACON::Exceptions::InvalidArgument.new "Cannot set suggested values if the option does not accept a value."
+    end
 
     if @value_mode.is_array? && !self.accepts_value?
       raise ACON::Exceptions::InvalidArgument.new " Cannot have VALUE::IS_ARRAY option mode when the option does not accept a value."
@@ -143,6 +149,20 @@ class Athena::Console::Input::Option
     end
 
     @default = ACON::Input::Value.from_value (@value_mode.accepts_value? || @value_mode.negatable?) ? default : false
+  end
+
+  def has_completion? : Bool
+    !@suggested_values.nil?
+  end
+
+  def complete(input : ACON::Completion::Input, suggestions : ACON::Completion::Suggestions) : Nil
+    return unless values = @suggested_values
+
+    if values.is_a?(Proc)
+      values = values.call input
+    end
+
+    suggestions.suggest_values values
   end
 
   # Returns `true` if `self` is able to accept a value, otherwise `false`.

--- a/src/components/console/src/input/option.cr
+++ b/src/components/console/src/input/option.cr
@@ -151,10 +151,12 @@ class Athena::Console::Input::Option
     @default = ACON::Input::Value.from_value (@value_mode.accepts_value? || @value_mode.negatable?) ? default : false
   end
 
+  # Returns `true` if this option is able to suggest values, otherwise `false`
   def has_completion? : Bool
     !@suggested_values.nil?
   end
 
+  # Determines what values should be added to the possible *suggestions* based on the provided *input*.
   def complete(input : ACON::Completion::Input, suggestions : ACON::Completion::Suggestions) : Nil
     return unless values = @suggested_values
 

--- a/src/components/console/src/spec.cr
+++ b/src/components/console/src/spec.cr
@@ -35,8 +35,9 @@ module Athena::Console::Spec
 
     abstract def status : ACON::Command::Status?
 
+    # Asserts that the return `#status` is successful.
     def assert_command_is_successful(message : String = "", *, file : String = __FILE__, line : Int32 = __LINE__) : Nil
-      self.status.should ACON::Spec::Expectations::CommandIsSuccessful.new, file: file, line: line
+      self.status.should ACON::Spec::Expectations::CommandIsSuccessful.new, file: file, line: line, failure_message: message.presence
     end
 
     protected def init_output(

--- a/src/components/console/src/spec.cr
+++ b/src/components/console/src/spec.cr
@@ -1,3 +1,5 @@
+require "./spec/expectations/*"
+
 # Provides helper types for testing `ACON::Command` and `ACON::Application`s.
 module Athena::Console::Spec
   # Contains common logic shared by both `ACON::Spec::CommandTester` and `ACON::Spec::ApplicationTester`.
@@ -29,6 +31,12 @@ module Athena::Console::Spec
     # Helper method to setting the `#inputs=` property.
     def inputs(*args : String) : Nil
       @inputs = args.to_a
+    end
+
+    abstract def status : ACON::Command::Status?
+
+    def assert_command_is_successful(message : String = "", *, file : String = __FILE__, line : Int32 = __LINE__) : Nil
+      self.status.should ACON::Spec::Expectations::CommandIsSuccessful.new, file: file, line: line
     end
 
     protected def init_output(

--- a/src/components/console/src/spec/expectations/command_is_successful.cr
+++ b/src/components/console/src/spec/expectations/command_is_successful.cr
@@ -1,0 +1,14 @@
+# :nodoc:
+struct Athena::Console::Spec::Expectations::CommandIsSuccessful
+  def match(actual_value : ::ACON::Command::Status?) : Bool
+    ACON::Command::Status::SUCCESS == actual_value
+  end
+
+  def failure_message(actual_value : ::ACON::Command::Status?) : String
+    "The command was unsuccessful"
+  end
+
+  def negative_failure_message(actual_value : ::ACON::Command::Status?) : String
+    "The command was unsuccessful"
+  end
+end


### PR DESCRIPTION
Implements command tab completion by leveraging the shell's built in completion features. Currently only `bash` is supported, but `fish` and `zsh` can/will be added in another PR. Command and option names are supported out of the box. Option/argument values can be defined by using the new `suggested_values` option when adding arguments/options which accepts either an `Enumerable(String)` or a block that should return an `Array(String)` if additional filtering is desired. The `#complete` method may also be overridden for more complex usages.

This functionality does require sourcing/placing a generated file in a location where you shell is able to read it. E.g. sourced within `~/.bashrc` or placed within `/etc/bash_completion.d/`. This is a one-time setup, so not too big of a deal.

This can be done via the `completion` command that is bundled in with all console applications. E.g. `./console completion > completion.sh`. Run `./console help completion` formore information.

The name of the binary used to generate the script is important. In this case, `completion.sh` would handle auto completion for a binary called `console`, but not one called something else.

The completion script also is required to run with real binaries, not via like `crystal run src/console.cr -- completion`.

- Support tab completion
- Add helper `assert_command_is_successful` to the `*Tester` types

Resolves #293 