### PR TITLE
Redirect controller

### DIFF
--- a/src/components/framework/spec/controller/redirect_spec.cr
+++ b/src/components/framework/spec/controller/redirect_spec.cr
@@ -1,0 +1,26 @@
+require "../spec_helper"
+
+@[ASPEC::TestCase::Focus]
+struct RedirectControllerTest < ASPEC::TestCase
+  def test_empty_route_permanent : Nil
+    request = ATH::Request.new "GET", "/"
+    controller = ATH::Controller::Redirect.new
+
+    ex = expect_raises ATH::Exceptions::HTTPException do
+      controller.redirect_url request, "", true
+    end
+
+    ex.status_code.should eq 410
+  end
+
+  def test_empty_route_non_permanent : Nil
+    request = ATH::Request.new "GET", "/"
+    controller = ATH::Controller::Redirect.new
+
+    ex = expect_raises ATH::Exceptions::HTTPException do
+      controller.redirect_url request, ""
+    end
+
+    ex.status_code.should eq 404
+  end
+end

--- a/src/components/framework/spec/controller/redirect_spec.cr
+++ b/src/components/framework/spec/controller/redirect_spec.cr
@@ -1,6 +1,5 @@
 require "../spec_helper"
 
-@[ASPEC::TestCase::Focus]
 struct RedirectControllerTest < ASPEC::TestCase
   def test_empty_route_permanent : Nil
     request = ATH::Request.new "GET", "/"

--- a/src/components/framework/spec/controllers/routing_controller.cr
+++ b/src/components/framework/spec/controllers/routing_controller.cr
@@ -17,6 +17,11 @@ class RoutingController < ATH::Controller
     ADI.container.object_id
   end
 
+  @[ARTA::Route(path: "/head-get/", methods: {"HEAD", "GET"})]
+  def head_get_trailing_slash : String
+    "HEAD-GET/"
+  end
+
   @[ARTA::Head("/head")]
   def head : String
     "HEAD"

--- a/src/components/framework/spec/routing_spec.cr
+++ b/src/components/framework/spec/routing_spec.cr
@@ -1,6 +1,5 @@
 require "./spec_helper"
 
-@[ASPEC::TestCase::Focus]
 struct RoutingTest < ATH::Spec::APITestCase
   def test_is_concurrently_safe : Nil
     spawn do

--- a/src/components/framework/spec/routing_spec.cr
+++ b/src/components/framework/spec/routing_spec.cr
@@ -1,5 +1,6 @@
 require "./spec_helper"
 
+@[ASPEC::TestCase::Focus]
 struct RoutingTest < ATH::Spec::APITestCase
   def test_is_concurrently_safe : Nil
     spawn do
@@ -216,5 +217,35 @@ struct RoutingTest < ATH::Spec::APITestCase
     self.get "/cookies"
 
     self.assert_cookie_has_value "key", "value"
+  end
+
+  def test_redirects_get_request_to_route_without_trailing_slash : Nil
+    self.get "/macro/get-nil/"
+
+    self.assert_response_redirects "/macro/get-nil"
+  end
+
+  def test_redirects_head_request_to_route_without_trailing_slash : Nil
+    self.request "HEAD", "/head/"
+
+    self.assert_response_redirects "/head"
+  end
+
+  def test_redirects_get_request_to_route_with_trailing_slash : Nil
+    self.get "/head-get"
+
+    self.assert_response_redirects "/head-get/"
+  end
+
+  def test_redirects_head_request_to_route_with_trailing_slash : Nil
+    self.request "HEAD", "/head-get"
+
+    self.assert_response_redirects "/head-get/"
+  end
+
+  def test_does_not_redirect_post_requests : Nil
+    self.post "/art/response/"
+
+    self.assert_response_has_status :not_found
   end
 end

--- a/src/components/framework/src/controller/redirect.cr
+++ b/src/components/framework/src/controller/redirect.cr
@@ -1,3 +1,4 @@
+# :nodoc:
 class Athena::Framework::Controller::Redirect
   def redirect_url(
     request : ATH::Request,
@@ -8,6 +9,10 @@ class Athena::Framework::Controller::Redirect
     https_port : Int32? = nil,
     keep_request_method : Bool = false
   ) : ATH::RedirectResponse
+    if path.empty?
+      raise ATH::Exceptions::HTTPException.new (permanent ? HTTP::Status::GONE : HTTP::Status::NOT_FOUND), ""
+    end
+
     status = if keep_request_method
                permanent ? HTTP::Status::TEMPORARY_REDIRECT : HTTP::Status::PERMANENT_REDIRECT
              else
@@ -15,7 +20,7 @@ class Athena::Framework::Controller::Redirect
              end
 
     # TODO: Handle redirecting to full URLs
-    # TODO: Handle customizing scheme/ports
+    # TODO: Handle customizing scheme/ports/qs
 
     ATH::RedirectResponse.new path, status
   end

--- a/src/components/framework/src/controller/redirect_controller.cr
+++ b/src/components/framework/src/controller/redirect_controller.cr
@@ -1,0 +1,22 @@
+class Athena::Framework::Controller::Redirect
+  def redirect_url(
+    request : ATH::Request,
+    path : String,
+    permanent : Bool = false,
+    scheme : String? = nil,
+    http_port : Int32? = nil,
+    https_port : Int32? = nil,
+    keep_request_method : Bool = false
+  ) : ATH::RedirectResponse
+    status = if keep_request_method
+               permanent ? HTTP::Status::TEMPORARY_REDIRECT : HTTP::Status::PERMANENT_REDIRECT
+             else
+               permanent ? HTTP::Status::MOVED_PERMANENTLY : HTTP::Status::FOUND
+             end
+
+    # TODO: Handle redirecting to full URLs
+    # TODO: Handle customizing scheme/ports
+
+    ATH::RedirectResponse.new path, status
+  end
+end

--- a/src/components/framework/src/ext/routing/annotation_route_loader.cr
+++ b/src/components/framework/src/ext/routing/annotation_route_loader.cr
@@ -507,7 +507,7 @@ module Athena::Framework::Routing::AnnotationRouteLoader
     # Manually wire up built-in controllers for now
     {% if base == nil %}
       @@actions["Athena::Framework::Controller::Redirect#redirect_url"] = ATH::Action.new(
-        action: Proc(Tuple(ATH::Request, String, Bool), ATH::RedirectResponse).new do |arguments|
+        action: Proc(Tuple(ATH::Request, String, Bool, String?, Int32?, Int32?, Bool), ATH::RedirectResponse).new do |arguments|
           Athena::Framework::Controller::Redirect.new.redirect_url *arguments
         end,
         parameters: {

--- a/src/components/framework/src/ext/routing/annotation_route_loader.cr
+++ b/src/components/framework/src/ext/routing/annotation_route_loader.cr
@@ -484,37 +484,26 @@ module Athena::Framework::Routing::AnnotationRouteLoader
     {% end %}
 
     # Manually wire up built-in controllers for now
-@@actions["Athena::Framework::Controller::Redirect#redirect_url"] = ATH::Action.new(
-  action: Proc(Tuple(ATH::Request, String, Bool), ATH::RedirectResponse).new do |arguments|
-    Athena::Framework::Controller::Redirect.new.redirect_url *arguments
-  end,
-  parameters: {ATH::Controller::ParameterMetadata(ATH::Request).new(
-    "request",
-    false,
-    nil,
-    ACF::AnnotationConfigurations.new(
-      {} of ACF::AnnotationConfigurations::Classes => Array(ACF::AnnotationConfigurations::ConfigurationBase)
-    ),
-  ), ATH::Controller::ParameterMetadata(String).new(
-    "path",
-    false,
-    nil,
-    ACF::AnnotationConfigurations.new(
-      {} of ACF::AnnotationConfigurations::Classes => Array(ACF::AnnotationConfigurations::ConfigurationBase)
-    ),
-  ), ATH::Controller::ParameterMetadata(Bool).new(
-    "permanent",
-    true,
-    false,
-    ACF::AnnotationConfigurations.new(
-      {} of ACF::AnnotationConfigurations::Classes => Array(ACF::AnnotationConfigurations::ConfigurationBase)
-    ),
-  )},
-  annotation_configurations: ACF::AnnotationConfigurations.new({} of ACF::AnnotationConfigurations::Classes => Array(ACF::AnnotationConfigurations::ConfigurationBase)),
-  params: ([] of ATH::Params::ParamInterface),
-  _controller: Athena::Framework::Controller::Redirect,
-  _return_type: ATH::RedirectResponse,
-)
+    {% if base == nil %}
+      @@actions["Athena::Framework::Controller::Redirect#redirect_url"] = ATH::Action.new(
+        action: Proc(Tuple(ATH::Request, String, Bool), ATH::RedirectResponse).new do |arguments|
+          Athena::Framework::Controller::Redirect.new.redirect_url *arguments
+        end,
+        parameters: {
+          ATH::Controller::ParameterMetadata(ATH::Request).new("request"),
+          ATH::Controller::ParameterMetadata(String).new("path"),
+          ATH::Controller::ParameterMetadata(Bool).new("permanent", true, false),
+          ATH::Controller::ParameterMetadata(String?).new("scheme", true, nil),
+          ATH::Controller::ParameterMetadata(Int32?).new("http_port", true, nil),
+          ATH::Controller::ParameterMetadata(Int32?).new("https_port", true, nil),
+          ATH::Controller::ParameterMetadata(Bool).new("keep_request_method", true, false),
+        },
+        annotation_configurations: ACF::AnnotationConfigurations.new,
+        params: ([] of ATH::Params::ParamInterface),
+        _controller: Athena::Framework::Controller::Redirect,
+        _return_type: ATH::RedirectResponse,
+      )
+    {% end %}
 
     ART.compile collection
 

--- a/src/components/framework/src/ext/routing/annotation_route_loader.cr
+++ b/src/components/framework/src/ext/routing/annotation_route_loader.cr
@@ -483,6 +483,39 @@ module Athena::Framework::Routing::AnnotationRouteLoader
       {% end %}
     {% end %}
 
+    # Manually wire up built-in controllers for now
+@@actions["Athena::Framework::Controller::Redirect#redirect_url"] = ATH::Action.new(
+  action: Proc(Tuple(ATH::Request, String, Bool), ATH::RedirectResponse).new do |arguments|
+    Athena::Framework::Controller::Redirect.new.redirect_url *arguments
+  end,
+  parameters: {ATH::Controller::ParameterMetadata(ATH::Request).new(
+    "request",
+    false,
+    nil,
+    ACF::AnnotationConfigurations.new(
+      {} of ACF::AnnotationConfigurations::Classes => Array(ACF::AnnotationConfigurations::ConfigurationBase)
+    ),
+  ), ATH::Controller::ParameterMetadata(String).new(
+    "path",
+    false,
+    nil,
+    ACF::AnnotationConfigurations.new(
+      {} of ACF::AnnotationConfigurations::Classes => Array(ACF::AnnotationConfigurations::ConfigurationBase)
+    ),
+  ), ATH::Controller::ParameterMetadata(Bool).new(
+    "permanent",
+    true,
+    false,
+    ACF::AnnotationConfigurations.new(
+      {} of ACF::AnnotationConfigurations::Classes => Array(ACF::AnnotationConfigurations::ConfigurationBase)
+    ),
+  )},
+  annotation_configurations: ACF::AnnotationConfigurations.new({} of ACF::AnnotationConfigurations::Classes => Array(ACF::AnnotationConfigurations::ConfigurationBase)),
+  params: ([] of ATH::Params::ParamInterface),
+  _controller: Athena::Framework::Controller::Redirect,
+  _return_type: ATH::RedirectResponse,
+)
+
     ART.compile collection
 
     collection

--- a/src/components/framework/src/ext/routing/redirectable_url_matcher.cr
+++ b/src/components/framework/src/ext/routing/redirectable_url_matcher.cr
@@ -1,0 +1,14 @@
+# :nodoc:
+class Athena::Framework::Routing::RedirectableURLMatcher < Athena::Routing::Matcher::URLMatcher
+  include ART::Matcher::RedirectableURLMatcherInterface
+
+  def redirect(path : String, route : String, scheme : String? = nil) : Hash(String, String?)?
+    {
+      "_controller" => "Athena::Framework::Controller::Redirect#redirect_url",
+      "_route"      => route,
+      "path"        => path,
+      "permanent"   => "true",
+      "scheme"      => scheme,
+    } of String => String?
+  end
+end

--- a/src/components/framework/src/ext/routing/router.cr
+++ b/src/components/framework/src/ext/routing/router.cr
@@ -1,6 +1,10 @@
 # :nodoc:
 @[ADI::Register(_default_uri: "%routing.base_uri%", name: "router", public: true, alias: ART::Generator::Interface)]
 class Athena::Framework::Routing::Router < Athena::Routing::Router
+  getter matcher : ART::Matcher::URLMatcherInterface do
+    ATH::Routing::RedirectableURLMatcher.new(@context)
+  end
+
   def initialize(
     default_locale : String? = nil,
     strict_requirements : Bool = true,

--- a/src/components/framework/src/redirect_response.cr
+++ b/src/components/framework/src/redirect_response.cr
@@ -25,7 +25,7 @@ class Athena::Framework::RedirectResponse < Athena::Framework::Response
   # Creates a response that should redirect to the provided *url* with the provided *status*, defaults to 302.
   #
   # An ArgumentError is raised if *url* is blank, or if *status* is not a valid redirection status code.
-  def initialize(url : String | Path, status : HTTP::Status | Int32 = HTTP::Status::FOUND, headers : HTTP::Headers | ATH::Response::Headers = ATH::Response::Headers.new)
+  def initialize(url : String | Path | URI, status : HTTP::Status | Int32 = HTTP::Status::FOUND, headers : HTTP::Headers | ATH::Response::Headers = ATH::Response::Headers.new)
     @url = url.to_s
 
     raise ArgumentError.new "Cannot redirect to an empty URL." if @url.blank?

--- a/src/components/routing/spec/matcher/redirectable_url_matcher_spec.cr
+++ b/src/components/routing/spec/matcher/redirectable_url_matcher_spec.cr
@@ -18,7 +18,7 @@ private class MockRedirectableURLMatcher < ART::Matcher::URLMatcher
     end
 
     if er = @@expected_route
-      route.should eq route
+      route.should eq er
     end
 
     if es = @@expected_scheme

--- a/src/components/routing/spec/matcher/redirectable_url_matcher_spec.cr
+++ b/src/components/routing/spec/matcher/redirectable_url_matcher_spec.cr
@@ -1,0 +1,158 @@
+require "../spec_helper"
+require "./abstract_url_matcher_test_case"
+
+private class MockRedirectableURLMatcher < ART::Matcher::URLMatcher
+  include ART::Matcher::RedirectableURLMatcherInterface
+
+  class_setter return_value : Hash(String, String?) = Hash(String, String?).new
+  class_setter was_called : Bool = true
+  class_setter expected_path : String? = nil
+  class_setter expected_route : String? = nil
+  class_setter expected_scheme : String? = nil
+
+  def redirect(path : String, route : String, scheme : String? = nil) : Hash(String, String?)?
+    @@was_called.should be_true
+
+    if ep = @@expected_path
+      path.should eq ep
+    end
+
+    if er = @@expected_route
+      route.should eq route
+    end
+
+    if es = @@expected_scheme
+      scheme.should eq es
+    end
+
+    @@return_value
+  ensure
+    @@return_value = Hash(String, String?).new
+    @@was_called = true
+    @@expected_path = nil
+    @@expected_route = nil
+    @@expected_scheme = nil
+  end
+end
+
+struct RedirectableURLMatcherTest < AbstractURLMatcherTestCase
+  def test_match_missing_trailing_slash : Nil
+    routes = self.build_collection do
+      add "test", ART::Route.new "/foo/"
+    end
+
+    self.get_matcher(routes).match("/foo").should eq({"_route" => "test"})
+  end
+
+  def test_match_extra_trailing_slash : Nil
+    routes = self.build_collection do
+      add "test", ART::Route.new "/foo"
+    end
+
+    self.get_matcher(routes).match("/foo/").should eq({"_route" => "test"})
+  end
+
+  def test_redirect_when_no_slash_for_non_safe_method : Nil
+    routes = self.build_collection do
+      add "test", ART::Route.new "/foo/"
+    end
+
+    expect_raises ART::Exception::ResourceNotFound do
+      self.get_matcher(routes, ART::RequestContext.new method: "POST").match "/foo"
+    end
+  end
+
+  # TODO: Uncomment scheme check when supported
+  def test_scheme_redirect_redirects_to_first_scheme : Nil
+    routes = self.build_collection do
+      add "test", ART::Route.new "/foo", schemes: {"FTP", "HTTPS"}
+    end
+
+    MockRedirectableURLMatcher.expected_path = "/foo"
+    MockRedirectableURLMatcher.expected_route = "test"
+    # MockRedirectableURLMatcher.expected_scheme = "ftp"
+
+    self.get_matcher(routes).match("/foo").should eq({"_route" => "test"})
+  end
+
+  # TODO: Enable when schemes are supported
+  def ptest_no_schema_redirect_if_one_of_multiple_schemas_matches : Nil
+    routes = self.build_collection do
+      add "test", ART::Route.new "/foo", schemes: {"https", "http"}
+    end
+
+    MockRedirectableURLMatcher.was_called = false
+
+    self.get_matcher(routes).match("/foo").should eq({"_route" => "test"})
+  end
+
+  # TODO: Enable when schemes are supported
+  def ptest_scheme_redirect_with_params : Nil
+    routes = self.build_collection do
+      add "test", ART::Route.new "/foo/{bar}", schemes: "https"
+    end
+
+    MockRedirectableURLMatcher.return_value = {"redirect" => "value"} of String => String?
+    MockRedirectableURLMatcher.expected_path = "/foo/baz"
+    MockRedirectableURLMatcher.expected_route = "test"
+    # MockRedirectableURLMatcher.expected_scheme = "https"
+
+    self.get_matcher(routes).match("/foo/baz").should eq({"_route" => "test", "bar" => "baz", "redirect" => "value"})
+  end
+
+  def test_scheme_redirect_for_root : Nil
+    routes = self.build_collection do
+      add "test", ART::Route.new "/", schemes: "https"
+    end
+
+    MockRedirectableURLMatcher.return_value = {"redirect" => "value"} of String => String?
+    MockRedirectableURLMatcher.expected_path = "/"
+    MockRedirectableURLMatcher.expected_route = "test"
+    # MockRedirectableURLMatcher.expected_scheme = "https"
+
+    self.get_matcher(routes).match("/").should eq({"_route" => "test", "redirect" => "value"})
+  end
+
+  def test_slash_redirect_with_params : Nil
+    routes = self.build_collection do
+      add "test", ART::Route.new "/foo/{bar}/"
+    end
+
+    MockRedirectableURLMatcher.return_value = {"redirect" => "value"} of String => String?
+    MockRedirectableURLMatcher.expected_path = "/foo/baz/"
+    MockRedirectableURLMatcher.expected_route = "test"
+
+    self.get_matcher(routes).match("/foo/baz").should eq({"_route" => "test", "bar" => "baz", "redirect" => "value"})
+  end
+
+  def test_redirect_preserves_url_encoding : Nil
+    routes = self.build_collection do
+      add "test", ART::Route.new "/foo:bar/"
+    end
+
+    MockRedirectableURLMatcher.expected_path = "/foo%3Abar/"
+
+    self.get_matcher(routes).match("/foo%3Abar").should eq({"_route" => "test"})
+  end
+
+  def test_match_scheme_requirement : Nil
+    routes = self.build_collection do
+      add "test", ART::Route.new "/foo", schemes: "https"
+    end
+
+    self.get_matcher(routes).match("/foo").should eq({"_route" => "test"})
+  end
+
+  def test_match_greedy_trailing_requirement_default1 : Nil
+    routes = self.build_collection do
+      add "a", ART::Route.new "/fr-fr/{a}", {"a" => "aaa"}, {"a" => /.+/}
+    end
+
+    self.get_matcher(routes).match("/fr-fr/").should eq({"_route" => "a", "a" => "aaa"})
+  end
+
+  private def get_matcher(routes : ART::RouteCollection, context : ART::RequestContext = ART::RequestContext.new) : ART::Matcher::URLMatcher
+    ART.compile routes
+    MockRedirectableURLMatcher.new context
+  end
+end

--- a/src/components/routing/src/matcher/redirectable_url_matcher_interface.cr
+++ b/src/components/routing/src/matcher/redirectable_url_matcher_interface.cr
@@ -1,0 +1,3 @@
+module Athena::Routing::Matcher::RedirectableURLMatcherInterface
+  abstract def redirect(path : String, route : String, scheme : String? = nil) : Hash(String, String?)?
+end

--- a/src/components/routing/src/matcher/redirectable_url_matcher_interface.cr
+++ b/src/components/routing/src/matcher/redirectable_url_matcher_interface.cr
@@ -1,3 +1,4 @@
+# :nodoc:
 module Athena::Routing::Matcher::RedirectableURLMatcherInterface
   abstract def redirect(path : String, route : String, scheme : String? = nil) : Hash(String, String?)?
 end

--- a/src/components/routing/src/matcher/url_matcher.cr
+++ b/src/components/routing/src/matcher/url_matcher.cr
@@ -38,6 +38,26 @@ class Athena::Routing::Matcher::URLMatcher
       raise ART::Exception::MethodNotAllowed.new allow
     end
 
+    unless self.is_a? ART::Matcher::RedirectableURLMatcherInterface
+      raise ART::Exception::ResourceNotFound.new "No routes found for '#{path}'."
+    end
+
+    if !@context.method.in? "GET", "HEAD"
+      # no-op
+    elsif !allow_schemes.empty?
+      redirect_schema
+    elsif "/" != (trimmed_path = (path.rstrip('/').presence || "/"))
+      path = trimmed_path == path ? "#{path}/" : trimmed_path
+
+      if match = self.do_match path, allow, allow_schemes
+        return match.merge! self.redirect(path, match["_route"].not_nil!("BUG: match does not have a '_route'."))
+      end
+
+      unless allow_schemes.empty?
+        redirect_schema
+      end
+    end
+
     raise ART::Exception::ResourceNotFound.new "No routes found for '#{path}'."
   end
 
@@ -47,7 +67,7 @@ class Athena::Routing::Matcher::URLMatcher
   end
 
   # ameba:disable Metrics/CyclomaticComplexity
-  private def do_match(path : String, allow : Array(String), allow_schemes : Array(String)) : Hash(String, String?)?
+  private def do_match(path : String, allow : Array(String) = [] of String, allow_schemes : Array(String) = [] of String) : Hash(String, String?)?
     allow.clear
     allow_schemes.clear
 
@@ -60,8 +80,7 @@ class Athena::Routing::Matcher::URLMatcher
 
     canonical_method = "GET" if "HEAD" == request_method
 
-    # ameba:disable Lint/UselessAssign
-    supports_redirect = false # TODO: Support this
+    supports_redirect = "GET" == canonical_method && self.is_a? ART::Matcher::RedirectableURLMatcherInterface
 
     ART::RouteProvider.static_routes[trimmed_path]?.try &.each do |data, required_host, required_methods, required_schemes, has_trailing_slash, _, condition|
       if condition && !(ART::RouteProvider.conditions[condition].call(@context, @request || self.build_request(path)))
@@ -89,7 +108,13 @@ class Athena::Routing::Matcher::URLMatcher
       end
 
       if "/" != path && has_trailing_slash == (trimmed_path == path)
-        # TODO: Support redirects
+        if supports_redirect && required_methods && (required_methods.empty? || required_methods.includes? "GET")
+          allow.clear
+          allow_schemes.clear
+
+          return
+        end
+
         next
       end
 
@@ -135,7 +160,13 @@ class Athena::Routing::Matcher::URLMatcher
           end
 
           if "/" != path && !has_trailing_var && has_trailing_slash == (trimmed_path == path)
-            # TODO: Support redirections
+            if supports_redirect && required_methods && (required_methods.empty? || required_methods.includes? "GET")
+              allow.clear
+              allow_schemes.clear
+
+              return
+            end
+
             next
           end
 
@@ -184,5 +215,18 @@ class Athena::Routing::Matcher::URLMatcher
     {% end %}
 
     request
+  end
+
+  private macro redirect_schema
+    scheme = @context.scheme
+    @context.scheme = allow_schemes.last? || ""
+
+    begin
+      if match = self.do_match path
+        return match.merge! self.redirect(path, match["_route"].not_nil!("BUG: match does not have a '_route'."), @context.scheme)
+      end
+    ensure
+      @context.scheme = scheme
+    end
   end
 end

--- a/src/components/routing/src/matcher/url_matcher.cr
+++ b/src/components/routing/src/matcher/url_matcher.cr
@@ -90,7 +90,7 @@ class Athena::Routing::Matcher::URLMatcher
       # Dup the data hash so we don't mutate the original.
       data = data.dup
 
-      required_host.try do |h|
+      if h = required_host
         case h
         in String then next if h != host
         in Regex
@@ -108,7 +108,7 @@ class Athena::Routing::Matcher::URLMatcher
       end
 
       if "/" != path && has_trailing_slash == (trimmed_path == path)
-        if supports_redirect && required_methods && (required_methods.empty? || required_methods.includes? "GET")
+        if supports_redirect && (!required_methods || (required_methods.empty? || required_methods.includes? "GET"))
           allow.clear
           allow_schemes.clear
 
@@ -160,7 +160,7 @@ class Athena::Routing::Matcher::URLMatcher
           end
 
           if "/" != path && !has_trailing_var && has_trailing_slash == (trimmed_path == path)
-            if supports_redirect && required_methods && (required_methods.empty? || required_methods.includes? "GET")
+            if supports_redirect && (!required_methods || (required_methods.empty? || required_methods.includes? "GET"))
               allow.clear
               allow_schemes.clear
 


### PR DESCRIPTION
* Introduce internal controller to handle redirects
  * Will redirect `GET` and `HEAD` requests with a trailing slash to the route without one if it exists, and vice versa.