### PR TITLE
Replace component specific `System::EOL` constants with top level `EOL` const

### DIFF
--- a/src/components/console/shard.yml
+++ b/src/components/console/shard.yml
@@ -2,7 +2,7 @@ name: athena-console
 
 version: 0.3.4
 
-crystal: ~> 1.8
+crystal: ~> 1.11
 
 license: MIT
 

--- a/src/components/console/spec/application_spec.cr
+++ b/src/components/console/spec/application_spec.cr
@@ -19,7 +19,7 @@ struct ApplicationTest < ASPEC::TestCase
 
   protected def assert_file_equals_string(filepath : String, string : String, *, file : String = __FILE__, line : Int32 = __LINE__) : Nil
     normalized_path = File.join __DIR__, "fixtures", filepath
-    string.should match(Regex.new(File.read(normalized_path).gsub ACON::System::EOL, "\n")), file: file, line: line
+    string.should match(Regex.new(File.read(normalized_path).gsub EOL, "\n")), file: file, line: line
   end
 
   protected def ensure_static_command_help(application : ACON::Application) : Nil
@@ -792,10 +792,10 @@ struct ApplicationTest < ASPEC::TestCase
     tester = ACON::Spec::ApplicationTester.new app
 
     tester.run command: "foo:bar", "--no-interaction": true, decorated: false
-    tester.display.should eq "execute called#{ACON::System::EOL}"
+    tester.display.should eq "execute called#{EOL}"
 
     tester.run command: "foo:bar", "-n": true, decorated: false
-    tester.display.should eq "execute called#{ACON::System::EOL}"
+    tester.display.should eq "execute called#{EOL}"
   end
 
   def test_run_global_option_and_no_command : Nil
@@ -974,7 +974,7 @@ struct ApplicationTest < ASPEC::TestCase
 
     tester = ACON::Spec::ApplicationTester.new app
     tester.run interactive: false
-    tester.display.should eq "execute called#{ACON::System::EOL}"
+    tester.display.should eq "execute called#{EOL}"
 
     # TODO: Test custom application default.
   end
@@ -987,7 +987,7 @@ struct ApplicationTest < ASPEC::TestCase
 
     tester = ACON::Spec::ApplicationTester.new app
     tester.run "--fooopt": "opt", interactive: false
-    tester.display.should eq "execute called#{ACON::System::EOL}opt#{ACON::System::EOL}"
+    tester.display.should eq "execute called#{EOL}opt#{EOL}"
   end
 
   def test_run_custom_single_default_command : Nil

--- a/src/components/console/spec/application_tester_spec.cr
+++ b/src/components/console/spec/application_tester_spec.cr
@@ -29,11 +29,11 @@ struct ApplicationTesterTest < ASPEC::TestCase
   end
 
   def test_output : Nil
-    @tester.output.to_s.should eq "foo#{ACON::System::EOL}"
+    @tester.output.to_s.should eq "foo#{EOL}"
   end
 
   def test_display : Nil
-    @tester.display.to_s.should eq "foo#{ACON::System::EOL}"
+    @tester.display.to_s.should eq "foo#{EOL}"
   end
 
   def test_status : Nil

--- a/src/components/console/spec/command_spec.cr
+++ b/src/components/console/spec/command_spec.cr
@@ -179,13 +179,13 @@ describe ACON::Command do
     it "interactive" do
       tester = ACON::Spec::CommandTester.new TestCommand.new
       tester.execute interactive: true
-      tester.display.should eq "interact called#{ACON::System::EOL}execute called#{ACON::System::EOL}"
+      tester.display.should eq "interact called#{EOL}execute called#{EOL}"
     end
 
     it "non-interactive" do
       tester = ACON::Spec::CommandTester.new TestCommand.new
       tester.execute interactive: false
-      tester.display.should eq "execute called#{ACON::System::EOL}"
+      tester.display.should eq "execute called#{EOL}"
     end
 
     it "invalid option" do

--- a/src/components/console/spec/command_tester_spec.cr
+++ b/src/components/console/spec/command_tester_spec.cr
@@ -28,11 +28,11 @@ struct CommandTesterTest < ASPEC::TestCase
   end
 
   def test_output : Nil
-    @tester.output.to_s.should eq "foo#{ACON::System::EOL}"
+    @tester.output.to_s.should eq "foo#{EOL}"
   end
 
   def test_display : Nil
-    @tester.display.to_s.should eq "foo#{ACON::System::EOL}"
+    @tester.display.to_s.should eq "foo#{EOL}"
   end
 
   def test_display_before_calling_execute : Nil

--- a/src/components/console/spec/commands/complete_spec.cr
+++ b/src/components/console/spec/commands/complete_spec.cr
@@ -52,7 +52,7 @@ struct CompleteCommandTest < ASPEC::TestCase
     })
 
     self.execute({"--current" => "0", "--input" => [] of String})
-    @tester.display.should eq "#{["help", "list", "completion", "hello", "ahoy", "foo:bar1", "afoobar1"].join("\n")}#{ACON::System::EOL}"
+    @tester.display.should eq "#{["help", "list", "completion", "hello", "ahoy", "foo:bar1", "afoobar1"].join("\n")}#{EOL}"
   end
 
   def test_additional_shell_support : Nil
@@ -96,7 +96,7 @@ struct CompleteCommandTest < ASPEC::TestCase
   @[DataProvider("provide_complete_command_name_inputs")]
   def test_completion_command_name(input : Array(String), suggestions : Array(String)) : Nil
     self.execute({"--current" => "0", "--input" => input})
-    @tester.display.should eq "#{suggestions.join("\n")}#{ACON::System::EOL}"
+    @tester.display.should eq "#{suggestions.join("\n")}#{EOL}"
   end
 
   def provide_complete_command_name_inputs : Hash
@@ -111,7 +111,7 @@ struct CompleteCommandTest < ASPEC::TestCase
   @[DataProvider("provide_input_definition_inputs")]
   def test_completion_command_input_definitions(input : Array(String), suggestions : Array(String)) : Nil
     self.execute({"--current" => "1", "--input" => input})
-    @tester.display.should eq "#{suggestions.join("\n")}#{ACON::System::EOL}"
+    @tester.display.should eq "#{suggestions.join("\n")}#{EOL}"
   end
 
   def provide_input_definition_inputs : Hash

--- a/src/components/console/spec/commands/list_spec.cr
+++ b/src/components/console/spec/commands/list_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
 private def normalize(input : String) : String
-  input.gsub ACON::System::EOL, "\n"
+  input.gsub EOL, "\n"
 end
 
 struct ListCommandTest < ASPEC::TestCase

--- a/src/components/console/spec/completion/output/bash_spec.cr
+++ b/src/components/console/spec/completion/output/bash_spec.cr
@@ -6,10 +6,10 @@ struct BashTest < CompletionOutputTestCase
   end
 
   def expected_options_output : String
-    "--option1\n--negatable\n--no-negatable#{ACON::System::EOL}"
+    "--option1\n--negatable\n--no-negatable#{EOL}"
   end
 
   def expected_values_output : String
-    "Green\nRed\nYellow#{ACON::System::EOL}"
+    "Green\nRed\nYellow#{EOL}"
   end
 end

--- a/src/components/console/spec/descriptor/abstract_descriptor_test_case.cr
+++ b/src/components/console/spec/descriptor/abstract_descriptor_test_case.cr
@@ -66,6 +66,6 @@ abstract struct AbstractDescriptorTestCase < ASPEC::TestCase
   end
 
   private def normalize_output(output : String) : String
-    output.gsub(ACON::System::EOL, "\n").strip
+    output.gsub(EOL, "\n").strip
   end
 end

--- a/src/components/console/spec/helper/abstract_question_helper_test_case.cr
+++ b/src/components/console/spec/helper/abstract_question_helper_test_case.cr
@@ -23,7 +23,7 @@ abstract struct AbstractQuestionHelperTest < ASPEC::TestCase
     output = stream.to_s
 
     if normalize
-      output = output.gsub ACON::System::EOL, "\n"
+      output = output.gsub EOL, "\n"
     end
 
     output.should contain string

--- a/src/components/console/spec/helper/formatter_spec.cr
+++ b/src/components/console/spec/helper/formatter_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
 private def normalize(input : String) : String
-  input.gsub ACON::System::EOL, "\n"
+  input.gsub EOL, "\n"
 end
 
 describe ACON::Helper::Formatter do

--- a/src/components/console/spec/helper/progress_bar_spec.cr
+++ b/src/components/console/spec/helper/progress_bar_spec.cr
@@ -330,9 +330,9 @@ struct ProgressBarTest < ASPEC::TestCase
 
     self.assert_output(
       output,
-      "  0/50 [>---------------------------]   0%#{ACON::System::EOL}",
-      "\e[1A\e[0J  1/50 [>---------------------------]   2%#{ACON::System::EOL}",
-      "\e[1A\e[0J  2/50 [=>--------------------------]   4%#{ACON::System::EOL}",
+      "  0/50 [>---------------------------]   0%#{EOL}",
+      "\e[1A\e[0J  1/50 [>---------------------------]   2%#{EOL}",
+      "\e[1A\e[0J  2/50 [=>--------------------------]   4%#{EOL}",
     )
   end
 
@@ -353,9 +353,9 @@ struct ProgressBarTest < ASPEC::TestCase
 
     self.assert_output(
       output,
-      " \033[44;37m 0/50\033[0m [>---------------------------]   0%#{ACON::System::EOL}",
-      "\e[1A\e[0J \033[44;37m 1/50\033[0m [>---------------------------]   2%#{ACON::System::EOL}",
-      "\e[1A\e[0J \033[44;37m 2/50\033[0m [=>--------------------------]   4%#{ACON::System::EOL}",
+      " \033[44;37m 0/50\033[0m [>---------------------------]   0%#{EOL}",
+      "\e[1A\e[0J \033[44;37m 1/50\033[0m [>---------------------------]   2%#{EOL}",
+      "\e[1A\e[0J \033[44;37m 2/50\033[0m [=>--------------------------]   4%#{EOL}",
     )
   end
 
@@ -377,12 +377,12 @@ struct ProgressBarTest < ASPEC::TestCase
 
     self.assert_output(
       acon_output,
-      "  0/50 [>---------------------------]   0%#{ACON::System::EOL}",
-      "  0/50 [>---------------------------]   0%#{ACON::System::EOL}",
-      "\e[1A\e[0J  1/50 [>---------------------------]   2%#{ACON::System::EOL}",
-      "\e[2A\e[0J  1/50 [>---------------------------]   2%#{ACON::System::EOL}",
-      "\e[1A\e[0J  1/50 [>---------------------------]   2%#{ACON::System::EOL}",
-      "  1/50 [>---------------------------]   2%#{ACON::System::EOL}",
+      "  0/50 [>---------------------------]   0%#{EOL}",
+      "  0/50 [>---------------------------]   0%#{EOL}",
+      "\e[1A\e[0J  1/50 [>---------------------------]   2%#{EOL}",
+      "\e[2A\e[0J  1/50 [>---------------------------]   2%#{EOL}",
+      "\e[1A\e[0J  1/50 [>---------------------------]   2%#{EOL}",
+      "  1/50 [>---------------------------]   2%#{EOL}",
     )
   end
 
@@ -424,9 +424,9 @@ struct ProgressBarTest < ASPEC::TestCase
 
     self.assert_output(
       output,
-      " 0/50 [>---------------------------]   0% %message% EXISTING TEXT.#{ACON::System::EOL}",
-      "\e[1A\e[0J 1/50 [>---------------------------]   2% MESSAGE\nTEXT! EXISTING TEXT.#{ACON::System::EOL}",
-      "\e[2A\e[0J 2/50 [=>--------------------------]   4% OTHER\nTEXT! EXISTING TEXT.#{ACON::System::EOL}",
+      " 0/50 [>---------------------------]   0% %message% EXISTING TEXT.#{EOL}",
+      "\e[1A\e[0J 1/50 [>---------------------------]   2% MESSAGE\nTEXT! EXISTING TEXT.#{EOL}",
+      "\e[2A\e[0J 2/50 [=>--------------------------]   4% OTHER\nTEXT! EXISTING TEXT.#{EOL}",
     )
   end
 
@@ -451,12 +451,12 @@ struct ProgressBarTest < ASPEC::TestCase
 
     self.assert_output(
       acon_output,
-      "  0/50 [>---------------------------]   0%#{ACON::System::EOL}",
-      " 0/50 [>]   0% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.#{ACON::System::EOL}",
-      "\e[4A\e[0J 0/50 [>]   0% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.#{ACON::System::EOL}",
-      "\e[3A\e[0J  1/50 [>---------------------------]   2%#{ACON::System::EOL}",
-      " 0/50 [>]   0% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.#{ACON::System::EOL}",
-      "\e[3A\e[0J 1/50 [>]   2% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.#{ACON::System::EOL}",
+      "  0/50 [>---------------------------]   0%#{EOL}",
+      " 0/50 [>]   0% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.#{EOL}",
+      "\e[4A\e[0J 0/50 [>]   0% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.#{EOL}",
+      "\e[3A\e[0J  1/50 [>---------------------------]   2%#{EOL}",
+      " 0/50 [>]   0% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.#{EOL}",
+      "\e[3A\e[0J 1/50 [>]   2% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.#{EOL}",
     )
   end
 
@@ -594,16 +594,16 @@ struct ProgressBarTest < ASPEC::TestCase
 
     self.assert_output(
       output,
-      "   0/200 [>---------------------------]   0%#{ACON::System::EOL}",
-      "  20/200 [==>-------------------------]  10%#{ACON::System::EOL}",
-      "  40/200 [=====>----------------------]  20%#{ACON::System::EOL}",
-      "  60/200 [========>-------------------]  30%#{ACON::System::EOL}",
-      "  80/200 [===========>----------------]  40%#{ACON::System::EOL}",
-      " 100/200 [==============>-------------]  50%#{ACON::System::EOL}",
-      " 120/200 [================>-----------]  60%#{ACON::System::EOL}",
-      " 140/200 [===================>--------]  70%#{ACON::System::EOL}",
-      " 160/200 [======================>-----]  80%#{ACON::System::EOL}",
-      " 180/200 [=========================>--]  90%#{ACON::System::EOL}",
+      "   0/200 [>---------------------------]   0%#{EOL}",
+      "  20/200 [==>-------------------------]  10%#{EOL}",
+      "  40/200 [=====>----------------------]  20%#{EOL}",
+      "  60/200 [========>-------------------]  30%#{EOL}",
+      "  80/200 [===========>----------------]  40%#{EOL}",
+      " 100/200 [==============>-------------]  50%#{EOL}",
+      " 120/200 [================>-----------]  60%#{EOL}",
+      " 140/200 [===================>--------]  70%#{EOL}",
+      " 160/200 [======================>-----]  80%#{EOL}",
+      " 180/200 [=========================>--]  90%#{EOL}",
       " 200/200 [============================] 100%",
     )
   end
@@ -618,8 +618,8 @@ struct ProgressBarTest < ASPEC::TestCase
 
     self.assert_output(
       output,
-      "  0/50 [>---------------------------]   0%#{ACON::System::EOL}",
-      " 25/50 [==============>-------------]  50%#{ACON::System::EOL}",
+      "  0/50 [>---------------------------]   0%#{EOL}",
+      " 25/50 [==============>-------------]  50%#{EOL}",
       " 50/50 [============================] 100%",
     )
   end
@@ -631,7 +631,7 @@ struct ProgressBarTest < ASPEC::TestCase
 
     self.assert_output(
       output,
-      "    0 [>---------------------------]#{ACON::System::EOL}",
+      "    0 [>---------------------------]#{EOL}",
       "    1 [->--------------------------]",
     )
   end
@@ -1109,7 +1109,7 @@ struct ProgressBarTest < ASPEC::TestCase
       "Processing \"foobar\"...",
       "\x1B[1G\x1B[2K\x1B[1A",
       self.generate_output(""),
-      "Foo!#{ACON::System::EOL}",
+      "Foo!#{EOL}",
       self.generate_output("[--->------------------------]"),
       "\nProcessing \"foobar\"...",
       self.generate_output("[----->----------------------]\nProcessing \"foobar\"..."),

--- a/src/components/console/spec/helper/progress_indicator_spec.cr
+++ b/src/components/console/spec/helper/progress_indicator_spec.cr
@@ -41,11 +41,11 @@ struct ProgressIndicatorTest < ASPEC::TestCase
       self.generate_output(" \\ Advancing..."),
       self.generate_output(" | Advancing..."),
       self.generate_output(" | Done..."),
-      ACON::System::EOL,
+      EOL,
       self.generate_output(" - Starting Again..."),
       self.generate_output(" \\ Starting Again..."),
       self.generate_output(" \\ Done Again..."),
-      ACON::System::EOL,
+      EOL,
     )
   end
 
@@ -62,9 +62,9 @@ struct ProgressIndicatorTest < ASPEC::TestCase
 
     self.assert_output(
       output,
-      " Starting...#{ACON::System::EOL}",
-      " Midway...#{ACON::System::EOL}",
-      " Done...#{ACON::System::EOL}#{ACON::System::EOL}",
+      " Starting...#{EOL}",
+      " Midway...#{EOL}",
+      " Done...#{EOL}#{EOL}",
     )
   end
 

--- a/src/components/console/spec/helper/table_spec.cr
+++ b/src/components/console/spec/helper/table_spec.cr
@@ -4,7 +4,7 @@ struct TableSpec < ASPEC::TestCase
   @output : IO
 
   protected def get_table_contents(table_name : String) : String
-    File.read(File.join __DIR__, "..", "fixtures", "helper", "table", "#{table_name}.txt") # .gsub(ACON::System::EOL, "\n")
+    File.read(File.join __DIR__, "..", "fixtures", "helper", "table", "#{table_name}.txt") # .gsub(EOL, "\n")
   end
 
   def initialize
@@ -51,7 +51,7 @@ struct TableSpec < ASPEC::TestCase
       .style(style)
       .render
 
-    self.output_content(output).should eq expected.gsub ACON::System::EOL, "\n"
+    self.output_content(output).should eq expected.gsub EOL, "\n"
   end
 
   def render_provider : Hash
@@ -970,7 +970,7 @@ struct TableSpec < ASPEC::TestCase
       .style(style)
       .render
 
-    self.output_content(output).should eq expected.gsub ACON::System::EOL, "\n"
+    self.output_content(output).should eq expected.gsub EOL, "\n"
   end
 
   def title_provider : Tuple
@@ -1098,7 +1098,7 @@ struct TableSpec < ASPEC::TestCase
       .horizontal
       .render
 
-    self.output_content(output).should eq expected.gsub ACON::System::EOL, "\n"
+    self.output_content(output).should eq expected.gsub EOL, "\n"
   end
 
   def horizontal_provider : Tuple
@@ -1163,7 +1163,7 @@ struct TableSpec < ASPEC::TestCase
       .vertical
       .render
 
-    self.output_content(output).should eq expected.gsub ACON::System::EOL, "\n"
+    self.output_content(output).should eq expected.gsub EOL, "\n"
   end
 
   def vertical_provider : Hash
@@ -1493,6 +1493,6 @@ struct TableSpec < ASPEC::TestCase
   end
 
   private def normalize(input : String) : String
-    input.gsub ACON::System::EOL, "\n"
+    input.gsub EOL, "\n"
   end
 end

--- a/src/components/console/spec/output/console_section_output_spec.cr
+++ b/src/components/console/spec/output/console_section_output_spec.cr
@@ -19,10 +19,10 @@ struct ConsoleSectionOutputTest < ASPEC::TestCase
     sections = Array(ACON::Output::Section).new
     output = ACON::Output::Section.new @io, sections, :normal, true, ACON::Formatter::Output.new
 
-    output.puts "Foo#{ACON::System::EOL}Bar"
+    output.puts "Foo#{EOL}Bar"
     output.clear
 
-    @io.to_s.should eq "Foo#{ACON::System::EOL}Bar#{ACON::System::EOL}\e[2A\e[0J"
+    @io.to_s.should eq "Foo#{EOL}Bar#{EOL}\e[2A\e[0J"
   end
 
   def test_clear_number_of_lines : Nil
@@ -32,7 +32,7 @@ struct ConsoleSectionOutputTest < ASPEC::TestCase
     output.puts "Foo\nBar\nBaz\nFooBar"
     output.clear 2
 
-    @io.to_s.should eq "Foo\nBar\nBaz\nFooBar#{ACON::System::EOL}\e[2A\e[0J"
+    @io.to_s.should eq "Foo\nBar\nBaz\nFooBar#{EOL}\e[2A\e[0J"
   end
 
   def test_clear_number_more_than_current_size : Nil
@@ -42,7 +42,7 @@ struct ConsoleSectionOutputTest < ASPEC::TestCase
     output.puts "Foo"
     output.clear 2
 
-    @io.to_s.should eq "Foo#{ACON::System::EOL}\e[2A\e[0J"
+    @io.to_s.should eq "Foo#{EOL}\e[2A\e[0J"
   end
 
   def test_clear_number_of_lines_multiple_sections : Nil
@@ -55,7 +55,7 @@ struct ConsoleSectionOutputTest < ASPEC::TestCase
     output2.clear 1
     output1.puts "Baz"
 
-    @io.to_s.should eq "Foo#{ACON::System::EOL}Bar#{ACON::System::EOL}\e[1A\e[0J\e[1A\e[0JBaz#{ACON::System::EOL}Foo#{ACON::System::EOL}"
+    @io.to_s.should eq "Foo#{EOL}Bar#{EOL}\e[1A\e[0J\e[1A\e[0JBaz#{EOL}Foo#{EOL}"
   end
 
   def test_clear_number_of_lines_multiple_sections_preserves_empty_lines : Nil
@@ -63,11 +63,11 @@ struct ConsoleSectionOutputTest < ASPEC::TestCase
     output1 = ACON::Output::Section.new @io, sections, :normal, true, ACON::Formatter::Output.new
     output2 = ACON::Output::Section.new @io, sections, :normal, true, ACON::Formatter::Output.new
 
-    output2.puts "#{ACON::System::EOL}foo"
+    output2.puts "#{EOL}foo"
     output2.clear 1
     output1.puts "bar"
 
-    @io.to_s.should eq "#{ACON::System::EOL}foo#{ACON::System::EOL}\e[1A\e[0J\e[1A\e[0Jbar#{ACON::System::EOL}#{ACON::System::EOL}"
+    @io.to_s.should eq "#{EOL}foo#{EOL}\e[1A\e[0J\e[1A\e[0Jbar#{EOL}#{EOL}"
   end
 
   def test_clear_with_question : Nil
@@ -81,7 +81,7 @@ struct ConsoleSectionOutputTest < ASPEC::TestCase
     ACON::Helper::Question.new.ask input, output, ACON::Question(String?).new("What's your favorite superhero?", nil)
     output.clear
 
-    @io.to_s.should eq "What's your favorite superhero?#{ACON::System::EOL}\e[2A\e[0J"
+    @io.to_s.should eq "What's your favorite superhero?#{EOL}\e[2A\e[0J"
   end
 
   def test_clear_after_overwrite_clear_correct_number_of_lines : Nil
@@ -91,7 +91,7 @@ struct ConsoleSectionOutputTest < ASPEC::TestCase
     output = ACON::Output::Section.new @io, sections, :normal, true, ACON::Formatter::Output.new
 
     output.overwrite "foo"
-    expected << "foo" << ACON::System::EOL
+    expected << "foo" << EOL
 
     output.clear
     expected << "\e[1A\e[0J"
@@ -106,17 +106,17 @@ struct ConsoleSectionOutputTest < ASPEC::TestCase
     output.puts "Foo"
     output.overwrite "Bar"
 
-    @io.to_s.should eq "Foo#{ACON::System::EOL}\e[1A\e[0JBar#{ACON::System::EOL}"
+    @io.to_s.should eq "Foo#{EOL}\e[1A\e[0JBar#{EOL}"
   end
 
   def test_overwrite_multiple_lines : Nil
     sections = Array(ACON::Output::Section).new
     output = ACON::Output::Section.new @io, sections, :normal, true, ACON::Formatter::Output.new
 
-    output.puts "Foo#{ACON::System::EOL}Bar#{ACON::System::EOL}Baz"
+    output.puts "Foo#{EOL}Bar#{EOL}Baz"
     output.overwrite "Bar"
 
-    @io.to_s.should eq "Foo#{ACON::System::EOL}Bar#{ACON::System::EOL}Baz#{ACON::System::EOL}\e[3A\e[0JBar#{ACON::System::EOL}"
+    @io.to_s.should eq "Foo#{EOL}Bar#{EOL}Baz#{EOL}\e[3A\e[0JBar#{EOL}"
   end
 
   def test_overwrite_multiple_section_output : Nil
@@ -130,7 +130,7 @@ struct ConsoleSectionOutputTest < ASPEC::TestCase
     output1.overwrite "Baz"
     output2.overwrite "Foobar"
 
-    @io.to_s.should eq "Foo#{ACON::System::EOL}Bar#{ACON::System::EOL}\e[2A\e[0JBar#{ACON::System::EOL}\e[1A\e[0JBaz#{ACON::System::EOL}Bar#{ACON::System::EOL}\e[1A\e[0JFoobar#{ACON::System::EOL}"
+    @io.to_s.should eq "Foo#{EOL}Bar#{EOL}\e[2A\e[0JBar#{EOL}\e[1A\e[0JBaz#{EOL}Bar#{EOL}\e[1A\e[0JFoobar#{EOL}"
   end
 
   def test_max_height : Nil
@@ -142,23 +142,23 @@ struct ConsoleSectionOutputTest < ASPEC::TestCase
 
     # Fill the section
     output.puts({"One", "Two", "Three"})
-    expected << "One" << ACON::System::EOL << "Two" << ACON::System::EOL << "Three" << ACON::System::EOL
+    expected << "One" << EOL << "Two" << EOL << "Three" << EOL
 
     # Cause overflow that'll redraw whole section, without the first line
     output.puts "Four"
     expected << "\e[3A\e[0J"
-    expected << "Two" << ACON::System::EOL << "Three" << ACON::System::EOL << "Four" << ACON::System::EOL
+    expected << "Two" << EOL << "Three" << EOL << "Four" << EOL
 
     # Cause overflow with multiple new lines at once
-    output.puts "Five#{ACON::System::EOL}Six"
+    output.puts "Five#{EOL}Six"
     expected << "\e[3A\e[0J"
-    expected << "Four" << ACON::System::EOL << "Five" << ACON::System::EOL << "Six" << ACON::System::EOL
+    expected << "Four" << EOL << "Five" << EOL << "Six" << EOL
 
     # Reset line height that'll redraw whole section, displaying all lines
     output.max_height = nil
     expected << "\e[3A\e[0J"
-    expected << "One" << ACON::System::EOL << "Two" << ACON::System::EOL << "Three" << ACON::System::EOL
-    expected << "Four" << ACON::System::EOL << "Five" << ACON::System::EOL << "Six" << ACON::System::EOL
+    expected << "One" << EOL << "Two" << EOL << "Three" << EOL
+    expected << "Four" << EOL << "Five" << EOL << "Six" << EOL
 
     @io.to_s.should eq expected.to_s
   end
@@ -175,22 +175,22 @@ struct ConsoleSectionOutputTest < ASPEC::TestCase
 
     # Fill the first section
     output1.puts({"One", "Two", "Three"})
-    expected << "One" << ACON::System::EOL << "Two" << ACON::System::EOL << "Three" << ACON::System::EOL
+    expected << "One" << EOL << "Two" << EOL << "Three" << EOL
 
     # Fill the second section
     output2.puts({"One", "Two", "Three"})
-    expected << "One" << ACON::System::EOL << "Two" << ACON::System::EOL << "Three" << ACON::System::EOL
+    expected << "One" << EOL << "Two" << EOL << "Three" << EOL
 
     # Cause overflow on second section that'll redraw whole section, without the first line
     output2.puts "Four"
     expected << "\e[3A\e[0J"
-    expected << "Two" << ACON::System::EOL << "Three" << ACON::System::EOL << "Four" << ACON::System::EOL
+    expected << "Two" << EOL << "Three" << EOL << "Four" << EOL
 
     # Cause overflow on first section that'll redraw whole section, without the first line
-    output1.puts "Four#{ACON::System::EOL}Five#{ACON::System::EOL}Six"
+    output1.puts "Four#{EOL}Five#{EOL}Six"
     expected << "\e[6A\e[0J"
-    expected << "Four" << ACON::System::EOL << "Five" << ACON::System::EOL << "Six" << ACON::System::EOL
-    expected << "Two" << ACON::System::EOL << "Three" << ACON::System::EOL << "Four" << ACON::System::EOL
+    expected << "Four" << EOL << "Five" << EOL << "Six" << EOL
+    expected << "Two" << EOL << "Three" << EOL << "Four" << EOL
 
     @io.to_s.should eq expected.to_s
   end
@@ -205,11 +205,11 @@ struct ConsoleSectionOutputTest < ASPEC::TestCase
     # Fill the section
     output.puts({"One", "Two"})
     output.print "Three"
-    expected << "One" << ACON::System::EOL << "Two" << ACON::System::EOL << "Three" << ACON::System::EOL
+    expected << "One" << EOL << "Two" << EOL << "Three" << EOL
 
     # Append text to the last line
     output.print " and Four"
-    expected << "\e[1A\e[0J" << "Three and Four" << ACON::System::EOL
+    expected << "\e[1A\e[0J" << "Three and Four" << EOL
 
     @io.to_s.should eq expected.to_s
   end
@@ -218,10 +218,10 @@ struct ConsoleSectionOutputTest < ASPEC::TestCase
     sections = Array(ACON::Output::Section).new
     output = ACON::Output::Section.new @io, sections, :normal, true, ACON::Formatter::Output.new
 
-    output.print "Foo#{ACON::System::EOL}"
+    output.print "Foo#{EOL}"
     output.print "Bar"
 
-    @io.to_s.should eq "Foo#{ACON::System::EOL}Bar#{ACON::System::EOL}"
+    @io.to_s.should eq "Foo#{EOL}Bar#{EOL}"
   end
 
   def test_write_multiple_sections_output_without_new_lines : Nil
@@ -232,28 +232,28 @@ struct ConsoleSectionOutputTest < ASPEC::TestCase
     output2 = ACON::Output::Section.new @io, sections, :normal, true, ACON::Formatter::Output.new
 
     output1.print "Foo"
-    expected << "Foo" << ACON::System::EOL
+    expected << "Foo" << EOL
 
     output2.puts "Bar"
-    expected << "Bar" << ACON::System::EOL
+    expected << "Bar" << EOL
 
     output1.puts " is not foo."
-    expected << "\e[2A\e[0JFoo is not foo." << ACON::System::EOL << "Bar" << ACON::System::EOL
+    expected << "\e[2A\e[0JFoo is not foo." << EOL << "Bar" << EOL
 
     output2.print "Baz"
-    expected << "Baz" << ACON::System::EOL
+    expected << "Baz" << EOL
 
     output2.print "bar"
-    expected << "\e[1A\e[0JBazbar" << ACON::System::EOL
+    expected << "\e[1A\e[0JBazbar" << EOL
 
     output2.puts ""
-    expected << "\e[1A\e[0JBazbar" << ACON::System::EOL
+    expected << "\e[1A\e[0JBazbar" << EOL
 
     output2.puts ""
-    expected << ACON::System::EOL
+    expected << EOL
 
     output2.puts "Done."
-    expected << "Done." << ACON::System::EOL
+    expected << "Done." << EOL
 
     @io.to_s.should eq expected.to_s
   end

--- a/src/components/console/spec/output/io_spec.cr
+++ b/src/components/console/spec/output/io_spec.cr
@@ -14,6 +14,6 @@ struct IOTest < ASPEC::TestCase
   def test_do_write : Nil
     output = ACON::Output::IO.new @io
     output.puts "foo"
-    output.to_s.should eq "foo#{ACON::System::EOL}"
+    output.to_s.should eq "foo#{EOL}"
   end
 end

--- a/src/components/console/spec/style/athena_style_spec.cr
+++ b/src/components/console/spec/style/athena_style_spec.cr
@@ -18,7 +18,7 @@ struct AthenaStyleTest < ASPEC::TestCase
 
   private def assert_file_equals_string(filepath : String, string : String, *, file : String = __FILE__, line : Int32 = __LINE__) : Nil
     normalized_path = File.join __DIR__, "..", "fixtures", filepath
-    string.should match(Regex.new(File.read(normalized_path).gsub ACON::System::EOL, "\n")), file: file, line: line
+    string.should match(Regex.new(File.read(normalized_path).gsub EOL, "\n")), file: file, line: line
   end
 
   def test_error_style : Nil
@@ -29,7 +29,7 @@ struct AthenaStyleTest < ASPEC::TestCase
     style = ACON::Style::Athena.new ACON::Input::Hash.new({} of String => String), output
     style.error_style.puts "foo"
 
-    io.to_s.should eq "foo#{ACON::System::EOL}"
+    io.to_s.should eq "foo#{EOL}"
   end
 
   def test_error_style_non_console_output : Nil
@@ -38,7 +38,7 @@ struct AthenaStyleTest < ASPEC::TestCase
     style = ACON::Style::Athena.new ACON::Input::Hash.new({} of String => String), output
     style.error_style.puts "foo"
 
-    io.to_s.should eq "foo#{ACON::System::EOL}"
+    io.to_s.should eq "foo#{EOL}"
   end
 
   @[DataProvider("output_provider")]

--- a/src/components/console/src/athena-console.cr
+++ b/src/components/console/src/athena-console.cr
@@ -131,15 +131,4 @@ module Athena::Console
 
   # Contains types related to lazily loading commands.
   module Loader; end
-
-  # :nodoc:
-  #
-  # TODO: Remove this in favor of `::System::EOL` when/if https://github.com/crystal-lang/crystal/pull/11303 is released.
-  module System
-    EOL = {% if flag? :windows %}
-            "\r\n"
-          {% else %}
-            "\n"
-          {% end %}
-  end
 end

--- a/src/components/console/src/commands/complete.cr
+++ b/src/components/console/src/commands/complete.cr
@@ -163,7 +163,7 @@ class Athena::Console::Commands::Complete < Athena::Console::Command
     command_name = Path.new(PROGRAM_NAME).basename
     File.write(
       "#{Dir.tempdir}/athena_#{command_name}.log",
-      "#{messages.join(ACON::System::EOL)}#{ACON::System::EOL}",
+      "#{messages.join(EOL)}#{EOL}",
       mode: "a"
     )
   end

--- a/src/components/console/src/helper/progress_bar.cr
+++ b/src/components/console/src/helper/progress_bar.cr
@@ -775,7 +775,7 @@ class Athena::Console::Helper::ProgressBar
         end
       end
     elsif @step > 0
-      message = "#{ACON::System::EOL}#{message}"
+      message = "#{EOL}#{message}"
     end
 
     @previous_message = original_message

--- a/src/components/console/src/output/io.cr
+++ b/src/components/console/src/output/io.cr
@@ -16,13 +16,13 @@ class Athena::Console::Output::IO < Athena::Console::Output
   end
 
   protected def do_write(message : String, new_line : Bool) : Nil
-    message += ACON::System::EOL if new_line
+    message += EOL if new_line
 
     @io.print message
   end
 
   private def io_do_write(message : String, new_line : Bool) : Nil
-    message += ACON::System::EOL if new_line
+    message += EOL if new_line
 
     @io.print message
   end

--- a/src/components/console/src/output/section.cr
+++ b/src/components/console/src/output/section.cr
@@ -103,7 +103,7 @@ class Athena::Console::Output::Section < Athena::Console::Output::IO
 
   protected def add_content(input : String, new_line : Bool = true) : Int32
     width = @terminal.width
-    lines = input.split ACON::System::EOL, remove_empty: false
+    lines = input.split EOL, remove_empty: false
     lines_added = 0
     count = lines.size - 1
 
@@ -112,7 +112,7 @@ class Athena::Console::Output::Section < Athena::Console::Output::IO
       # - every line that is not the last line
       # - if new_line is required, also add it to the last line
       if idx < count || new_line
-        line += ACON::System::EOL
+        line += EOL
       end
 
       # Skip line if there is no text (or new line)
@@ -120,7 +120,7 @@ class Athena::Console::Output::Section < Athena::Console::Output::IO
 
       # For the first line, check if the previous line (last entry of @content) needs to be continued
       # I.e. does not end with a line break
-      if idx == 0 && @content[-1]?.try { |l| !l.ends_with? ACON::System::EOL }
+      if idx == 0 && @content[-1]?.try { |l| !l.ends_with? EOL }
         # Deduct the line count of the previous line
         w = (self.get_display_width(@content[-1]) / width).ceil.to_i
         @lines -= w.zero? ? 1 : w
@@ -144,7 +144,7 @@ class Athena::Console::Output::Section < Athena::Console::Output::IO
   end
 
   protected def do_write(message : String, new_line : Bool) : Nil
-    if !new_line && message.ends_with? ACON::System::EOL
+    if !new_line && message.ends_with? EOL
       message = message.chomp
       new_line = true
     end
@@ -157,7 +157,7 @@ class Athena::Console::Output::Section < Athena::Console::Output::IO
 
     # Check if the previous line (last entry of @content) needs to be continued
     # i.e. does not end with a line break. In which case, it needs to be erased first
-    lines_to_clear = (last_line = @content[-1]? || "").presence.try { |l| !l.ends_with?(ACON::System::EOL) } ? 1 : 0
+    lines_to_clear = (last_line = @content[-1]? || "").presence.try { |l| !l.ends_with?(EOL) } ? 1 : 0
     delete_last_line = lines_to_clear == 1
 
     lines_added = self.add_content message, new_line
@@ -196,8 +196,8 @@ class Athena::Console::Output::Section < Athena::Console::Output::IO
       number_of_lines_to_clear += (max_height = section.max_height) ? Math.min(section.lines, max_height) : section.lines
 
       unless (section_content = section.visible_content).empty?
-        unless section_content.ends_with? ACON::System::EOL
-          section_content = "#{section_content}#{ACON::System::EOL}"
+        unless section_content.ends_with? EOL
+          section_content = "#{section_content}#{EOL}"
         end
 
         erased_content << section_content

--- a/src/components/console/src/output/sized_buffer.cr
+++ b/src/components/console/src/output/sized_buffer.cr
@@ -23,7 +23,7 @@ class Athena::Console::Output::SizedBuffer < Athena::Console::Output
   protected def do_write(message : String, new_line : Bool) : Nil
     @buffer += message
 
-    @buffer += System::EOL if new_line
+    @buffer += EOL if new_line
 
     @buffer = @buffer.chars.last(@max_length).join
   end

--- a/src/components/console/src/spec.cr
+++ b/src/components/console/src/spec.cr
@@ -20,7 +20,7 @@ module Athena::Console::Spec
       output = output.to_s
 
       if normalize
-        output = output.gsub System::EOL, "\n"
+        output = output.gsub EOL, "\n"
       end
 
       output
@@ -34,7 +34,7 @@ module Athena::Console::Spec
       output = self.output.as(ACON::Output::ConsoleOutput).error_output.to_s
 
       if normalize
-        output = output.gsub System::EOL, "\n"
+        output = output.gsub EOL, "\n"
       end
 
       output
@@ -88,7 +88,7 @@ module Athena::Console::Spec
       input_stream = IO::Memory.new
 
       inputs.each do |input|
-        input_stream << "#{input}#{System::EOL}"
+        input_stream << "#{input}#{EOL}"
       end
 
       input_stream.rewind

--- a/src/components/console/src/style/athena.cr
+++ b/src/components/console/src/style/athena.cr
@@ -50,7 +50,7 @@ class Athena::Console::Style::Athena < Athena::Console::Style::Output
 
     if @input.interactive?
       self.new_line
-      @buffered_output.print System::EOL
+      @buffered_output.print EOL
     end
 
     answer
@@ -248,7 +248,7 @@ class Athena::Console::Style::Athena < Athena::Console::Style::Output
   # :inherit:
   def new_line(count : Int32 = 1) : Nil
     super
-    @buffered_output.print System::EOL * count
+    @buffered_output.print EOL * count
   end
 
   # :inherit:
@@ -389,7 +389,7 @@ class Athena::Console::Style::Athena < Athena::Console::Style::Output
   end
 
   private def auto_prepend_block : Nil
-    chars = @buffered_output.fetch.gsub System::EOL, "\n"
+    chars = @buffered_output.fetch.gsub EOL, "\n"
 
     if chars.empty?
       return self.new_line
@@ -422,7 +422,7 @@ class Athena::Console::Style::Athena < Athena::Console::Style::Output
     messages.each_with_index do |message, idx|
       message = ACON::Formatter::Output.escape message if escape
 
-      lines.concat output_wrapper.wrap(message, @line_length - prefix_length - indent_length, ACON::System::EOL).split ACON::System::EOL
+      lines.concat output_wrapper.wrap(message, @line_length - prefix_length - indent_length, EOL).split EOL
 
       lines << "" if messages.size > 1 && idx < (messages.size - 1)
     end

--- a/src/components/console/src/style/output.cr
+++ b/src/components/console/src/style/output.cr
@@ -31,7 +31,7 @@ abstract class Athena::Console::Style::Output
 
   # :inherit:
   def new_line(count : Int32 = 1) : Nil
-    @output.print System::EOL * count
+    @output.print EOL * count
   end
 
   # Creates and returns an `ACON::Helper::ProgressBar`, optionally with the provided *max* amount of steps.

--- a/src/components/framework/shard.yml
+++ b/src/components/framework/shard.yml
@@ -2,7 +2,7 @@ name: athena
 
 version: 0.18.2
 
-crystal: ~> 1.8
+crystal: ~> 1.11
 
 license: MIT
 

--- a/src/components/framework/spec/controller_spec.cr
+++ b/src/components/framework/spec/controller_spec.cr
@@ -8,7 +8,7 @@ describe ATH::Controller do
 
       response.status.should eq HTTP::Status::OK
       response.headers["content-type"].should eq "text/html"
-      response.content.should eq "Greetings, TEST!#{ATH::System::EOL}"
+      response.content.should eq "Greetings, TEST!#{EOL}"
     end
 
     it "creates a proper response for the template with a layout" do
@@ -17,7 +17,7 @@ describe ATH::Controller do
 
       response.status.should eq HTTP::Status::OK
       response.headers["content-type"].should eq "text/html"
-      response.content.should eq "<h1>Content:</h1> Greetings, TEST!#{ATH::System::EOL}"
+      response.content.should eq "<h1>Content:</h1> Greetings, TEST!#{EOL}"
     end
   end
 

--- a/src/components/framework/src/athena.cr
+++ b/src/components/framework/src/athena.cr
@@ -130,17 +130,6 @@ module Athena::Framework
   # See each command class for more information.
   module Commands; end
 
-  # :nodoc:
-  #
-  # TODO: Remove this in favor of `::System::EOL` when/if https://github.com/crystal-lang/crystal/pull/11303 is released.
-  module System
-    EOL = {% if flag? :windows %}
-            "\r\n"
-          {% else %}
-            "\n"
-          {% end %}
-  end
-
   # Runs an `HTTP::Server` listening on the given *port* and *host*.
   #
   # ```


### PR DESCRIPTION
* Require Crystal `~> 1.11`