### PR TITLE
ZSH auto completion support

### DIFF
--- a/src/components/console/spec/commands/complete_spec.cr
+++ b/src/components/console/spec/commands/complete_spec.cr
@@ -41,7 +41,7 @@ struct CompleteCommandTest < ASPEC::TestCase
   end
 
   def test_unsupported_shell_option : Nil
-    expect_raises ACON::Exceptions::RuntimeError, "Shell completion is not supported for your shell: 'unsupported' (supported: 'bash')." do
+    expect_raises ACON::Exceptions::RuntimeError, "Shell completion is not supported for your shell: 'unsupported' (supported: 'bash', 'zsh')." do
       self.execute({"--shell" => "unsupported"})
     end
   end

--- a/src/components/console/spec/commands/dump_completion_spec.cr
+++ b/src/components/console/spec/commands/dump_completion_spec.cr
@@ -11,7 +11,7 @@ struct DumpCompletionCommandTest < ASPEC::TestCase
 
   def complete_provider : Hash
     {
-      "shell" => {[] of String, ["bash"]},
+      "shell" => {[] of String, ["bash", "zsh"]},
     }
   end
 end

--- a/src/components/console/spec/completion/output/bash_spec.cr
+++ b/src/components/console/spec/completion/output/bash_spec.cr
@@ -1,0 +1,15 @@
+require "./completion_output_test_case"
+
+struct BashTest < CompletionOutputTestCase
+  def completion_output : ACON::Completion::Output::Interface
+    ACON::Completion::Output::Bash.new
+  end
+
+  def expected_options_output : String
+    "--option1\n--negatable\n--no-negatable#{ACON::System::EOL}"
+  end
+
+  def expected_values_output : String
+    "Green\nRed\nYellow#{ACON::System::EOL}"
+  end
+end

--- a/src/components/console/spec/completion/output/completion_output_test_case.cr
+++ b/src/components/console/spec/completion/output/completion_output_test_case.cr
@@ -1,0 +1,34 @@
+abstract struct CompletionOutputTestCase < ASPEC::TestCase
+  abstract def completion_output : ACON::Completion::Output::Interface
+  abstract def expected_options_output : String
+  abstract def expected_values_output : String
+
+  def test_options : Nil
+    options = [
+      ACON::Input::Option.new("option1", "o", :none, "First Option"),
+      ACON::Input::Option.new("negatable", nil, :negatable, "Can be negative"),
+    ]
+
+    suggestions = ACON::Completion::Suggestions.new
+    suggestions.suggest_options options
+
+    buffer = IO::Memory.new
+
+    self.completion_output.write suggestions, ACON::Output::IO.new buffer
+
+    buffer.to_s.should eq self.expected_options_output
+  end
+
+  def test_values : Nil
+    suggestions = ACON::Completion::Suggestions.new
+    suggestions.suggest_value "Green", "Beans are green"
+    suggestions.suggest_value "Red", "Roses are red"
+    suggestions.suggest_value "Yellow", "Canaries are yellow"
+
+    buffer = IO::Memory.new
+
+    self.completion_output.write suggestions, ACON::Output::IO.new buffer
+
+    buffer.to_s.should eq self.expected_values_output
+  end
+end

--- a/src/components/console/spec/completion/output/zsh_spec.cr
+++ b/src/components/console/spec/completion/output/zsh_spec.cr
@@ -1,0 +1,15 @@
+require "./completion_output_test_case"
+
+struct ZshTest < CompletionOutputTestCase
+  def completion_output : ACON::Completion::Output::Interface
+    ACON::Completion::Output::Zsh.new
+  end
+
+  def expected_options_output : String
+    "--option1\tFirst Option\n--negatable\tCan be negative\n--no-negatable\tCan be negative\n"
+  end
+
+  def expected_values_output : String
+    "Green\tBeans are green\nRed\tRoses are red\nYellow\tCanaries are yellow\n"
+  end
+end

--- a/src/components/console/src/application.cr
+++ b/src/components/console/src/application.cr
@@ -315,7 +315,7 @@ class Athena::Console::Application
     end
 
     if input.completion_type.option_name?
-      suggestions.suggest_options self.definition.options
+      suggestions.suggest_options self.definition.options.values
 
       return
     end

--- a/src/components/console/src/commands/complete.cr
+++ b/src/components/console/src/commands/complete.cr
@@ -12,6 +12,7 @@ class Athena::Console::Commands::Complete < Athena::Console::Command
   def initialize(completion_outputs : Hash(String, ACON::Completion::Output::Interface.class) = Hash(String, ACON::Completion::Output::Interface.class).new)
     @completion_outputs = completion_outputs.merge!({
       "bash" => ACON::Completion::Output::Bash,
+      "zsh"  => ACON::Completion::Output::Zsh,
     } of String => ACON::Completion::Output::Interface.class)
 
     super()
@@ -88,7 +89,7 @@ class Athena::Console::Commands::Complete < Athena::Console::Command
       if completion_input.completion_type.option_name?
         self.log "  Completing option names for the <comment>#{command.is_a?(ACON::Commands::Lazy) ? command.command.class : command.class}</> command."
 
-        suggestions.suggest_options command.definition.options
+        suggestions.suggest_options command.definition.options.values
       else
         self.log({
           "  Completing using the <comment>#{command.is_a?(ACON::Commands::Lazy) ? command.command.class : command.class}</> class.",

--- a/src/components/console/src/commands/dump_completion.cr
+++ b/src/components/console/src/commands/dump_completion.cr
@@ -18,6 +18,7 @@ class Athena::Console::Commands::DumpCompletion < Athena::Console::Command
     shell = self.class.guess_shell
 
     rc_file, completion_file = case shell
+                               when "zsh" then {"~/.zshrc", "$fpath[1]/_#{command_name}"}
                                else
                                  {"~/.bashrc", "/etc/bash_completion.d/#{command_name}"}
                                end
@@ -70,6 +71,7 @@ TEXT
 
     completion_script = case shell
                         when "bash" then ACON::Completion::Output::Bash::Script.new command_name, ACON::Commands::Complete::API_VERSION
+                        when "zsh"  then ACON::Completion::Output::Zsh::Script.new command_name, ACON::Commands::Complete::API_VERSION
                         else
                           if output.is_a? ACON::Output::ConsoleOutputInterface
                             output = output.error_output

--- a/src/components/console/src/completion/output/completion.bash
+++ b/src/components/console/src/completion/output/completion.bash
@@ -29,7 +29,7 @@ _athena_<%= @command_name %>() {
     local cur prev words cword
     _get_comp_words_by_ref -n := cur prev words cword
 
-    # Crystal doesn't get the script as the first arg, so remove it and decrement cword by 1 to compensate
+    # Crystal doesn\'t get the script as the first arg, so remove it and decrement cword by 1 to compensate
     cword=$(expr $cword - 1)
     words=("${words[@]:1}")
 

--- a/src/components/console/src/completion/output/completion.zsh
+++ b/src/components/console/src/completion/output/completion.zsh
@@ -1,0 +1,75 @@
+#compdef <%= @command_name %>
+
+#
+# zsh completions for <%= @command_name %>
+#
+# References:
+#   - https://github.com/symfony/symfony/blob/503a7b3cb62fb6de70176b07bd1c4242e3addc5b/src/Symfony/Component/Console/Resources/completion.bash
+
+_athena_<%= @command_name %>() {
+    local lastParam flagPrefix requestComp out comp
+    local -a completions
+
+    # The user could have moved the cursor backwards on the command-line.
+    # We need to trigger completion from the $CURRENT location, so we need
+    # to truncate the command-line ($words) up to the $CURRENT location.
+    # (We cannot use $CURSOR as its value does not work when a command is an alias.)
+    words=("${=words[1,CURRENT]}") lastParam=${words[-1]}
+
+    # For zsh, when completing a flag with an = (e.g., <%= @command_name %> -n=<TAB>)
+    # completions must be prefixed with the flag
+    setopt local_options BASH_REMATCH
+    if [[ "${lastParam}" =~ '-.*=' ]]; then
+        # We are dealing with a flag with an =
+        flagPrefix="-P ${BASH_REMATCH}"
+    fi
+
+    # Prepare the command to obtain completions
+    # Crystal doesn\'t get the script as the first arg, so skip it when iterating over `words` and decrement CURRENT by 2 instead of 1 to compensate
+    requestComp="${words[0]} ${words[1]} _complete --no-interaction -szsh -a<%= @version %> -c$((CURRENT-2))" i=""
+    for w in ${words[@]:1}; do
+        w=$(printf -- '%b' "$w")
+        # remove quotes from typed values
+        quote="${w:0:1}"
+        if [ "$quote" = \' ]; then
+            w="${w%\'}"
+            w="${w#\'}"
+        elif [ "$quote" = \" ]; then
+            w="${w%\"}"
+            w="${w#\"}"
+        fi
+        # empty values are ignored
+        if [ ! -z "$w" ]; then
+            i="${i}-i${w} "
+        fi
+    done
+
+    # Ensure at least 1 input
+    if [ "${i}" = "" ]; then
+        requestComp="${requestComp} -i\" \""
+    else
+        requestComp="${requestComp} ${i}"
+    fi
+
+    # Use eval to handle any environment variables and such
+    out=$(eval ${requestComp} 2>/dev/null)
+
+    while IFS='\n' read -r comp; do
+        if [ -n "$comp" ]; then
+            # If requested, completions are returned with a description.
+            # The description is preceded by a TAB character.
+            # For zsh\'s _describe, we need to use a : instead of a TAB.
+            # We first need to escape any : as part of the completion itself.
+            comp=${comp//:/\\:}
+            local tab=$(printf '\t')
+            comp=${comp//$tab/:}
+            completions+=${comp}
+        fi
+    done < <(printf "%s\n" "${out[@]}")
+
+    # Let inbuilt _describe handle completions
+    eval _describe "completions" completions $flagPrefix
+    return $?
+}
+
+compdef _athena_<%= @command_name %> <%= @command_name %> ./<%= @command_name %>

--- a/src/components/console/src/completion/output/zsh.cr
+++ b/src/components/console/src/completion/output/zsh.cr
@@ -1,0 +1,23 @@
+# :nodoc:
+struct Athena::Console::Completion::Output::Zsh < Athena::Console::Completion::Output::Interface
+  # :nodoc:
+  record Script, command_name : String, version : Int32 do
+    ECR.def_to_s "#{__DIR__}/completion.zsh"
+  end
+
+  def write(suggestions : ACON::Completion::Suggestions, output : ACON::Output::Interface) : Nil
+    values = suggestions.suggested_values.map do |v|
+      "#{v.value}#{(desc = v.description.presence) ? "\t#{desc}" : ""}"
+    end
+
+    suggestions.suggested_options.each do |option|
+      values << "--#{option.name}#{(desc = option.description.presence) ? "\t#{desc}" : ""}"
+
+      if option.negatable?
+        values << "--no-#{option.name}#{(desc = option.description.presence) ? "\t#{desc}" : ""}"
+      end
+    end
+
+    output.puts values.join "\n"
+  end
+end

--- a/src/components/console/src/completion/suggestions.cr
+++ b/src/components/console/src/completion/suggestions.cr
@@ -40,8 +40,8 @@ class Athena::Console::Completion::Suggestions
   end
 
   # Adds each of the provided *options* to `#suggested_options`.
-  def suggest_options(options : ::Hash(String, ACON::Input::Option)) : self
-    options.each_value do |option|
+  def suggest_options(options : ::Enumerable(ACON::Input::Option)) : self
+    options.each do |option|
       self.suggest_option option
     end
 


### PR DESCRIPTION
Follow up to #294 to add `zsh` support

- Add completion support for `zsh`
- Add test coverage on shell output types
- Make suggestion options an array versus hash