### PR TITLE
Add `object_of` DI extension macro

### DIFF
--- a/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
@@ -11,7 +11,7 @@ end
 describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
   describe "compiler errors" do
     describe "root level" do
-      it "errors if a configuration value has the incorrect type" do
+      it "errors if a required configuration value has not been provided" do
         assert_error "Required configuration property 'test.id : Int32' must be provided.", <<-CR
           module Schema
             include ADI::Extension::Schema

--- a/src/components/dependency_injection/spec/extension_spec.cr
+++ b/src/components/dependency_injection/spec/extension_spec.cr
@@ -1,0 +1,234 @@
+require "./spec_helper"
+
+private def assert_success(code : String, *, line : Int32 = __LINE__) : Nil
+  ASPEC::Methods.assert_success <<-CR, codegen: true, line: line
+    require "./spec_helper.cr"
+    #{code}
+    Schema.validate
+  CR
+end
+
+private def assert_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
+  ASPEC::Methods.assert_error message, <<-CR, line: line
+    require "./spec_helper.cr"
+    #{code}
+    ADI::ServiceContainer.new
+  CR
+end
+
+describe ADI::Extension do
+  it "happy path" do
+    assert_success <<-CR
+      module Schema
+        include ADI::Extension::Schema
+        property id : Int32
+        property name : String = "Fred"
+        def self.validate
+          it do
+            {{OPTIONS.size}}.should eq 2
+            {{OPTIONS[0]["name"].stringify}}.should eq "id"
+            {{OPTIONS[0]["type"].stringify}}.should eq "Int32"
+            {{OPTIONS[0]["default"].stringify}}.should be_empty
+            {{OPTIONS[1]["name"].stringify}}.should eq "name"
+            {{OPTIONS[1]["type"].stringify}}.should eq "String"
+            {{OPTIONS[1]["default"].stringify}}.should eq %("Fred")
+          end
+        end
+      end
+      ADI.register_extension "test", Schema
+      ADI.configure({
+        test: {
+          id: 10,
+        },
+      })
+    CR
+  end
+
+  it "allows using NoReturn array default to inherit type of the array" do
+    assert_success <<-CR
+      module Schema
+        include ADI::Extension::Schema
+        property values : Array(Int32 | String) = [] of NoReturn
+        def self.validate
+          it do
+            {{OPTIONS.size}}.should eq 1
+            {{OPTIONS[0]["name"].stringify}}.should eq "values"
+            {{OPTIONS[0]["type"].stringify}}.should eq "Array(Int32 | String)"
+            {{OPTIONS[0]["default"].stringify}}.should eq "Array(Int32 | String).new"
+          end
+        end
+      end
+      ADI.register_extension "test", Schema
+    CR
+  end
+
+  describe "object_of / object_of?" do
+    it "is able to resolve parameters from the object value" do
+      assert_success <<-CR
+        module Schema
+          include ADI::Extension::Schema
+          object_of connection, username : String, password : String, port : Int32 = 1234
+          macro finished
+            macro finished
+              def self.validate
+                it { \\{{ADI::CONFIG["test"]["connection"]["username"]}}.should eq "addminn" }
+                it { \\{{ADI::CONFIG["test"]["connection"]["password"]}}.should eq "abc123" }
+                it { \\{{ADI::CONFIG["test"]["connection"]["port"]}}.should eq 1234 }
+              end
+            end
+          end
+        end
+        ADI.register_extension "test", Schema
+
+        ADI.configure({
+          test: {
+            connection: {
+              username: "%app.username%",
+              password: "abc123",
+            },
+          },
+          parameters: {
+            "app.username": "addminn",
+          },
+        })
+      CR
+    end
+
+    it "errors if a required configuration value has not been provided" do
+      assert_error "Configuration value 'test.connection' is missing required value for 'port' of type 'Int32'.", <<-CR
+        module Schema
+          include ADI::Extension::Schema
+
+          object_of connection, username : String, password : String, port : Int32
+        end
+
+        ADI.register_extension "test", Schema
+
+        ADI.configure({
+          test: {
+            connection: {
+              username: "admin",
+              password: "abc123",
+            },
+          },
+        })
+      CR
+    end
+
+    it "errors if a configuration value has been provided a value of the wrong type" do
+      assert_error "Expected configuration value 'test.connection.port' to be a 'Int32', but got 'Bool'.", <<-CR
+        module Schema
+          include ADI::Extension::Schema
+
+          object_of connection, username : String, password : String, port : Int32
+        end
+
+        ADI.register_extension "test", Schema
+
+        ADI.configure({
+          test: {
+            connection: {
+              username: "admin",
+              password: "abc123",
+              port: false,
+            },
+          },
+        })
+      CR
+    end
+
+    it "object_of?" do
+      assert_success <<-CR
+        module Schema
+          include ADI::Extension::Schema
+          object_of? rule, id : Int32, stop : Bool = false
+          def self.validate
+            it do
+              {{OPTIONS.size}}.should eq 1
+              {{OPTIONS[0]["name"].stringify}}.should eq "rule"
+              {{OPTIONS[0]["type"].stringify}}.should eq "(NamedTuple(T) | Nil)"
+              {{OPTIONS[0]["default"].stringify}}.should eq ""
+              {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
+              {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
+              {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
+              {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
+              {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
+            end
+          end
+        end
+        ADI.register_extension "test", Schema
+      CR
+    end
+  end
+
+  describe "array_of / array_of?" do
+    it "array_of" do
+      assert_success <<-CR
+        module Schema
+          include ADI::Extension::Schema
+          array_of rules, id : Int32, stop : Bool = false
+          def self.validate
+            it do
+              {{OPTIONS.size}}.should eq 1
+              {{OPTIONS[0]["name"].stringify}}.should eq "rules"
+              {{OPTIONS[0]["type"].stringify}}.should eq "Array(T)"
+              {{OPTIONS[0]["default"].stringify}}.should eq "[]"
+              {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
+              {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
+              {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
+              {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
+              {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
+            end
+          end
+        end
+        ADI.register_extension "test", Schema
+      CR
+    end
+
+    it "array_of with assign" do
+      assert_success <<-CR
+        module Schema
+          include ADI::Extension::Schema
+          array_of rules = [{id: 10, stop: true}], id : Int32, stop : Bool = false
+          def self.validate
+            it do
+              {{OPTIONS.size}}.should eq 1
+              {{OPTIONS[0]["name"].stringify}}.should eq "rules"
+              {{OPTIONS[0]["type"].stringify}}.should eq "Array(T)"
+              {{OPTIONS[0]["default"].stringify}}.should eq "[{id: 10, stop: true}]"
+              {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
+              {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
+              {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
+              {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
+              {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
+            end
+          end
+        end
+        ADI.register_extension "test", Schema
+      CR
+    end
+
+    it "array_of?" do
+      assert_success <<-CR
+        module Schema
+          include ADI::Extension::Schema
+          array_of? rules, id : Int32, stop : Bool = false
+          def self.validate
+            it do
+              {{OPTIONS.size}}.should eq 1
+              {{OPTIONS[0]["name"].stringify}}.should eq "rules"
+              {{OPTIONS[0]["type"].stringify}}.should eq "(Array(T) | Nil)"
+              {{OPTIONS[0]["default"].stringify}}.should eq "nil"
+              {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
+              {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
+              {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
+              {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
+              {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
+            end
+          end
+        end
+        ADI.register_extension "test", Schema
+      CR
+    end
+  end
+end

--- a/src/components/dependency_injection/src/compiler_passes/merge_extension_config.cr
+++ b/src/components/dependency_injection/src/compiler_passes/merge_extension_config.cr
@@ -114,14 +114,22 @@ module Athena::DependencyInjection::ServiceContainer::MergeExtensionConfig
                                    # Resolve enum value to enum members
                                    config_value = "#{type}.new(#{config_value})".id
                                  elsif config_value.is_a?(NamedTupleLiteral)
-                                   p = prop["type"]
-
                                    # Fill in `nil` values to missing nilable NT keys
-                                   p.keys.each do |k|
-                                     t = p[k]
+                                   if member_map = prop["members"]
+                                     member_map.each do |k, decl|
+                                       if config_value[k] == nil && decl && decl.type.resolve.nilable?
+                                         config_value[k] = nil
+                                       end
+                                     end
+                                   else
+                                     p = prop["type"]
 
-                                     if config_value[k] == nil && t.nilable?
-                                       config_value[k] = nil
+                                     p.keys.each do |k|
+                                       t = p[k]
+
+                                       if config_value[k] == nil && t.nilable?
+                                         config_value[k] = nil
+                                       end
                                      end
                                    end
 

--- a/src/components/dependency_injection/src/extension.cr
+++ b/src/components/dependency_injection/src/extension.cr
@@ -24,6 +24,36 @@ module Athena::DependencyInjection::Extension::Schema
     %}
   end
 
+  macro object_of(name, *members)
+    process_object_of({{name}}, {{members.splat}}, nilable: false)
+  end
+
+  macro object_of?(name, *members)
+    process_object_of({{name}}, {{members.splat}}, nilable: true)
+  end
+
+  private macro process_object_of(name_or_assign, *members, nilable)
+    {%
+      __nil = nil
+
+      if name_or_assign.is_a?(Assign)
+        name = name_or_assign.target
+        default = name_or_assign.value
+      else
+        name = name_or_assign.name
+        default = pp # Hack to ensure the default is a Nop to differentiate it from `nil`
+      end
+
+      member_map = {__nil: nil}
+      members.each do |m|
+        m.raise "All members must be `TypeDeclaration`s." unless m.is_a? TypeDeclaration
+        member_map[m.var.id] = m
+      end
+
+      OPTIONS << {name: name, type: (type = (nilable ? parse_type("NamedTuple?").resolve : NamedTuple)), default: default, root: name, members: member_map}
+    %}
+  end
+
   # An array of a complex type
   macro array_of(name, *members)
     process_array_of({{name}}, {{members.splat}}, nilable: false)
@@ -38,7 +68,7 @@ module Athena::DependencyInjection::Extension::Schema
       __nil = nil
 
       if name_or_assign.is_a?(Assign)
-        name = name_or_assign.target
+        name = name_or_assign.target.id
         default = name_or_assign.value
       else
         name = name_or_assign.name
@@ -51,7 +81,7 @@ module Athena::DependencyInjection::Extension::Schema
         member_map[m.var.id] = m
       end
 
-      OPTIONS << {name: name, type: nilable ? Array? : Array, default: default, root: name, members: member_map}
+      OPTIONS << {name: name, type: (type = (nilable ? parse_type("Array?").resolve : Array)), default: nilable ? nil : default, root: name, members: member_map}
     %}
   end
 end


### PR DESCRIPTION
Works similar to #348, but for a single object. Provides similar functionality as a `NamedTuple` typed object, but more flexible as it can have default values and make use of the nested doc type stuff coming up.

* Adds more extension spec coverage