### PR TITLE
Enable GH merge queue to trigger CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  merge_group:
   pull_request:
     branches:
       - 'master'


### PR DESCRIPTION
Otherwise was causing the merge queue to kick out PRs due to required checks timing out.