### PR TITLE
Add `array_of` DI extension macro

### DIFF
--- a/src/components/dependency_injection/spec/compiler_passes/merge_configs_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_configs_spec.cr
@@ -16,7 +16,7 @@ describe ADI::ServiceContainer::MergeConfigs do
           module Defaults
             include ADI::Extension::Schema
 
-            property? allow_credentials : Bool = false
+            property allow_credentials : Bool = false
             property allow_origin : Array(String) = [] of String
           end
         end

--- a/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
@@ -315,9 +315,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
         string name = "fred"
         string? nilable
 
-        color_type : Color
-        color_sym : Color
-        value : Hash(String, String)
+        type_of color_type : Color
+        type_of color_sym : Color
+        type_of value : Hash(String, String)
       end
 
       ADI.register_extension "blah", Schema
@@ -372,7 +372,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
       module Schema
         include ADI::Extension::Schema
 
-        array_of foo, Int32
+        array foo : Int32
       end
 
       ADI.register_extension "test", Schema

--- a/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
@@ -16,8 +16,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
           module Schema
             include ADI::Extension::Schema
 
-            int id
-            string name
+            property id : Int32
+            property name : String
           end
 
           ADI.register_extension "test", Schema
@@ -35,7 +35,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
           module Schema
             include ADI::Extension::Schema
 
-            array foo : Int32
+            property foo : Array(Int32)
           end
 
           ADI.register_extension "test", Schema
@@ -53,7 +53,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
           module Schema
             include ADI::Extension::Schema
 
-            array foo : Int32
+            property foo : Array(Int32)
           end
 
           ADI.register_extension "test", Schema
@@ -71,7 +71,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
           module Schema
             include ADI::Extension::Schema
 
-            bigint id
+            property id : Int64
           end
 
           ADI.register_extension "test", Schema
@@ -98,8 +98,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
               module Defaults
                 include ADI::Extension::Schema
 
-                string name
-                int id
+                property name : String
+                property id : Int32
               end
             end
           end
@@ -129,7 +129,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
               module Defaults
                 include ADI::Extension::Schema
 
-                array foo : Int32
+                property foo : Array(Int32)
               end
             end
           end
@@ -159,7 +159,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
               module Defaults
                 include ADI::Extension::Schema
 
-                array foo : Int32
+                property foo : Array(Int32)
               end
             end
           end
@@ -189,7 +189,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
               module Defaults
                 include ADI::Extension::Schema
 
-                array foo : Int32
+                property foo : Array(Int32)
               end
             end
           end
@@ -219,7 +219,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
               module Defaults
                 include ADI::Extension::Schema
 
-                array foo : Int32
+                property foo : Array(Int32)
               end
             end
           end
@@ -249,7 +249,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
               module Defaults
                 include ADI::Extension::Schema
 
-                int id
+                property id : Int32
               end
             end
           end
@@ -287,7 +287,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
         module Schema
           include ADI::Extension::Schema
 
-          int id
+          property id : Int32
         end
 
         ADI.register_extension "test", Schema
@@ -310,14 +310,13 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
 
         ID = 10.0
 
-        int id
-        float float = Schema::ID
-        string name = "fred"
-        string? nilable
-
-        type_of color_type : Color
-        type_of color_sym : Color
-        type_of value : Hash(String, String)
+        property id : Int32
+        property float : Float64 = Schema::ID
+        property name : String = "fred"
+        property nilable : String?
+        property color_type : Color
+        property color_sym : Color
+        property value : Hash(String, String)
       end
 
       ADI.register_extension "blah", Schema
@@ -352,7 +351,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
       module Schema
         include ADI::Extension::Schema
 
-        int id = 123
+        property id : Int32 = 123
       end
 
       ADI.register_extension "blah", Schema
@@ -372,7 +371,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
       module Schema
         include ADI::Extension::Schema
 
-        array foo : Int32
+        property foo : Array(Int32)
       end
 
       ADI.register_extension "test", Schema
@@ -398,7 +397,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
       module Schema
         include ADI::Extension::Schema
 
-        array foo : Int32 | String = [] of NoReturn
+        property foo : Array(Int32 | String) = [] of NoReturn
       end
 
       ADI.register_extension "test", Schema
@@ -419,7 +418,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
       module Schema
         include ADI::Extension::Schema
 
-        array foo : Int32 | String = [] of NoReturn
+        property foo : Array(Int32 | String) = [] of NoReturn
       end
 
       ADI.register_extension "test", Schema
@@ -448,13 +447,13 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
         module One
           include ADI::Extension::Schema
 
-          bool enabled = false
+          property enabled : Bool = false
         end
 
         module Two
           include ADI::Extension::Schema
 
-          bool enabled = false
+          property enabled : Bool = false
         end
       end
 
@@ -479,19 +478,19 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
         module One
           include ADI::Extension::Schema
 
-          bool enabled = false
-          int id
+          property enabled : Bool = false
+          property id : Int32
         end
 
         module Two
           include ADI::Extension::Schema
 
-          bool enabled = false
+          property enabled : Bool = false
 
           module Three
             include ADI::Extension::Schema
 
-            bool enabled = false
+            property enabled : Bool = false
           end
         end
       end

--- a/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
@@ -8,7 +8,7 @@ private def assert_error(message : String, code : String, *, line : Int32 = __LI
   CR
 end
 
-describe ADI::ServiceContainer::MergeExtensionConfig do
+describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
   describe "compiler errors" do
     describe "root level" do
       it "errors if a configuration value has the incorrect type" do
@@ -16,8 +16,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
           module Schema
             include ADI::Extension::Schema
 
-            property id : Int32
-            property name : String
+            int id
+            string name
           end
 
           ADI.register_extension "test", Schema
@@ -35,7 +35,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
           module Schema
             include ADI::Extension::Schema
 
-            property foo : Array(Int32)
+            array foo : Int32
           end
 
           ADI.register_extension "test", Schema
@@ -53,7 +53,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
           module Schema
             include ADI::Extension::Schema
 
-            property foo : Array(Int32)
+            array foo : Int32
           end
 
           ADI.register_extension "test", Schema
@@ -71,7 +71,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
           module Schema
             include ADI::Extension::Schema
 
-            property id : Int32
+            bigint id
           end
 
           ADI.register_extension "test", Schema
@@ -98,8 +98,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
               module Defaults
                 include ADI::Extension::Schema
 
-                property name : String
-                property id : Int32
+                string name
+                int id
               end
             end
           end
@@ -129,7 +129,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
               module Defaults
                 include ADI::Extension::Schema
 
-                property foo : Array(Int32)
+                array foo : Int32
               end
             end
           end
@@ -159,7 +159,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
               module Defaults
                 include ADI::Extension::Schema
 
-                property foo : Array(Int32)
+                array foo : Int32
               end
             end
           end
@@ -189,7 +189,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
               module Defaults
                 include ADI::Extension::Schema
 
-                property foo : Array(Int32)
+                array foo : Int32
               end
             end
           end
@@ -219,7 +219,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
               module Defaults
                 include ADI::Extension::Schema
 
-                property foo : Array(Int32) = [] of NoReturn
+                array foo : Int32
               end
             end
           end
@@ -249,7 +249,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
               module Defaults
                 include ADI::Extension::Schema
 
-                property id : Int32
+                int id
               end
             end
           end
@@ -287,7 +287,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
         module Schema
           include ADI::Extension::Schema
 
-          property id : Int32
+          int id
         end
 
         ADI.register_extension "test", Schema
@@ -310,13 +310,14 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
 
         ID = 10.0
 
-        property id : Int32
-        property float : Float64 = Schema::ID
-        property name : String = "fred"
-        property nilable : String?
-        property color_type : Color
-        property color_sym : Color
-        property value : Hash(String, String)
+        int id
+        float float = Schema::ID
+        string name = "fred"
+        string? nilable
+
+        color_type : Color
+        color_sym : Color
+        value : Hash(String, String)
       end
 
       ADI.register_extension "blah", Schema
@@ -351,7 +352,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
       module Schema
         include ADI::Extension::Schema
 
-        property id : Int32 = 123
+        int id = 123
       end
 
       ADI.register_extension "blah", Schema
@@ -371,7 +372,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
       module Schema
         include ADI::Extension::Schema
 
-        property foo : Array(Int32)
+        array_of foo, Int32
       end
 
       ADI.register_extension "test", Schema
@@ -397,7 +398,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
       module Schema
         include ADI::Extension::Schema
 
-        property foo : Array(Int32) = [] of NoReturn
+        array foo : Int32 | String = [] of NoReturn
       end
 
       ADI.register_extension "test", Schema
@@ -405,6 +406,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
       macro finished
         macro finished
           it { (\\{{ADI::CONFIG["test"]["foo"]}}).should be_empty }
+          it { \\{{ADI::CONFIG["test"]["foo"].stringify}}.should eq "Array(Int32 | String).new" }
         end
       end
     CR
@@ -417,7 +419,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
       module Schema
         include ADI::Extension::Schema
 
-        property foo : Array(Int32) = [] of NoReturn
+        array foo : Int32 | String = [] of NoReturn
       end
 
       ADI.register_extension "test", Schema
@@ -446,13 +448,13 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
         module One
           include ADI::Extension::Schema
 
-          property? enabled : Bool = false
+          bool enabled = false
         end
 
         module Two
           include ADI::Extension::Schema
 
-          property? enabled : Bool = false
+          bool enabled = false
         end
       end
 
@@ -477,19 +479,19 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
         module One
           include ADI::Extension::Schema
 
-          property? enabled : Bool = false
-          property id : Int32
+          bool enabled = false
+          int id
         end
 
         module Two
           include ADI::Extension::Schema
 
-          property? enabled : Bool = false
+          bool enabled = false
 
           module Three
             include ADI::Extension::Schema
 
-            property? enabled : Bool = false
+            bool enabled = false
           end
         end
       end

--- a/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
@@ -8,7 +8,7 @@ private def assert_error(message : String, code : String, *, line : Int32 = __LI
   CR
 end
 
-describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
+describe ADI::ServiceContainer::MergeExtensionConfig do
   describe "compiler errors" do
     describe "root level" do
       it "errors if a configuration value has the incorrect type" do
@@ -317,6 +317,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
         property color_type : Color
         property color_sym : Color
         property value : Hash(String, String)
+        property regex : Regex
       end
 
       ADI.register_extension "blah", Schema
@@ -326,7 +327,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
           id:    123,
           color_type: Color::Red,
           color_sym: :blue,
-          value: {"id" => "10", "name" => "fred"}
+          value: {"id" => "10", "name" => "fred"},
+          regex: /foo/
         },
       })
 
@@ -339,6 +341,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, focus: true do
           it { \\{{ADI::CONFIG["blah"]["color_type"]}}.should eq Color::Red }
           it { \\{{ADI::CONFIG["blah"]["color_sym"]}}.should eq Color::Blue }
           it { \\{{ADI::CONFIG["blah"]["value"]}}.should eq({"id" => "10", "name" => "fred"}) }
+          it { \\{{ADI::CONFIG["blah"]["regex"]}}.should eq /foo/ }
         end
       end
     CR

--- a/src/components/dependency_injection/src/athena-dependency_injection.cr
+++ b/src/components/dependency_injection/src/athena-dependency_injection.cr
@@ -197,3 +197,19 @@ module Athena::DependencyInjection
     {% ADI::ServiceContainer::EXTENSIONS[name.id.stringify] = schema %}
   end
 end
+
+module Schema
+  include ADI::Extension::Schema
+
+  array_of rules, path : Regex? = nil, stop : Bool = false
+end
+
+ADI.register_extension "test", Schema
+
+ADI.configure({
+  test: {
+    rules: [
+      {path: /foo/, stop: nil},
+    ],
+  },
+})

--- a/src/components/dependency_injection/src/athena-dependency_injection.cr
+++ b/src/components/dependency_injection/src/athena-dependency_injection.cr
@@ -197,3 +197,29 @@ module Athena::DependencyInjection
     {% ADI::ServiceContainer::EXTENSIONS[name.id.stringify] = schema %}
   end
 end
+
+# module Schema
+#   include ADI::Extension::Schema
+
+#   module SubConfig
+#     include ADI::Extension::Schema
+
+#     module Defaults
+#       include ADI::Extension::Schema
+
+#       array foo : Int32
+#     end
+#   end
+# end
+
+# ADI.register_extension "test", Schema
+
+# ADI.configure({
+#   test: {
+#     sub_config: {
+#       defaults: {
+#         foo: [] of String,
+#       },
+#     },
+#   },
+# })

--- a/src/components/dependency_injection/src/athena-dependency_injection.cr
+++ b/src/components/dependency_injection/src/athena-dependency_injection.cr
@@ -197,29 +197,3 @@ module Athena::DependencyInjection
     {% ADI::ServiceContainer::EXTENSIONS[name.id.stringify] = schema %}
   end
 end
-
-# module Schema
-#   include ADI::Extension::Schema
-
-#   module SubConfig
-#     include ADI::Extension::Schema
-
-#     module Defaults
-#       include ADI::Extension::Schema
-
-#       array foo : Int32
-#     end
-#   end
-# end
-
-# ADI.register_extension "test", Schema
-
-# ADI.configure({
-#   test: {
-#     sub_config: {
-#       defaults: {
-#         foo: [] of String,
-#       },
-#     },
-#   },
-# })

--- a/src/components/dependency_injection/src/athena-dependency_injection.cr
+++ b/src/components/dependency_injection/src/athena-dependency_injection.cr
@@ -197,19 +197,3 @@ module Athena::DependencyInjection
     {% ADI::ServiceContainer::EXTENSIONS[name.id.stringify] = schema %}
   end
 end
-
-module Schema
-  include ADI::Extension::Schema
-
-  array_of rules, path : Regex? = nil, stop : Bool = false
-end
-
-ADI.register_extension "test", Schema
-
-ADI.configure({
-  test: {
-    rules: [
-      {path: /foo/, stop: nil},
-    ],
-  },
-})

--- a/src/components/dependency_injection/src/compiler_passes/merge_extension_config.cr
+++ b/src/components/dependency_injection/src/compiler_passes/merge_extension_config.cr
@@ -143,6 +143,8 @@ module Athena::DependencyInjection::ServiceContainer::MergeExtensionConfig
               extension_config_for_current_property[prop["name"]] = resolved_value
             end
           end
+
+          pp CONFIG
         %}
       {% end %}
     end

--- a/src/components/dependency_injection/src/compiler_passes/merge_extension_config.cr
+++ b/src/components/dependency_injection/src/compiler_passes/merge_extension_config.cr
@@ -143,8 +143,6 @@ module Athena::DependencyInjection::ServiceContainer::MergeExtensionConfig
               extension_config_for_current_property[prop["name"]] = resolved_value
             end
           end
-
-          pp EXTENSION_SCHEMA_PROPERTIES_MAP
         %}
       {% end %}
     end

--- a/src/components/dependency_injection/src/compiler_passes/merge_extension_config.cr
+++ b/src/components/dependency_injection/src/compiler_passes/merge_extension_config.cr
@@ -143,8 +143,6 @@ module Athena::DependencyInjection::ServiceContainer::MergeExtensionConfig
               extension_config_for_current_property[prop["name"]] = resolved_value
             end
           end
-
-          pp CONFIG
         %}
       {% end %}
     end

--- a/src/components/dependency_injection/src/compiler_passes/merge_extension_config.cr
+++ b/src/components/dependency_injection/src/compiler_passes/merge_extension_config.cr
@@ -50,7 +50,7 @@ module Athena::DependencyInjection::ServiceContainer::MergeExtensionConfig
               obj = ext_options
 
               if ext_path.empty?
-                obj[o.var.id] = o
+                obj[o["name"]] = o
                 EXTENSION_SCHEMA_PROPERTIES_MAP[ext_name] << {o, ext_path}
               else
                 ext_path.each_with_index do |k, idx|
@@ -58,7 +58,7 @@ module Athena::DependencyInjection::ServiceContainer::MergeExtensionConfig
                   obj = obj[k]
 
                   if idx == ext_path.size - 1
-                    obj[o.var.id] = o
+                    obj[o["name"]] = o
                     EXTENSION_SCHEMA_PROPERTIES_MAP[ext_name] << {o, ext_path}
                   end
                 end
@@ -102,19 +102,19 @@ module Athena::DependencyInjection::ServiceContainer::MergeExtensionConfig
               end
 
               # Then handle any light transformations needed to get the configuration value into the expected format/type
-              if (config_value = extension_config_for_current_property[prop.var.id]) != nil
+              if (config_value = extension_config_for_current_property[prop["name"]]) != nil
                 config_value = config_value.is_a?(Path) ? config_value.resolve : config_value
 
-                resolved_value = if config_value.is_a?(SymbolLiteral) && (type = prop.type.resolve) <= ::Enum
-                                   config_value.raise "Unknown '#{type}' enum member '#{config_value}' for property '#{([ext_name] + ext_path).join('.').id}.#{prop.var.id}'." unless type.constants.any?(&.downcase.id.==(config_value.id))
+                resolved_value = if config_value.is_a?(SymbolLiteral) && (type = prop["type"]) <= ::Enum
+                                   config_value.raise "Unknown '#{type}' enum member '#{config_value}' for property '#{([ext_name] + ext_path).join('.').id}.#{prop["name"]}'." unless type.constants.any?(&.downcase.id.==(config_value.id))
 
                                    # Resolve symbol literals to enum members
                                    config_value = "#{type}.new(#{config_value})".id
-                                 elsif config_value.is_a?(NumberLiteral) && (type = prop.type.resolve) <= ::Enum
+                                 elsif config_value.is_a?(NumberLiteral) && (type = prop["type"]) <= ::Enum
                                    # Resolve enum value to enum members
                                    config_value = "#{type}.new(#{config_value})".id
                                  elsif config_value.is_a?(NamedTupleLiteral)
-                                   p = prop.type.resolve
+                                   p = prop["type"]
 
                                    # Fill in `nil` values to missing nilable NT keys
                                    p.keys.each do |k|
@@ -131,18 +131,20 @@ module Athena::DependencyInjection::ServiceContainer::MergeExtensionConfig
                                  end
               else
                 # Otherwise fall back on the default value of the property
-                resolved_value = if prop.value.is_a?(Nop)
+                resolved_value = if prop["default"].is_a?(Nop)
                                    nil
-                                 elsif prop.value.is_a?(Path)
-                                   prop.value.resolve
+                                 elsif prop["default"].is_a?(Path)
+                                   prop["default"].resolve
                                  else
-                                   prop.value
+                                   prop["default"]
                                  end
               end
 
-              extension_config_for_current_property[prop.var] = resolved_value
+              extension_config_for_current_property[prop["name"]] = resolved_value
             end
           end
+
+          pp EXTENSION_SCHEMA_PROPERTIES_MAP
         %}
       {% end %}
     end

--- a/src/components/dependency_injection/src/compiler_passes/validate_arguments.cr
+++ b/src/components/dependency_injection/src/compiler_passes/validate_arguments.cr
@@ -81,21 +81,33 @@ module Athena::DependencyInjection::ServiceContainer::ValidateArguments
                     values_to_resolve = [{prop["type"], config_value, ext_path + [prop["name"]]}]
 
                     values_to_resolve.each_with_index do |(prop_type, cfv, stack), idx|
-                      resolved_type = if cfv.is_a?(BoolLiteral)
+                      resolved_type = if cfv.nil?
+                                        Nil
+                                      elsif cfv.is_a?(BoolLiteral)
                                         Bool
                                       elsif cfv.is_a?(StringLiteral)
                                         String
                                       elsif cfv.is_a?(SymbolLiteral)
                                         Symbol
+                                      elsif cfv.is_a?(RegexLiteral)
+                                        Regex
                                       elsif cfv.is_a?(ArrayLiteral)
                                         # Fallback on the type of the property if no type was specified
-                                        array_type = (cfv.of || cfv.type) || prop_type.type_vars.first
+                                        if member_map = prop["members"]
+                                          cfv.each_with_index do |v, v_idx|
+                                            values_to_resolve << {member_map, v, stack + [v_idx]}
+                                          end
 
-                                        cfv.each_with_index do |v, v_idx|
-                                          values_to_resolve << {array_type.resolve, v, stack + [v_idx]}
+                                          Array
+                                        else
+                                          array_type = (cfv.of || cfv.type) || prop_type.type_vars.first
+
+                                          cfv.each_with_index do |v, v_idx|
+                                            values_to_resolve << {array_type.resolve, v, stack + [v_idx]}
+                                          end
+
+                                          parse_type("Array(#{array_type})").resolve
                                         end
-
-                                        parse_type("Array(#{array_type})").resolve
                                       elsif cfv.is_a?(NumberLiteral)
                                         kind = cfv.kind
 
@@ -111,6 +123,17 @@ module Athena::DependencyInjection::ServiceContainer::ValidateArguments
                                       elsif cfv.is_a?(TypeNode) || cfv.is_a?(HashLiteral)
                                         cfv
                                       elsif cfv.is_a?(NamedTupleLiteral)
+                                        # The prop type is from an array_of, so we need to fill in defaults
+                                        if prop_type.is_a?(NamedTupleLiteral)
+                                          provided_keys = cfv.keys
+
+                                          prop_type.keys.reject { |k| k.stringify == "__nil" || provided_keys.includes? k }.each do |k|
+                                            decl = prop_type[k]
+
+                                            cfv[k] = decl.value
+                                          end
+                                        end
+
                                         cfv.each do |k, v|
                                           nt_key_type = prop_type[k]
 
@@ -129,15 +152,27 @@ module Athena::DependencyInjection::ServiceContainer::ValidateArguments
                                           elsif k == "__nil"
                                             # no-op
                                           else
-                                            values_to_resolve << {nt_key_type.resolve, v, stack + [k]}
+                                            type = nt_key_type.is_a?(TypeDeclaration) ? nt_key_type.type : nt_key_type
+
+                                            values_to_resolve << {type.resolve, v, stack + [k]}
                                           end
                                         end
 
-                                        missing_keys = prop_type.keys - cfv.keys
+                                        missing_keys = prop_type.keys.reject { |k| k.stringify == "__nil" } - cfv.keys
 
                                         unless missing_keys.empty?
                                           missing_keys.each do |mk|
-                                            unless prop_type[mk].nilable?
+                                            mt = prop_type[mk]
+
+                                            nilable = if mt.is_a?(TypeNode)
+                                                        mt.nilable?
+                                                      elsif mt.is_a?(TypeDeclaration)
+                                                        mt.type.resolve.nilable?
+                                                      else
+                                                        false
+                                                      end
+
+                                            unless nilable
                                               path = "#{stack[0]}"
 
                                               stack[1..].each do |p|
@@ -153,11 +188,10 @@ module Athena::DependencyInjection::ServiceContainer::ValidateArguments
                                           end
                                         end
 
-                                        # TODO: Figure out if there's a way to get a TypeNode reference to the named tuple instance itself.
                                         nil
                                       end
 
-                      unless resolved_type.nil?
+                      if resolved_type
                         values_to_resolve[idx][2] = resolved_type
 
                         # Handles outer most typing issues.
@@ -195,6 +229,8 @@ module Athena::DependencyInjection::ServiceContainer::ValidateArguments
               end
             end
           end
+
+          pp CONFIG
         %}
       {% end %}
     end

--- a/src/components/dependency_injection/src/compiler_passes/validate_arguments.cr
+++ b/src/components/dependency_injection/src/compiler_passes/validate_arguments.cr
@@ -229,8 +229,6 @@ module Athena::DependencyInjection::ServiceContainer::ValidateArguments
               end
             end
           end
-
-          pp CONFIG
         %}
       {% end %}
     end

--- a/src/components/dependency_injection/src/extension.cr
+++ b/src/components/dependency_injection/src/extension.cr
@@ -10,11 +10,11 @@ module Athena::DependencyInjection::Extension::Schema
 
       # Special case: Allow using NoReturn to "inherit" type from the TypeDeclaration for Array types.
       # I.e. to make it so you do not have to retype the type if its long/complex
-      default = if (declaration.type.resolve <= Array &&
+      default = if declaration.type.resolve <= Array &&
                    !declaration.value.is_a?(Nop) &&
                    (array_type = ((declaration.value.of || declaration.value.type))) &&
                    !array_type.is_a?(Nop) &&
-                   array_type.resolve == NoReturn.resolve)
+                   array_type.resolve == NoReturn.resolve
                   "#{declaration.type.id}.new".id
                 else
                   declaration.value


### PR DESCRIPTION
Follow up to https://github.com/athena-framework/athena/issues/332#issuecomment-1933299250, I thought about it and realized there's not much benefit in having the dedicated type macros, just to try and construct the type that you could otherwise get directly off the `TypeDeclaration`.

However, I did see a lot of value in the `array_of` macro as a means of defining an array of anonymous strictly typed objects. Before you had to do this as an array of a named tuple type, but this had some downsides. Mainly that you are unable to define defaults for the property. As such in order to make a key optional, it had to be nilable.

* Add `array_of` macro to `ADI::Extension::Schema`
* Remove `property?`
* Refactors `EXTENSION_SCHEMA_PROPERTIES_MAP` to not use `TypeDeclaration` directly