### PR TITLE
Introduce special markup to allow documenting `array_of` and `object_of` properties

### DIFF
--- a/docs/templates/crystal/material/schema.html
+++ b/docs/templates/crystal/material/schema.html
@@ -12,9 +12,14 @@
       <strong>type: </strong>{{ param['type'] |convert_markdown_ctx(obj, heading_level+2, obj.abs_id) }}
     </div>
 
-    <div class="schema-default">
-      <strong>default: </strong>{{ param['default'] |convert_markdown_ctx(obj, heading_level+2, obj.abs_id) }}
-    </div>
+
+      <div class="schema-default">
+        {% if param['default'] != '``' %}
+          <strong>default: </strong>{{ param['default'] |convert_markdown_ctx(obj, heading_level+2, obj.abs_id) }}
+        {% else %}
+          <strong>Required</strong>
+        {% endif %}
+      </div>
 
     <div class="doc doc-contents {% if root %}first{% endif %}">
       {% if obj.doc %}{{ obj.doc | convert_markdown_ctx(obj, heading_level, obj.abs_id) }}{% endif %}
@@ -22,7 +27,11 @@
 
     {% if 'members' in param %}
       <div class="schema-members">
-        <p>This property consists of an object with the following properties:
+        {% if 'Array' in param['type'] %}
+          <p>This property consists of an array of objects with the following properties:</p>
+        {% else %}
+          <p>This property consists of an object with the following properties:</p>
+        {% endif %}
 
         <blockquote style="color: inherit;">
           {% for member in param['members'] %}
@@ -34,9 +43,13 @@
               <strong>type: </strong>{{ member['type'] |convert_markdown_ctx(obj, heading_level+4, obj.abs_id) }}
             </div>
 
-            <div class="schema-default">
-              <strong>default: </strong>{{ member['default'] |convert_markdown_ctx(obj, heading_level+4, obj.abs_id) }}
-            </div>
+              <div class="schema-default">
+                {% if member['default'] != '``' %}
+                  <strong>default: </strong>{{ member['default'] |convert_markdown_ctx(obj, heading_level+4, obj.abs_id) }}
+                {% else %}
+                  <strong>Required</strong>
+                {% endif %}
+              </div>
 
             <div class="doc doc-contents {% if root %}first{% endif %}">
               {{ member['doc'] | convert_markdown_ctx(obj, heading_level+4, obj.abs_id) }}

--- a/docs/templates/crystal/material/type.html
+++ b/docs/templates/crystal/material/type.html
@@ -3,6 +3,12 @@
 <div class="doc doc-object doc-type {{ obj.kind }}">
 {% if "Athena::DependencyInjection::Extension::Schema" in obj.included_modules  %}
   <div class="doc doc-contents {% if root %}first{% endif %}">
+    {% if obj.parent %}
+      {% filter heading(heading_level, id=obj.abs_id, class="doc doc-heading", toc_label=obj.name) -%}
+        <code>{{ obj.full_name }}</code>
+      {%- endfilter %}
+    {% endif %}
+
     {% if obj.doc %}{{ obj.doc |convert_markdown_ctx(obj, heading_level, obj.abs_id) }}{% endif %}
 
     {% include "schema.html" with context %}

--- a/mkdocs-common.yml
+++ b/mkdocs-common.yml
@@ -37,6 +37,7 @@ extra_css:
 watch:
   - src/
   - ../../../mkdocs-common.yml
+  - ../../../docs/templates
 
 extra:
   homepage: /

--- a/src/components/dependency_injection/spec/extension_spec.cr
+++ b/src/components/dependency_injection/spec/extension_spec.cr
@@ -32,6 +32,10 @@ describe ADI::Extension do
             {{OPTIONS[1]["name"].stringify}}.should eq "name"
             {{OPTIONS[1]["type"].stringify}}.should eq "String"
             {{OPTIONS[1]["default"].stringify}}.should eq %("Fred")
+
+            {{CONFIG_DOCS.stringify}}.should eq <<-JSON
+            [{"name":"id","type":"`Int32`","default":"``"}, {"name":"name","type":"`String`","default":"`Fred`"}] of Nil
+            JSON
           end
         end
       end
@@ -55,6 +59,10 @@ describe ADI::Extension do
             {{OPTIONS[0]["name"].stringify}}.should eq "values"
             {{OPTIONS[0]["type"].stringify}}.should eq "Array(Int32 | String)"
             {{OPTIONS[0]["default"].stringify}}.should eq "Array(Int32 | String).new"
+
+            {{CONFIG_DOCS.stringify}}.should eq <<-JSON
+            [{"name":"values","type":"`Array(Int32 | String)`","default":"`Array(Int32 | String).new`"}] of Nil
+            JSON
           end
         end
       end
@@ -147,12 +155,16 @@ describe ADI::Extension do
               {{OPTIONS.size}}.should eq 1
               {{OPTIONS[0]["name"].stringify}}.should eq "rule"
               {{OPTIONS[0]["type"].stringify}}.should eq "(NamedTuple(T) | Nil)"
-              {{OPTIONS[0]["default"].stringify}}.should eq ""
+              {{OPTIONS[0]["default"].stringify}}.should eq "nil"
               {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
               {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
               {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
               {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
               {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
+
+              {{CONFIG_DOCS.stringify}}.should eq <<-JSON
+              [{"name":"rule","type":"`(NamedTuple(T) | Nil)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":"NONE"},{"name":"stop","type":"`Bool`","default":"`false`","doc":"NONE"}]}] of Nil
+              JSON
             end
           end
         end
@@ -201,6 +213,10 @@ describe ADI::Extension do
               {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
               {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
               {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
+
+              {{CONFIG_DOCS.stringify}}.should eq <<-JSON
+              [{"name":"rules","type":"`Array(T)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":"NONE"},{"name":"stop","type":"`Bool`","default":"`false`","doc":"NONE"}]}] of Nil
+              JSON
             end
           end
         end
@@ -224,6 +240,10 @@ describe ADI::Extension do
               {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
               {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
               {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
+
+              {{CONFIG_DOCS.stringify}}.should eq <<-JSON
+              [{"name":"rules","type":"`(Array(T) | Nil)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":"NONE"},{"name":"stop","type":"`Bool`","default":"`false`","doc":"NONE"}]}] of Nil
+              JSON
             end
           end
         end

--- a/src/components/dependency_injection/spec/extension_spec.cr
+++ b/src/components/dependency_injection/spec/extension_spec.cr
@@ -145,6 +145,67 @@ describe ADI::Extension do
       CR
     end
 
+    it "object_of" do
+      assert_success <<-CR
+        module Schema
+          include ADI::Extension::Schema
+          object_of rule, id : Int32, stop : Bool = false
+          def self.validate
+            it do
+              {{OPTIONS.size}}.should eq 1
+              {{OPTIONS[0]["name"].stringify}}.should eq "rule"
+              {{OPTIONS[0]["type"].stringify}}.should eq "NamedTuple(T)"
+              {{OPTIONS[0]["default"].stringify}}.should eq ""
+              {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
+              {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
+              {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
+              {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
+              {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
+
+              {{CONFIG_DOCS.stringify}}.should eq <<-JSON
+              [{"name":"rule","type":"`NamedTuple(T)`","default":"``","members":[{"name":"id","type":"`Int32`","default":"``","doc":"NONE"},{"name":"stop","type":"`Bool`","default":"`false`","doc":"NONE"}]}] of Nil
+              JSON
+            end
+          end
+        end
+        ADI.register_extension "test", Schema
+        ADI.configure({
+          test: {
+            rule: {
+              id: 10
+            },
+          },
+        })
+      CR
+    end
+
+    it "object_of with assign" do
+      assert_success <<-CR
+        module Schema
+          include ADI::Extension::Schema
+          object_of rule = {id: 999}, id : Int32, stop : Bool = false
+          def self.validate
+            it do
+              {{OPTIONS.size}}.should eq 1
+              {{OPTIONS[0]["name"].stringify}}.should eq "rule"
+              {{OPTIONS[0]["type"].stringify}}.should eq "NamedTuple(T)"
+              {{OPTIONS[0]["default"].stringify}}.should eq "{id: 999, stop: false}"
+              {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
+              {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
+              {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
+              {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
+              {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
+
+              {{CONFIG_DOCS.stringify}}.should eq <<-JSON
+              [{"name":"rule","type":"`NamedTuple(T)`","default":"`{id: 999}`","members":[{"name":"id","type":"`Int32`","default":"``","doc":"NONE"},{"name":"stop","type":"`Bool`","default":"`false`","doc":"NONE"}]}] of Nil
+              JSON
+            end
+          end
+        end
+        ADI.register_extension "test", Schema
+      CR
+    end
+
     it "object_of?" do
       assert_success <<-CR
         module Schema
@@ -164,6 +225,33 @@ describe ADI::Extension do
 
               {{CONFIG_DOCS.stringify}}.should eq <<-JSON
               [{"name":"rule","type":"`(NamedTuple(T) | Nil)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":"NONE"},{"name":"stop","type":"`Bool`","default":"`false`","doc":"NONE"}]}] of Nil
+              JSON
+            end
+          end
+        end
+        ADI.register_extension "test", Schema
+      CR
+    end
+
+    it "object_of? with assign" do
+      assert_success <<-CR
+        module Schema
+          include ADI::Extension::Schema
+          object_of? rule = {id: 999}, id : Int32, stop : Bool = false
+          def self.validate
+            it do
+              {{OPTIONS.size}}.should eq 1
+              {{OPTIONS[0]["name"].stringify}}.should eq "rule"
+              {{OPTIONS[0]["type"].stringify}}.should eq "(NamedTuple(T) | Nil)"
+              {{OPTIONS[0]["default"].stringify}}.should eq "nil"
+              {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
+              {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
+              {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
+              {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
+              {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
+
+              {{CONFIG_DOCS.stringify}}.should eq <<-JSON
+              [{"name":"rule","type":"`(NamedTuple(T) | Nil)`","default":"`{id: 999}`","members":[{"name":"id","type":"`Int32`","default":"``","doc":"NONE"},{"name":"stop","type":"`Bool`","default":"`false`","doc":"NONE"}]}] of Nil
               JSON
             end
           end
@@ -215,7 +303,7 @@ describe ADI::Extension do
               {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
 
               {{CONFIG_DOCS.stringify}}.should eq <<-JSON
-              [{"name":"rules","type":"`Array(T)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":"NONE"},{"name":"stop","type":"`Bool`","default":"`false`","doc":"NONE"}]}] of Nil
+              [{"name":"rules","type":"`Array(T)`","default":"`[{id: 10, stop: true}]`","members":[{"name":"id","type":"`Int32`","default":"``","doc":"NONE"},{"name":"stop","type":"`Bool`","default":"`false`","doc":"NONE"}]}] of Nil
               JSON
             end
           end

--- a/src/components/dependency_injection/src/extension.cr
+++ b/src/components/dependency_injection/src/extension.cr
@@ -2,6 +2,9 @@ module Athena::DependencyInjection::Extension::Schema
   macro included
     # :nodoc:
     OPTIONS = [] of Nil
+
+    # This must be public so its included in docs and mkdocs can access it.
+    CONFIG_DOCS = [] of Nil
   end
 
   macro property(declaration)
@@ -21,7 +24,11 @@ module Athena::DependencyInjection::Extension::Schema
                 end
 
       OPTIONS << {name: declaration.var.id, type: declaration.type.resolve, default: default, root: declaration}
+      CONFIG_DOCS << %({"name":"#{declaration.var.id}","type":"`#{declaration.type.id}`","default":"`#{default.id}`"}).id
     %}
+
+    # {{ @caller.first.doc_comment }}
+    abstract def {{declaration.var.id}} : {{declaration.type.id}}
   end
 
   macro object_of(name, *members)
@@ -44,14 +51,49 @@ module Athena::DependencyInjection::Extension::Schema
         default = pp # Hack to ensure the default is a Nop to differentiate it from `nil`
       end
 
-      member_map = {__nil: nil}
-      members.each do |m|
-        m.raise "All members must be `TypeDeclaration`s." unless m.is_a? TypeDeclaration
-        member_map[m.var.id] = m
+      doc_string = ""
+      member_doc_map = {} of Nil => Nil
+      in_member_docblock = false
+      current_member = nil
+
+      @caller.first.doc.lines.each_with_index do |line, idx|
+        # --- denotes member docblock start/end
+        if "---" == line
+          in_member_docblock = true
+
+          # >> denotes start of property docs
+        elsif in_member_docblock && line.starts_with?(">>")
+          current_member, docs = line[2..].split(':')
+
+          member_doc_map[current_member.id.stringify] = "#{docs.id}\\n"
+        elsif current_member
+          member_doc_map[current_member.id.stringify] += "#{line.id}\\n"
+        elsif "---" == line && in_member_docblock
+          in_member_docblock = false
+          current_member = nil
+        else
+          # The line where the docs are added in already have a `#`,
+          # so no need to
+          doc_string += "#{idx == 0 ? "".id : "\# ".id}#{line.id}\n"
+        end
       end
 
-      OPTIONS << {name: name, type: (type = (nilable ? parse_type("NamedTuple?").resolve : NamedTuple)), default: default, root: name, members: member_map}
+      members_string = "["
+      member_map = {__nil: nil}
+      members.each_with_index do |m, idx|
+        m.raise "All members must be `TypeDeclaration`s." unless m.is_a? TypeDeclaration
+        member_map[m.var.id] = m
+        members_string += %({"name":"#{m.var.id}","type":"`#{m.type.id}`","default":"`#{m.value.id}`","doc":"#{(member_doc_map[m.var.stringify] || "NONE").strip.strip.gsub(/"/, "\\\"").id}"})
+        members_string += "," unless idx == members.size - 1
+      end
+      members_string += "]"
+
+      OPTIONS << {name: name, type: (type = (nilable ? parse_type("NamedTuple?").resolve : NamedTuple)), default: nilable ? nil : default, root: name, members: member_map}
+      CONFIG_DOCS << %({"name":"#{name.id}","type":"`#{type.id}`","default":"`#{(nilable ? nil : default).id}`","members":#{members_string.id}}).id
     %}
+
+    # {{ doc_string.strip.id }}
+    abstract def {{name.id}}
   end
 
   # An array of a complex type
@@ -75,13 +117,48 @@ module Athena::DependencyInjection::Extension::Schema
         default = [] of NoReturn
       end
 
-      member_map = {__nil: nil}
-      members.each do |m|
-        m.raise "All members must be `TypeDeclaration`s." unless m.is_a? TypeDeclaration
-        member_map[m.var.id] = m
+      doc_string = ""
+      member_doc_map = {} of Nil => Nil
+      in_member_docblock = false
+      current_member = nil
+
+      @caller.first.doc.lines.each_with_index do |line, idx|
+        # --- denotes member docblock start/end
+        if "---" == line
+          in_member_docblock = true
+
+          # >> denotes start of property docs
+        elsif in_member_docblock && line.starts_with?(">>")
+          current_member, docs = line[2..].split(':')
+
+          member_doc_map[current_member.id.stringify] = "#{docs.id}\\n"
+        elsif current_member
+          member_doc_map[current_member.id.stringify] += "#{line.id}\\n"
+        elsif "---" == line && in_member_docblock
+          in_member_docblock = false
+          current_member = nil
+        else
+          # The line where the docs are added in already have a `#`,
+          # so no need to
+          doc_string += "#{idx == 0 ? "".id : "\# ".id}#{line.id}\n"
+        end
       end
 
+      members_string = "["
+      member_map = {__nil: nil}
+      members.each_with_index do |m, idx|
+        m.raise "All members must be `TypeDeclaration`s." unless m.is_a? TypeDeclaration
+        member_map[m.var.id] = m
+        members_string += %({"name":"#{m.var.id}","type":"`#{m.type.id}`","default":"`#{m.value.id}`","doc":"#{(member_doc_map[m.var.stringify] || "NONE").strip.strip.gsub(/"/, "\\\"").id}"})
+        members_string += "," unless idx == members.size - 1
+      end
+      members_string += "]"
+
       OPTIONS << {name: name, type: (type = (nilable ? parse_type("Array?").resolve : Array)), default: nilable ? nil : default, root: name, members: member_map}
+      CONFIG_DOCS << %({"name":"#{name.id}","type":"`#{type.id}`","default":"`#{(nilable ? nil : default).id}`","members":#{members_string.id}}).id
     %}
+
+    # {{ doc_string.strip.id }}
+    abstract def {{name.id}}
   end
 end

--- a/src/components/dependency_injection/src/extension.cr
+++ b/src/components/dependency_injection/src/extension.cr
@@ -44,7 +44,7 @@ module Athena::DependencyInjection::Extension::Schema
       __nil = nil
 
       if name_or_assign.is_a?(Assign)
-        name = name_or_assign.target
+        name = name_or_assign.target.id
         default = name_or_assign.value
       else
         name = name_or_assign.name
@@ -89,7 +89,7 @@ module Athena::DependencyInjection::Extension::Schema
       members_string += "]"
 
       OPTIONS << {name: name, type: (type = (nilable ? parse_type("NamedTuple?").resolve : NamedTuple)), default: nilable ? nil : default, root: name, members: member_map}
-      CONFIG_DOCS << %({"name":"#{name.id}","type":"`#{type.id}`","default":"`#{(nilable ? nil : default).id}`","members":#{members_string.id}}).id
+      CONFIG_DOCS << %({"name":"#{name.id}","type":"`#{type.id}`","default":"`#{(nilable && default.is_a?(Nop) ? nil : default).id}`","members":#{members_string.id}}).id
     %}
 
     # {{ doc_string.strip.id }}
@@ -155,7 +155,7 @@ module Athena::DependencyInjection::Extension::Schema
       members_string += "]"
 
       OPTIONS << {name: name, type: (type = (nilable ? parse_type("Array?").resolve : Array)), default: nilable ? nil : default, root: name, members: member_map}
-      CONFIG_DOCS << %({"name":"#{name.id}","type":"`#{type.id}`","default":"`#{(nilable ? nil : default).id}`","members":#{members_string.id}}).id
+      CONFIG_DOCS << %({"name":"#{name.id}","type":"`#{type.id}`","default":"`#{(nilable && default.empty? ? nil : default).id}`","members":#{members_string.id}}).id
     %}
 
     # {{ doc_string.strip.id }}

--- a/src/components/framework/src/bundle.cr
+++ b/src/components/framework/src/bundle.cr
@@ -1,5 +1,4 @@
 @[Athena::Framework::Annotations::Bundle("framework")]
-# :nodoc:
 struct Athena::Framework::Bundle < Athena::Framework::AbstractBundle
   PASSES = [
     {Athena::Framework::CompilerPasses::MakeControllerServicesPublicPass, nil, nil},
@@ -16,7 +15,54 @@ struct Athena::Framework::Bundle < Athena::Framework::AbstractBundle
 
       property? enabled : Bool = false
 
-      property rules : Array({path: Regex}) = [] of NoReturn
+      # The rules used to determine the best format.
+      # Rules should be defined in priority order, with the highest priority having index 0.
+      #
+      # ### Example
+      #
+      # ```
+      # ADI.configure({
+      #   framework: {
+      #     format_listener: {
+      #       enabled: true,
+      #       rules:   [
+      #         {priorities: ["json", "xml"], host: "api.example.com", fallback_format: "json"},
+      #         {path: /^\/image/, priorities: ["jpeg", "gif"], fallback_format: false},
+      #         {path: /^\/admin/, priorities: ["xml", "html"]},
+      #         {priorities: ["text/html", "*/*"], fallback_format: "html"},
+      #       ],
+      #     },
+      #   },
+      # })
+      # ```
+      #
+      # Assuming an `accept` header with the value `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8,application/json`,
+      # a request made to `/foo` from the `api.example.com` hostname; the request format would be `json`.
+      # If the request was not made from that hostname; the request format would be `html`.
+      # The rules can be as complex or as simple as needed depending on the use case of your application.
+      #
+      # ---
+      # >>path: Use this rules configuration if the request's path matches the regex.
+      # >>host: Use this rules configuration if the request's hostname matches the regex.
+      # >>methods: Use this rules configuration if the request's method is one of these configured methods.
+      # >>priorities: Defines the order of media types the application prefers. If a format is provided instead of a media type,
+      # the format is converted into a list of media types matching the format.
+      # >>fallback_format: If `nil` and the `path`, `host`, or `methods` did not match the current request, skip this rule and try the next one.
+      # If set to a format string, use that format. If `false`, return a `406` instead of considering the next rule.
+      # >>stop: If `true`, disables the format listener for this and any following rules.
+      # Can be used as a way to enable the listener on a subset of routes within the application.
+      # >>prefer_extension: Determines if the `accept` header, or route path `_format` parameter takes precedence.
+      # For example, say there is a routed defined as `/foo.{_format}`. When `false`, the format from `_format` placeholder is checked last against the defined `priorities`.
+      # Whereas if `true`, it would be checked first.
+      # ---
+      array_of rules,
+        path : Regex? = nil,
+        host : Regex? = nil,
+        methods : Array(String)? = nil,
+        priorities : Array(String)? = nil,
+        fallback_format : String | Bool | Nil = "json",
+        stop : Bool = false,
+        prefer_extension : Bool = true
     end
 
     # Configured how `ATH::Listeners::CORS` functions.


### PR DESCRIPTION
* Fix linking to schema pages
* Denote required configuration properties
* Re-build entire site when templates are edited
* Introduce special markup that can be added to an `array_of` or `object_of` property to allow documenting their child properties
  * Builds out a JSON string that is consumed within the custom mkdocs material template in order to build out the list and related information