### PR TITLE
Break out compiled specs into their own CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,20 @@ jobs:
           SHARDS_OVERRIDE: shard.dev.yml
       - name: Ameba
         run: ./bin/ameba
-  test:
+  test_compiled:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+      - name: Install Dependencies
+        run: shards install --skip-postinstall --skip-executables
+        env:
+          SHARDS_OVERRIDE: shard.dev.yml
+      - name: Compiled Specs
+        run: ./scripts/test.sh all compiled
+        shell: bash
+  test_unit:
     strategy:
       fail-fast: false
       matrix:
@@ -67,5 +80,5 @@ jobs:
         env:
           SHARDS_OVERRIDE: shard.dev.yml
       - name: Specs
-        run: ./scripts/test.sh
+        run: ./scripts/test.sh all unit
         shell: bash

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,18 +1,35 @@
 #!/usr/bin/env bash
 
-EXIT_CODE=0
 DEFAULT_OPTIONS=(-Dstrict_multi_assign -Dpreview_overload_order --order=random --error-on-warnings)
 CRYSTAL=${CRYSTAL:=crystal}
 
 # Runs the specs for all, or optionally a single component
 #
-# $1 - (optional) component to runs specs, or all if empty
+# $1 - (optional) component name to runs specs for, or "all". Defaults to "all".
+# $2 - (optional) "type" of specs to run: "unit", "compiled", or "all". Defaults to "all".
 
-if [ -n "$1" ]
+COMPONENT=${1-all}
+TYPE=${2-unit}
+
+if [ $TYPE == "unit" ]
 then
-  $CRYSTAL spec "${DEFAULT_OPTIONS[@]}" "src/components/$1/spec"
+  DEFAULT_OPTIONS+=("--tag=~compiled")
+elif [ $TYPE == "compiled" ]
+then
+  DEFAULT_OPTIONS+=("--tag=compiled")
+elif [ $TYPE != "all" ]
+then
+  echo "Second argument must be 'unit', 'compiled', or 'all' got '${2}'."
+  exit 1
+fi
+
+if [ $COMPONENT != "all" ]
+then
+  echo $CRYSTAL spec "${DEFAULT_OPTIONS[@]}" "src/components/$1/spec"
   exit $?
 fi
+
+EXIT_CODE=0
 
 for component in $(find src/components/ -maxdepth 2 -type f -name shard.yml | xargs -I{} dirname {} | sort); do
   echo "::group::$component"

--- a/src/components/console/spec/compiler_spec.cr
+++ b/src/components/console/spec/compiler_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 describe Athena::Console do
-  describe "compiler errors" do
+  describe "compiler errors", tags: "compiled" do
     describe "when a command configured via annotation doesn't have a name" do
       it "non hidden no aliases" do
         ASPEC::Methods.assert_error "Console command 'NoNameCommand' has an 'ACONA::AsCommand' annotation but is missing the commands's name. It was not provided as the first positional argument nor via the 'name' field.", <<-CR

--- a/src/components/dependency_injection/spec/compiler_passes/auto_configure_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/auto_configure_spec.cr
@@ -103,7 +103,7 @@ ADI.auto_configure UnusedInterface5, {tags: [{name: "string_unused_tag5"}]}
 record UnusedTagClient, services : Array(UnusedInterface)
 
 describe ADI::ServiceContainer::AutoConfigure do
-  describe "compiler errors", tags: "compiler" do
+  describe "compiler errors", tags: "compiled" do
     it "errors if the `tags` field is not of a valid type" do
       assert_error "Tags for 'foo' must be an 'ArrayLiteral', got 'NumberLiteral'.", <<-CR
         @[ADI::Register(tags: 123)]

--- a/src/components/dependency_injection/spec/compiler_passes/factory_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/factory_spec.cr
@@ -71,7 +71,7 @@ class InstanceInjectService
 end
 
 describe ADI::ServiceContainer::RegisterServices do
-  describe "compiler errors", tags: "compiler" do
+  describe "compiler errors", tags: "compiled" do
     it "errors if a factory method is an instance method" do
       assert_error "Failed to register service 'foo'. Factory method 'foo' within 'Foo' is an instance method.", <<-CR
         @[ADI::Register(factory: "foo")]

--- a/src/components/dependency_injection/spec/compiler_passes/generic_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/generic_spec.cr
@@ -17,7 +17,7 @@ struct GenericServiceBase(T, B)
 end
 
 describe ADI::ServiceContainer::ResolveGenerics do
-  describe "compiler errors", tags: "compiler" do
+  describe "compiler errors", tags: "compiled" do
     it "errors if the generic service does not have a name." do
       assert_error "Failed to register services for 'Foo(T)'. Generic services must explicitly provide a name.", <<-CR
         @[ADI::Register]

--- a/src/components/dependency_injection/spec/compiler_passes/merge_configs_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_configs_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
 describe ADI::ServiceContainer::MergeConfigs do
-  it "deep merges consecutive `ADI.configure` call", tags: "compiler" do
+  it "deep merges consecutive `ADI.configure` call", tags: "compiled" do
     ASPEC::Methods.assert_success <<-CR
       require "../spec_helper"
 

--- a/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
@@ -8,7 +8,7 @@ private def assert_error(message : String, code : String, *, line : Int32 = __LI
   CR
 end
 
-describe ADI::ServiceContainer::MergeExtensionConfig do
+describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
   describe "compiler errors" do
     describe "root level" do
       it "errors if a configuration value has the incorrect type" do

--- a/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
@@ -280,7 +280,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
       CR
     end
 
-    it "errors if nothing is configured, but a property is required", tags: "compiler" do
+    it "errors if nothing is configured, but a property is required", tags: "compiled" do
       assert_error "Required configuration property 'test.id : Int32' must be provided.", <<-CR
         require "../spec_helper"
 
@@ -295,7 +295,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
     end
   end
 
-  it "extension configuration value resolution", tags: "compiler" do
+  it "extension configuration value resolution", tags: "compiled" do
     ASPEC::Methods.assert_success <<-CR, codegen: true
       require "../spec_helper"
 
@@ -347,7 +347,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
     CR
   end
 
-  it "does not error if nothing is configured, but all properties have defaults or are nilable", tags: "compiler" do
+  it "does not error if nothing is configured, but all properties have defaults or are nilable", tags: "compiled" do
     ASPEC::Methods.assert_success <<-CR, codegen: true
       require "../spec_helper"
 
@@ -367,7 +367,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
     CR
   end
 
-  it "inherits type of arrays from property if not explicitly set", tags: "compiler" do
+  it "inherits type of arrays from property if not explicitly set", tags: "compiled" do
     ASPEC::Methods.assert_success <<-CR, codegen: true
       require "../spec_helper"
 
@@ -393,7 +393,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
     CR
   end
 
-  it "allows using NoReturn to type empty arrays in schema", tags: "compiler" do
+  it "allows using NoReturn to type empty arrays in schema", tags: "compiled" do
     ASPEC::Methods.assert_success <<-CR, codegen: true
       require "../spec_helper"
 
@@ -414,7 +414,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
     CR
   end
 
-  it "allows customizing values when using NoReturn to type empty arrays defaults in schema", tags: "compiler" do
+  it "allows customizing values when using NoReturn to type empty arrays defaults in schema", tags: "compiled" do
     ASPEC::Methods.assert_success <<-CR, codegen: true
       require "../spec_helper"
 
@@ -440,7 +440,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
     CR
   end
 
-  it "expands schema to include expected structure/defaults if not configuration is provided", tags: "compiler" do
+  it "expands schema to include expected structure/defaults if not configuration is provided", tags: "compiled" do
     ASPEC::Methods.assert_success <<-CR, codegen: true
       require "../spec_helper"
 
@@ -471,7 +471,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig do
     CR
   end
 
-  it "expands schema to include expected structure/defaults if not explicitly provided", tags: "compiler" do
+  it "expands schema to include expected structure/defaults if not explicitly provided", tags: "compiled" do
     ASPEC::Methods.assert_success <<-CR, codegen: true
       require "../spec_helper"
 

--- a/src/components/dependency_injection/spec/compiler_passes/register_services_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/register_services_spec.cr
@@ -48,7 +48,7 @@ record MultipleAliasService,
   four : MultipleAliasOne | MultipleAliasTwo
 
 describe ADI::ServiceContainer::RegisterServices do
-  describe "compiler errors", tags: "compiler" do
+  describe "compiler errors", tags: "compiled" do
     it "errors if a service has multiple ADI::Register annotations but not all of them have a name" do
       assert_error "Failed to register services for 'Foo'. Services based on this type must each explicitly provide a name.", <<-CR
         @[ADI::Register(name: "one")]

--- a/src/components/dependency_injection/spec/compiler_passes/resolve_parameter_placeholders_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/resolve_parameter_placeholders_spec.cr
@@ -9,7 +9,7 @@ private def assert_error(message : String, code : String, *, line : Int32 = __LI
 end
 
 describe ADI::ServiceContainer::ResolveParameterPlaceholders do
-  describe "compiler errors", tags: "compiler" do
+  describe "compiler errors", tags: "compiled" do
     it "errors if a parameter references another undefined placeholder." do
       assert_error "Parameter 'parameters[app.name]' referenced unknown parameter 'app.version'.", <<-CR
         ADI.configure({

--- a/src/components/dependency_injection/spec/compiler_passes/resolve_values_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/resolve_values_spec.cr
@@ -76,7 +76,7 @@ ADI.auto_configure ServiceValuePriorityService, {bind: {alias_overridden_by_auto
 ADI.bind alias_overridden_by_global_bind : ResolveValuePriorityInterface, "@service_priority_one"
 
 describe ADI::ServiceContainer::ResolveValues do
-  describe "compiler errors", tags: "compiler" do
+  describe "compiler errors", tags: "compiled" do
     it "errors if a service string reference doesn't map to a known service" do
       assert_error "Failed to register service 'foo'. Argument 'id : Int32' references undefined service 'bar'.", <<-CR
         @[ADI::Register(_id: "@bar")]

--- a/src/components/dependency_injection/spec/compiler_passes/validate_arguments_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/validate_arguments_spec.cr
@@ -9,7 +9,7 @@ private def assert_error(message : String, code : String, *, line : Int32 = __LI
 end
 
 describe ADI::ServiceContainer::ValidateArguments do
-  describe "compiler errors", tags: "compiler" do
+  describe "compiler errors", tags: "compiled" do
     it "errors if a expects a string value parameter but it is not of that type" do
       assert_error "Parameter 'value : String' of service 'foo' (Foo) expects a String but got '123'.", <<-CR
         @[ADI::Register(_value: "%value%")]

--- a/src/components/dependency_injection/spec/compiler_passes/validate_arguments_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/validate_arguments_spec.cr
@@ -8,8 +8,8 @@ private def assert_error(message : String, code : String, *, line : Int32 = __LI
   CR
 end
 
-describe ADI::ServiceContainer::ValidateArguments do
-  describe "compiler errors", tags: "compiled" do
+describe ADI::ServiceContainer::ValidateArguments, tags: "compiled" do
+  describe "compiler errors" do
     it "errors if a expects a string value parameter but it is not of that type" do
       assert_error "Parameter 'value : String' of service 'foo' (Foo) expects a String but got '123'.", <<-CR
         @[ADI::Register(_value: "%value%")]

--- a/src/components/event_dispatcher/spec/compiler_spec.cr
+++ b/src/components/event_dispatcher/spec/compiler_spec.cr
@@ -2,7 +2,7 @@ require "./spec_helper"
 
 # Changes here should also be reflected in `framework/spec/ext/event_dispatcher/register_listeners_spec.cr`
 describe Athena::EventDispatcher do
-  describe "compiler errors", tags: "compiler" do
+  describe "compiler errors", tags: "compiled" do
     it "when the listener method is static" do
       ASPEC::Methods.assert_error "Event listener methods can only be defined as instance methods. Did you mean 'MyListener#listener'?", <<-CR
         require "./spec_helper.cr"

--- a/src/components/framework/spec/compiler_spec.cr
+++ b/src/components/framework/spec/compiler_spec.cr
@@ -17,7 +17,7 @@ private def assert_success(code : String, *, line : Int32 = __LINE__) : Nil
 end
 
 describe Athena::Framework do
-  describe "compiler errors", tags: "compiler" do
+  describe "compiler errors", tags: "compiled" do
     it "action parameter missing type restriction" do
       assert_error "Route action parameter 'CompileController#action:id' must have a type restriction.", <<-CODE
         class CompileController < ATH::Controller

--- a/src/components/framework/spec/controllers/routing_controller.cr
+++ b/src/components/framework/spec/controllers/routing_controller.cr
@@ -7,7 +7,7 @@ class RoutingController < ATH::Controller
   @[ARTA::Get("get/safe")]
   def safe_request_check : String
     initial_query = @request_store.request.try &.query
-    sleep 2 if initial_query == "foo"
+    sleep 250.milliseconds if initial_query == "foo"
     check_query = @request_store.request.try &.query
 
     initial_query == check_query ? "safe" : "unsafe"

--- a/src/components/framework/spec/ext/console/register_commands_spec.cr
+++ b/src/components/framework/spec/ext/console/register_commands_spec.cr
@@ -17,7 +17,7 @@ private def assert_success(code : String, *, line : Int32 = __LINE__, file : Str
 end
 
 describe ATH do
-  describe "Console", tags: "compiler" do
+  describe "Console", tags: "compiled" do
     it "errors if no name is provided" do
       assert_error "Console command 'TestCommand' has an 'ACONA::AsCommand' annotation but is missing the commands's name. It was not provided as the first positional argument nor via the 'name' field.", <<-CR
         require "../../spec_helper.cr"

--- a/src/components/framework/spec/ext/event_dispatcher/register_listeners_spec.cr
+++ b/src/components/framework/spec/ext/event_dispatcher/register_listeners_spec.cr
@@ -13,7 +13,7 @@ end
 # Changes here should also be reflected in `event_dispatcher/spec/compiler.cr`
 describe ATH do
   describe "EventDispatcher" do
-    describe "compiler errors", tags: "compiler" do
+    describe "compiler errors", tags: "compiled" do
       it "when the listener method is static" do
         assert_error "Event listener methods can only be defined as instance methods. Did you mean 'MyListener#listener'?", <<-CR
           @[ADI::Register]

--- a/src/components/framework/spec/routing_spec.cr
+++ b/src/components/framework/spec/routing_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 struct RoutingTest < ATH::Spec::APITestCase
   def test_is_concurrently_safe : Nil
     spawn do
-      sleep 1
+      sleep 100.milliseconds
       self.get("/get/safe?bar").body.should eq %("safe")
     end
     self.get("/get/safe?foo").body.should eq %("safe")

--- a/src/components/routing/spec/requirement/enum_spec.cr
+++ b/src/components/routing/spec/requirement/enum_spec.cr
@@ -24,6 +24,7 @@ struct EnumRequirementTest < ASPEC::TestCase
     ART::Requirement::Enum(EnumRequirementEnumFlags).new(:b, :c).to_s.should eq "b|c"
   end
 
+  @[Tags("compiled")]
   def test_constructor_non_enum_type : Nil
     self.assert_error "'Int32' is not an Enum type.", <<-CR
       require "../spec_helper"

--- a/src/components/spec/spec/compiler_spec.cr
+++ b/src/components/spec/spec/compiler_spec.cr
@@ -9,7 +9,7 @@ private def assert_error(message : String, code : String, *, codegen : Bool = fa
 end
 
 describe Athena::Spec do
-  describe "compiler errors", tags: "compiler" do
+  describe "compiler errors", tags: "compiled" do
     describe ASPEC::TestCase::TestWith do
       describe "args" do
         it "non tuple value" do

--- a/src/components/spec/spec/methods_spec.cr
+++ b/src/components/spec/spec/methods_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 describe ASPEC::Methods do
-  describe ".assert_error" do
+  describe ".assert_error", tags: "compiled" do
     describe "no codegen" do
       it do
         assert_error "can't instantiate abstract class Foo", <<-CR
@@ -20,7 +20,7 @@ describe ASPEC::Methods do
     end
   end
 
-  describe ".assert_success" do
+  describe ".assert_success", tags: "compiled" do
     describe "no codegen" do
       it do
         assert_success <<-CR
@@ -44,7 +44,7 @@ describe ASPEC::Methods do
     end
   end
 
-  describe ".run_executable" do
+  describe ".run_executable", tags: "compiled" do
     it "without input" do
       run_executable "ls", ["./.github"] do |output, error, status|
         output.should eq %(dependabot.yml\nworkflows\n)


### PR DESCRIPTION
* Updates `scripts/test.sh` to allow running unit, compiled, or both specs
* Updated compiled tag to `compiled` from `compiler`

Resolves #368 