### PR TITLE
Require component `spec` helper files within `framework` `spec` file

### DIFF
--- a/src/components/framework/src/spec.cr
+++ b/src/components/framework/src/spec.cr
@@ -1,5 +1,11 @@
 require "athena-spec"
+
+require "athena-clock/spec"
+require "athena-console/spec"
+require "athena-event_dispatcher/spec"
 require "athena-dependency_injection/spec"
+require "athena-validator/spec"
+
 require "./spec/*"
 
 # :nodoc:


### PR DESCRIPTION
* Ensures test helpers from all components are available when the framework component's file is required
  * I.e. `require "athena/spec"`