### PR TITLE
Raise an error if an object fails to serialize

### DIFF
--- a/src/components/framework/spec/controllers/view_controller.cr
+++ b/src/components/framework/spec/controllers/view_controller.cr
@@ -1,5 +1,7 @@
 require "../spec_helper"
 
+private record Unserializable
+
 record JSONSerializableModel, id : Int32, name : String do
   include JSON::Serializable
 end
@@ -14,6 +16,15 @@ end
 
 @[ARTA::Route(path: "view")]
 class ViewController < ATH::Controller
+  @[ARTA::Get("/unserializable")]
+  def unserializable : Unserializable
+    Unserializable.new
+  end
+
+  @[ARTA::Get("/nil")]
+  def nil_return : Nil
+  end
+
   @[ARTA::Get("/json")]
   def json_serializable : JSONSerializableModel
     JSONSerializableModel.new 10, "Bob"

--- a/src/components/framework/spec/view_controller_spec.cr
+++ b/src/components/framework/spec/view_controller_spec.cr
@@ -1,6 +1,16 @@
 require "./spec_helper"
 
 struct ViewControllerTest < ATH::Spec::APITestCase
+  def test_unserializable_object : Nil
+    self.get "/view/unserializable"
+    self.assert_response_has_status :internal_server_error
+  end
+
+  def test_nil : Nil
+    self.get "/view/nil"
+    self.assert_response_has_status :no_content
+  end
+
   def test_json_serializable_object : Nil
     self.get("/view/json").body.should eq %({"id":10,"name":"Bob"})
   end

--- a/src/components/framework/src/exceptions/logic.cr
+++ b/src/components/framework/src/exceptions/logic.cr
@@ -1,0 +1,3 @@
+# Represents a code logic error that should lead directly to a fix in your code.
+class Athena::Framework::Exceptions::Logic < ::Exception
+end

--- a/src/components/framework/src/view/view_handler.cr
+++ b/src/components/framework/src/view/view_handler.cr
@@ -158,7 +158,15 @@ class Athena::Framework::View::ViewHandler
                     athena_serializer_context.add_exclusion_strategy s
                   end
 
-                  @serializer.serialize data, format, athena_serializer_context
+                  serialized_data = @serializer.serialize data, format, athena_serializer_context
+
+                  # If the serialized data is "null", but the data is not `nil`, assume this means the serializer component failed to serialize it,
+                  # raise an error as it is likely the user forgot to include either `JSON::Serializable` or `ASR::Serializable`.
+                  if "null" == serialized_data && !data.nil?
+                    raise ATH::Exceptions::Logic.new "Failed to serialize response body. Did you forget to include either `JSON::Serializable` or `ASR::Serializable`?"
+                  end
+
+                  serialized_data
                 end
     end
 


### PR DESCRIPTION
* Indicates it does not include either `JSON::Serializable` or `ASR::Serializable`

Fixes #351 