### PR TITLE
Support tab completing when binary is in `bin/` directory

### DIFF
--- a/src/components/console/CHANGELOG.md
+++ b/src/components/console/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.4] - 2023-10-10
+
+### Added
+
+- Add support for `bin/console` and `./bin/console` to the completion scripts ([#323](https://github.com/athena-framework/athena/pull/323)) (George Dietrich)
+
 ## [0.3.3] - 2023-10-09
 
 ### Changed
@@ -100,6 +106,7 @@ _First release a part of the monorepo._
 
 _Initial release._
 
+[0.3.4]: https://github.com/athena-framework/console/releases/tag/v0.3.4
 [0.3.3]: https://github.com/athena-framework/console/releases/tag/v0.3.3
 [0.3.2]: https://github.com/athena-framework/console/releases/tag/v0.3.2
 [0.3.1]: https://github.com/athena-framework/console/releases/tag/v0.3.1

--- a/src/components/console/CHANGELOG.md
+++ b/src/components/console/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add support for `bin/console` and `./bin/console` to the completion scripts ([#323](https://github.com/athena-framework/athena/pull/323)) (George Dietrich)
+- Add support for tab completion to the `bash` shell when binary is in the `bin/` directory and referenced with `./` ([#323](https://github.com/athena-framework/athena/pull/323)) (George Dietrich)
 
 ## [0.3.3] - 2023-10-09
 

--- a/src/components/console/shard.yml
+++ b/src/components/console/shard.yml
@@ -1,6 +1,6 @@
 name: athena-console
 
-version: 0.3.3
+version: 0.3.4
 
 crystal: ~> 1.8
 

--- a/src/components/console/src/athena-console.cr
+++ b/src/components/console/src/athena-console.cr
@@ -115,7 +115,7 @@ alias ACONA = ACON::Annotations
 # WARNING: The completion script may only be used with real built binaries, not temporary ones such as `crystal run src/console.cr -- completion`.
 # This is to ensure the performance of the script is sufficient, and to avoid any issues with the naming of the temporary binary.
 module Athena::Console
-  VERSION = "0.3.3"
+  VERSION = "0.3.4"
 
   # Contains all the `Athena::Console` based annotations.
   module Annotations; end

--- a/src/components/console/src/commands/complete.cr
+++ b/src/components/console/src/commands/complete.cr
@@ -3,7 +3,7 @@ require "semantic_version"
 @[Athena::Console::Annotations::AsCommand("|_complete", description: "Internal command to provide shell completion suggestions")]
 # :nodoc:
 class Athena::Console::Commands::Complete < Athena::Console::Command
-  API_VERSION = 1
+  API_VERSION = 2
 
   @completion_outputs : Hash(String, ACON::Completion::Output::Interface.class)
 

--- a/src/components/console/src/completion/output/completion.bash
+++ b/src/components/console/src/completion/output/completion.bash
@@ -89,4 +89,4 @@ _athena_<%= @command_name %>() {
     fi
 }
 
-complete -F _athena_<%= @command_name %> <%= @command_name %> ./<%= @command_name %>
+complete -F _athena_<%= @command_name %> <%= @command_name %> ./<%= @command_name %> ./bin/<%= @command_name %>


### PR DESCRIPTION
* Release new console version with this improvement

# Release Checklist

## Before Merging

- [x] Bump `version` in `shard.yml`
  -~~If a minor, also update version in `README.md` & root `Getting Started` section~~
- [x] Bump `VERSION` constraint
- [x] Add `CHANGELOG.md` entry
- ~~**(optional)** Bump `crystal` version within `shard.yaml` if applicable~~
- ~~**(optional)** Bump version constraints within dependent components if applicable~~

## After Merging

- [ ] Cut tags via `./scripts/release.sh tag ...` helper script
- [ ] Run `shards update` in `demo` applications and run specs to smoke test the release
- [ ] Create GH releases on those tags
- [ ] Run `shards update` in `website`, and `skeleton` applications
- [ ] Post release announcement on socials (gitter, forums, discord)