### PR TITLE
Make `ACON::Helper.remove_decorations` remove hyperlinks

### DIFF
--- a/src/components/console/spec/helper/helper_spec.cr
+++ b/src/components/console/spec/helper/helper_spec.cr
@@ -27,4 +27,14 @@ struct HelperTest < ASPEC::TestCase
   def test_format_time(seconds : Int32 | Time::Span, expected : String) : Nil
     ACON::Helper.format_time(seconds).should eq expected
   end
+
+  @[TestWith(
+    {"abc", "abc"},
+    {"abc<fg=default;bg=default>", "abc"},
+    {"a\033[1;36mbc", "abc"},
+    {"a\033]8;;http://url\033\\b\033]8;;\033\\c", "abc"},
+  )]
+  def test_remove_docoration(decorated_text : String, expected : String) : Nil
+    ACON::Helper.remove_decoration(ACON::Formatter::Output.new, decorated_text).should eq expected
+  end
 end

--- a/src/components/console/spec/helper/table_spec.cr
+++ b/src/components/console/spec/helper/table_spec.cr
@@ -787,6 +787,28 @@ struct TableSpec < ASPEC::TestCase
     TABLE
   end
 
+  def test_hyperlink_and_max_width : Nil
+    table = ACON::Helper::Table.new output = self.io_output true
+
+    table
+      .rows([
+        ["<href=Lorem>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor</>"],
+      ])
+      .column_max_width(0, 17)
+      .render
+
+    self.output_content(output).should eq <<-TABLE
+    +-------------------+
+    | \e]8;;Lorem\e\\Lorem ipsum dolor\e]8;;\e\\ |
+    | \e]8;;Lorem\e\\sit amet, consect\e]8;;\e\\ |
+    | \e]8;;Lorem\e\\etur adipiscing e\e]8;;\e\\ |
+    | \e]8;;Lorem\e\\lit, sed do eiusm\e]8;;\e\\ |
+    | \e]8;;Lorem\e\\od tempor\e]8;;\e\\         |
+    +-------------------+
+
+    TABLE
+  end
+
   def test_append_row : Nil
     sections = [] of ACON::Output::Section
 

--- a/src/components/console/src/helper/helper.cr
+++ b/src/components/console/src/helper/helper.cr
@@ -57,8 +57,16 @@ abstract class Athena::Console::Helper
   def self.remove_decoration(formatter : ACON::Formatter::Interface, string : String) : String
     is_decorated = formatter.decorated?
     formatter.decorated = false
+
+    # Remove <...> formatting
     string = formatter.format string
+
+    # Remove already formatted characters
     string = string.gsub /\033\[[^m]*m/, ""
+
+    # Remove terminal hyperlinks
+    string = string.gsub /\033]8;[^;]*;[^\033]*\033\\/, ""
+
     formatter.decorated = is_decorated
 
     string


### PR DESCRIPTION
* Remove hyperlinks when removing decorations
* Add specs for `Helper.remove_decorations`
* Add spec to ensure tables with hyperlinks align correctly