### PR TITLE
Make manually wiring up services easier

### DIFF
--- a/src/components/dependency_injection/spec/compiler_passes/normalize_definitions_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/normalize_definitions_spec.cr
@@ -1,0 +1,85 @@
+require "../spec_helper"
+
+private def assert_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
+  ASPEC::Methods.assert_error message, <<-CR, line: line
+    require "../spec_helper.cr"
+    module MySchema
+      include ADI::Extension::Schema
+
+      property id : Int32 = 10
+    end
+
+    class SomeService; end
+
+    module MyExtension
+      macro included
+          macro finished
+            {% verbatim do %}
+              {%
+                #{code}
+              %}
+            {% end %}
+          end
+        end
+    end
+
+    ADI.register_extension "test", MySchema
+    ADI.add_compiler_pass MyExtension, :before_optimization, 1028
+    ADI::ServiceContainer.new
+  CR
+end
+
+describe ADI::ServiceContainer::NormalizeDefinitions, tags: "compiled" do
+  describe "compiler errors" do
+    it "`class` is not provided" do
+      assert_error "Service 'some_service' is missing required 'class' property.", <<-CR
+        SERVICE_HASH["some_service"] = {
+          public: false,
+        }
+      CR
+    end
+  end
+
+  it "applies defaults to missing properties" do
+    ASPEC::Methods.assert_success <<-CR, codegen: true
+      require "../spec_helper.cr"
+      module MySchema
+        include ADI::Extension::Schema
+
+        property id : Int32 = 10
+      end
+
+      class SomeService; end
+
+      module MyExtension
+        macro included
+            macro finished
+              {% verbatim do %}
+                {%
+                  SERVICE_HASH["some_service"] = {
+                    class: SomeService,
+                  }
+                %}
+              {% end %}
+            end
+          end
+      end
+
+      ADI.register_extension "test", MySchema
+      ADI.add_compiler_pass MyExtension, :before_optimization, 1028
+      ADI::ServiceContainer.new
+
+      macro finished
+        macro finished
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["class"].stringify}}.should eq "SomeService" }
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["public"]}}.should be_false }
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["calls"].stringify}}.should eq "[]" }
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["tags"].stringify}}.should eq "{}" }
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["generics"].stringify}}.should eq "[]" }
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"].stringify}}.should eq "{}" }
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["shared"]}}.should be_true }
+        end
+      end
+    CR
+  end
+end

--- a/src/components/dependency_injection/spec/compiler_passes/process_parameters_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/process_parameters_spec.cr
@@ -1,0 +1,66 @@
+require "../spec_helper"
+
+describe ADI::ServiceContainer::ProcessParameters, tags: "compiled" do
+  it "populates parameter information of registered services" do
+    ASPEC::Methods.assert_success <<-CR, codegen: true
+      require "../spec_helper.cr"
+
+      @[ADI::Register(_id: 123)]
+      class SomeService
+        def initialize(@id : Int32); end
+      end
+
+      ADI::ServiceContainer.new
+
+      macro finished
+        macro finished
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"].size}}.should eq 1 }
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["arg"].stringify}}.should eq "id : Int32" }
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["name"].stringify}}.should eq %("id") }
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["internal_name"].stringify}}.should eq %("id") }
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["idx"]}}.should eq 0 }
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["restriction"].stringify}}.should eq "Int32" }
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["resolved_restriction"].stringify}}.should eq "Int32" }
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["default_value"]}}.should be_nil }
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["value"].stringify}}.should eq "123" }
+        end
+      end
+    CR
+  end
+
+  it "does not override value of manually wired up parameters" do
+    ASPEC::Methods.assert_success <<-CR, codegen: true
+      require "../spec_helper.cr"
+
+      class SomeService
+        def initialize(@id : Int32); end
+      end
+
+      module MyExtension
+        macro included
+          macro finished
+            {% verbatim do %}
+              {%
+                SERVICE_HASH["some_service"] = {
+                  class: SomeService,
+                  parameters: {
+                    id: {value: 999}
+                  }
+                }
+              %}
+            {% end %}
+          end
+        end
+      end
+
+      ADI.add_compiler_pass MyExtension, :before_optimization, 1028
+      ADI::ServiceContainer.new
+
+      macro finished
+        macro finished
+          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["value"].stringify}}.should eq "999" }
+        end
+      end
+    CR
+  end
+end

--- a/src/components/dependency_injection/src/compiler_passes/auto_configure.cr
+++ b/src/components/dependency_injection/src/compiler_passes/auto_configure.cr
@@ -35,7 +35,8 @@ module Athena::DependencyInjection::ServiceContainer::AutoConfigure
           end
 
           SERVICE_HASH.each do |service_id, definition|
-            tags = definition["class_ann"]["tags"] || [] of Nil
+            # Support missing `class_ann` definition due to manually wired up services.
+            tags = ((ann = definition["class_ann"]) && (ann["tags"])) || [] of Nil
 
             unless tags.is_a? ArrayLiteral
               definition["class_ann"].raise "Tags for '#{service_id.id}' must be an 'ArrayLiteral', got '#{tags.class_name.id}'."

--- a/src/components/dependency_injection/src/compiler_passes/normalize_definitions.cr
+++ b/src/components/dependency_injection/src/compiler_passes/normalize_definitions.cr
@@ -1,0 +1,53 @@
+# :nodoc:
+#
+# Runs after extensions to normalize the manually wired up services.
+# Ensures required keys are present and with proper defaults if not specified.
+module Athena::DependencyInjection::ServiceContainer::NormalizeDefinitions
+  macro included
+    macro finished
+      {% verbatim do %}
+        {%
+          SERVICE_HASH.each do |service_id, definition|
+            definition_keys = definition.keys.map &.stringify
+
+            unless definition_keys.includes? "class"
+              definition.raise "Service '#{service_id.id}' is missing required 'class' property."
+            end
+
+            unless definition_keys.includes? "public"
+              definition["public"] = false
+            end
+
+            unless definition_keys.includes? "shared"
+              definition["shared"] = definition["class"].class?
+            end
+
+            unless definition_keys.includes? "calls"
+              definition["calls"] = [] of Nil
+            end
+
+            unless definition_keys.includes? "tags"
+              definition["tags"] = {} of Nil => Nil
+            end
+
+            unless definition_keys.includes? "bindings"
+              definition["bindings"] = {} of Nil => Nil
+            end
+
+            unless definition_keys.includes? "parameters"
+              definition["parameters"] = {} of Nil => Nil
+            end
+
+            unless definition_keys.includes? "generics"
+              definition["generics"] = [] of Nil
+            end
+
+            unless definition_keys.includes? "aliases"
+              definition["aliases"] = [] of Nil
+            end
+          end
+        %}
+      {% end %}
+    end
+  end
+end

--- a/src/components/dependency_injection/src/compiler_passes/process_aliases.cr
+++ b/src/components/dependency_injection/src/compiler_passes/process_aliases.cr
@@ -1,0 +1,34 @@
+# :nodoc:
+module Athena::DependencyInjection::ServiceContainer::ProcessAliases
+  macro included
+    macro finished
+      {% verbatim do %}
+        {%
+          SERVICE_HASH.each do |service_id, definition|
+            if al = definition["aliases"]
+              aliases = al.is_a?(ArrayLiteral) ? al : [al]
+
+              aliases.each do |a|
+                id_key = a.resolve.name.gsub(/::/, "_").underscore
+                alias_service_id = id_key.is_a?(StringLiteral) ? id_key : id_key.stringify
+
+                SERVICE_HASH[a.resolve] = {
+                  class:      definition["class"].resolve,
+                  class_ann:  definition["class_ann"],
+                  tags:       {} of Nil => Nil,
+                  parameters: definition["parameters"],
+                  bindings:   {} of Nil => Nil,
+                  generics:   [] of Nil,
+
+                  alias_service_id:   alias_service_id,
+                  aliased_service_id: service_id,
+                  alias:              true,
+                }
+              end
+            end
+          end
+        %}
+      {% end %}
+    end
+  end
+end

--- a/src/components/dependency_injection/src/compiler_passes/process_parameters.cr
+++ b/src/components/dependency_injection/src/compiler_passes/process_parameters.cr
@@ -1,0 +1,58 @@
+# :nodoc:
+#
+# Processes each service definition to determine their constructor parameters.
+# Also ensures manually wired up services have full and proper initializer information
+module Athena::DependencyInjection::ServiceContainer::ProcessParameters
+  macro included
+    macro finished
+      {% verbatim do %}
+        {%
+          SERVICE_HASH.each do |service_id, definition|
+            klass = definition["class"]
+
+            initializer = if f = definition["factory"]
+                            f.first.class.methods.find(&.name.==(f[1]))
+                          elsif specific_initializer = klass.methods.find(&.annotation(ADI::Inject))
+                            specific_initializer
+                          else
+                            klass.methods.find(&.name.==("initialize"))
+                          end
+
+            # If no initializer was resolved, assume it's the default argless constructor.
+            initializer_args = (i = initializer) ? i.args : [] of Nil
+
+            parameters = definition["parameters"]
+
+            initializer_args.each_with_index do |initializer_arg, idx|
+              param_name = initializer_arg.name.id.stringify
+              default_value = nil
+
+              # Inherit value if it was already configured on the param
+              value = if (p = parameters[param_name]) && p.keys.map(&.stringify).includes?("value")
+                        p["value"]
+                      else
+                        nil
+                      end
+
+              # Set the default value is there is one.
+              if !(dv = initializer_arg.default_value).is_a?(Nop)
+                default_value = value = dv
+              end
+
+              parameters[initializer_arg.name.id.stringify] = {
+                arg:                  initializer_arg,
+                name:                 initializer_arg.name.stringify,
+                idx:                  idx,
+                internal_name:        initializer_arg.internal_name.stringify,
+                restriction:          initializer_arg.restriction,
+                resolved_restriction: ((r = initializer_arg.restriction).is_a?(Nop) ? nil : r.resolve),
+                default_value:        default_value,
+                value:                value || default_value,
+              }
+            end
+          end
+        %}
+      {% end %}
+    end
+  end
+end

--- a/src/components/dependency_injection/src/compiler_passes/resolve_generics.cr
+++ b/src/components/dependency_injection/src/compiler_passes/resolve_generics.cr
@@ -5,23 +5,25 @@ module Athena::DependencyInjection::ServiceContainer::ResolveGenerics
       {% verbatim do %}
         {%
           SERVICE_HASH.each do |service_id, definition|
-            ann = definition["class_ann"]
-            generics = ann.args
-            klass = definition["class"]
+            # Support missing `class_ann` definition due to manually wired up services.
+            if ann = definition["class_ann"]
+              generics = ann.args
+              klass = definition["class"]
 
-            if !klass.type_vars.empty? && (ann && !ann[:name])
-              klass.raise "Failed to register services for '#{klass}'. Generic services must explicitly provide a name."
+              if !klass.type_vars.empty? && (ann && !ann[:name])
+                klass.raise "Failed to register services for '#{klass}'. Generic services must explicitly provide a name."
+              end
+
+              if !klass.type_vars.empty? && generics.empty?
+                klass.raise "Failed to register service '#{service_id.id}'. Generic services must provide the types to use via the 'generics' field."
+              end
+
+              if klass.type_vars.size != generics.size
+                klass.raise "Failed to register service '#{service_id.id}'. Expected #{klass.type_vars.size} generics types got #{generics.size}."
+              end
+
+              definition["generics"] = generics
             end
-
-            if !klass.type_vars.empty? && generics.empty?
-              klass.raise "Failed to register service '#{service_id.id}'. Generic services must provide the types to use via the 'generics' field."
-            end
-
-            if klass.type_vars.size != generics.size
-              klass.raise "Failed to register service '#{service_id.id}'. Expected #{klass.type_vars.size} generics types got #{generics.size}."
-            end
-
-            definition["generics"] = generics
           end
         %}
       {% end %}

--- a/src/components/dependency_injection/src/service_container.cr
+++ b/src/components/dependency_injection/src/service_container.cr
@@ -8,9 +8,11 @@ require "./compiler_passes/*"
 #
 # TODO: Reduce the amount of duplication when [this issue](https://github.com/crystal-lang/crystal/pull/9091) is resolved.
 class Athena::DependencyInjection::ServiceContainer
+  # :nodoc:
+  #
   # Define a hash to store services while the container is being built
   # Key is the ID of the service and the value is another hash containing its arguments, type, etc.
-  private SERVICE_HASH = {} of Nil => Nil
+  SERVICE_HASH = {} of Nil => Nil
 
   # Define a hash to store the service ids for each tag.
   #
@@ -29,7 +31,10 @@ class Athena::DependencyInjection::ServiceContainer
     # Sets up common concepts so that future passes can leverage them
     before_optimization: {
       100 => [
+        NormalizeDefinitions,
         RegisterServices,
+        ProcessAliases,
+        ProcessParameters,
         AutoConfigure,
         ResolveGenerics,
       ],


### PR DESCRIPTION
This PR makes it easier to work with manually registering services by reducing amount of boilerplate needed to do so.

* Ensure `class_ann` is present before auto configuring tags and/or resolving generics
  * TODO: I think we should refactor things to decouple the annotations from the service definitions. This way `register_services` _ONLY_ uses them to populate the definitions and things can still be manually wired up. I.e. it makes the annotations specific to the auto registration pass, and not a requirement for the whole process
* Create new `NormalizeDefinitions` pass that ensures required keys are present and with proper defaults if not specified
  * Makes it so you do not have to provide _every_ property when manually registering  service
* Breaks out the alias and parameter processes from `register_services` pass into their own passes
  * Makes it so aliases can be handled via manual registration via including the array of aliases within the definition and not just on the annotation
  * Allows manually wired up parameters to have their extra information populated (type, idx, etc) while still retaining the previous value
* Refactor factory resolution to include non "new" class methods
  * Allows new parameter pass to be dumber