### PR TITLE
Bump ameba to fix macro expansion error when building it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check Spelling
-        uses: crate-ci/typos@v1.14.6
+        uses: crate-ci/typos@v1.16.1
   check_format:
     runs-on: ubuntu-latest
     container:

--- a/shard.yml
+++ b/shard.yml
@@ -42,7 +42,8 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.4.0
+    # version: ~> 1.4.0
+    commit: 60948fffd0f73d374fbd94c1915a8cd7dd6b83f5
   athena-spec:
     github: athena-framework/spec
     version: ~> 0.3.2

--- a/src/components/routing/src/matcher/traceable_url_matcher.cr
+++ b/src/components/routing/src/matcher/traceable_url_matcher.cr
@@ -90,7 +90,7 @@ class Athena::Routing::Matcher::TraceableURLMatcher < Athena::Routing::Matcher::
       regex_source = compiled_route.regex.source
 
       # Use rindex since we want the right most ending `$`
-      pos = regex_source.rindex('$').not_nil!
+      pos = regex_source.rindex!('$')
       has_trailing_slash = '/' == regex_source[pos - 1]
 
       # Enable multiline mode to catch paths with new lines


### PR DESCRIPTION
- Bump ameba to crystal-ameba/ameba@60948fffd0f73d374fbd94c1915a8cd7dd6b83f5 to workaround https://github.com/crystal-ameba/ameba/issues/372 until a new version is released
  - Fix new error due to newer version
- Bump `typos` to latest release