### PR TITLE
Support service calls

### DIFF
--- a/src/components/dependency_injection/spec/compiler_passes/calls_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/calls_spec.cr
@@ -1,0 +1,44 @@
+require "../spec_helper"
+
+private def assert_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
+  ASPEC::Methods.assert_error message, <<-CR, line: line
+    require "../spec_helper.cr"
+    #{code}
+    ADI::ServiceContainer.new
+  CR
+end
+
+@[ADI::Register(public: true, calls: [
+  {"foo"},
+  {"foo", {3}},
+  {"foo", {6}},
+])]
+class CallClient
+  getter values = [] of Int32
+
+  def foo(value : Int32 = 1)
+    @values << value
+  end
+end
+
+describe ADI::ServiceContainer do
+  describe "compiler errors", tags: "compiled" do
+    it "errors if the method of a call is empty" do
+      assert_error "Method name cannot be empty.", <<-CR
+        @[ADI::Register(calls: [{""}])]
+        record Foo
+      CR
+    end
+
+    it "errors if the method does not exist on the type" do
+      assert_error "Failed to auto register service for 'foo' (Foo). Call references non-existent method 'foo'.", <<-CR
+        @[ADI::Register(calls: [{"foo"}])]
+        record Foo
+      CR
+    end
+  end
+
+  it "allows defining calls" do
+    ADI.container.call_client.values.should eq [1, 3, 6]
+  end
+end

--- a/src/components/dependency_injection/src/compiler_passes/define_getters.cr
+++ b/src/components/dependency_injection/src/compiler_passes/define_getters.cr
@@ -22,11 +22,18 @@ module Athena::DependencyInjection::ServiceContainer::DefineGetters
               {% if metadata[:alias] %}
                 {{metadata[:aliased_service_id].id}}
               {% else %}
-                {{constructor_service}}.{{constructor_method.id}}({{
-                                                                    metadata["parameters"].map do |name, param|
-                                                                      "#{name.id}: #{param["value"]}".id
-                                                                    end.splat
-                                                                  }})
+                instance = {{constructor_service}}.{{constructor_method.id}}({{
+                                                                               metadata["parameters"].map do |name, param|
+                                                                                 "#{name.id}: #{param["value"]}".id
+                                                                               end.splat
+                                                                             }})
+
+                {% for call in metadata[:calls] %}
+                  {% method, args = call %}
+                  instance.{{method.id}}({{args.splat}})
+                {% end %}
+
+                instance
               {% end %}
             end
 

--- a/src/components/framework/src/bundle.cr
+++ b/src/components/framework/src/bundle.cr
@@ -314,9 +314,8 @@ struct Athena::Framework::Bundle < Athena::Framework::AbstractBundle
               end
 
               SERVICE_HASH["athena_framework_listeners_format"] = {
-                class:   ATH::View::FormatNegotiator,
-                factory: {ATH::View::FormatNegotiator, "create"},
-                calls:   calls,
+                class: ATH::View::FormatNegotiator,
+                calls: calls,
               }
             end
           %}

--- a/src/components/framework/src/bundle.cr
+++ b/src/components/framework/src/bundle.cr
@@ -272,7 +272,7 @@ struct Athena::Framework::Bundle < Athena::Framework::AbstractBundle
             if cfg["enabled"] && !cfg["rules"].empty?
               matcher_arguments_to_service_id_map = {} of Nil => Nil
 
-              map = [] of Nil
+              calls = [] of Nil
 
               cfg["rules"].each_with_index do |rule, idx|
                 matcher_id = {rule["path"], rule["host"], rule["methods"], nil}.symbolize
@@ -305,15 +305,18 @@ struct Athena::Framework::Bundle < Athena::Framework::AbstractBundle
                   matcher_service_id = matcher_arguments_to_service_id_map[matcher_id]
                 end
 
-                map << %({#{matcher_service_id.id}, ATH::View::FormatNegotiator::Rule.new(#{rule.double_splat})}).id
+                calls << {"add", {matcher_service_id.id, "ATH::View::FormatNegotiator::Rule.new(
+                  stop: #{rule["stop"]},
+                  priorities: #{rule["priorities"]},
+                  prefer_extension: #{rule["prefer_extension"]},
+                  fallback_format: #{rule["fallback_format"]}
+                )".id}}
               end
 
               SERVICE_HASH["athena_framework_listeners_format"] = {
-                class:      ATH::View::FormatNegotiator,
-                factory:    {ATH::View::FormatNegotiator, "create"},
-                parameters: {
-                  map: {value: map.id},
-                },
+                class:   ATH::View::FormatNegotiator,
+                factory: {ATH::View::FormatNegotiator, "create"},
+                calls:   calls,
               }
             end
           %}

--- a/src/components/framework/src/ext/console/compiler_passes/register_commands.cr
+++ b/src/components/framework/src/ext/console/compiler_passes/register_commands.cr
@@ -54,9 +54,9 @@ module Athena::Framework::Console::CompilerPasses::RegisterCommands
 
               SERVICE_HASH[lazy_service_id = "_#{service_id.id}_lazy"] = {
                 class:      "ACON::Commands::Lazy",
-                ivar_type:  "ACON::Commands::Lazy",
                 tags:       [] of Nil,
                 generics:   [] of Nil,
+                calls:      [] of Nil,
                 public:     false,
                 parameters: {
                   name:        {value: command_name},
@@ -73,9 +73,9 @@ module Athena::Framework::Console::CompilerPasses::RegisterCommands
 
           SERVICE_HASH[loader_id = "athena_console_command_loader_container"] = {
             class:      "Athena::Framework::Console::ContainerCommandLoaderLocator",
-            ivar_type:  "Athena::Framework::Console::ContainerCommandLoaderLocator",
             tags:       [] of Nil,
             generics:   [] of Nil,
+            calls:      [] of Nil,
             public:     false,
             parameters: {
               container: {value: "self".id},
@@ -84,9 +84,9 @@ module Athena::Framework::Console::CompilerPasses::RegisterCommands
 
           SERVICE_HASH[command_loader_service_id = "athena_console_command_loader"] = {
             class:      Athena::Framework::Console::ContainerCommandLoader,
-            ivar_type:  Athena::Framework::Console::ContainerCommandLoader,
             tags:       [] of Nil,
             generics:   [] of Nil,
+            calls:      [] of Nil,
             public:     false,
             parameters: {
               command_map: {value: "#{command_map} of String => ACON::Command.class".id},

--- a/src/components/framework/src/view/format_negotiator.cr
+++ b/src/components/framework/src/view/format_negotiator.cr
@@ -4,30 +4,12 @@
 class Athena::Framework::View::FormatNegotiator < ANG::Negotiator
   # :nodoc:
   record Rule,
-    path : Regex = /^\//,
-    host : Regex? = nil,
-    methods : Array(String)? = nil,
     priorities : Array(String)? = nil,
     fallback_format : String | Bool | Nil = false,
     stop : Bool = false,
     prefer_extension : Bool = true
 
   @map : Array({ATH::RequestMatcher::Interface, ATH::View::FormatNegotiator::Rule}) = [] of {ATH::RequestMatcher::Interface, ATH::View::FormatNegotiator::Rule}
-
-  # TODO: Handle this via `calls` on the service def
-  protected def self.create(
-    request_store : ATH::RequestStore,
-    map : Array({ATH::RequestMatcher::Interface, ATH::View::FormatNegotiator::Rule}),
-    mime_types : Hash(String, Array(String)) = Hash(String, Array(String)).new
-  ) : self
-    instance = new request_store, mime_types
-
-    map.each do |(matcher, rule)|
-      instance.add matcher, rule
-    end
-
-    instance
-  end
 
   def initialize(
     @request_store : ATH::RequestStore,


### PR DESCRIPTION
Follow up to #337. Allows services to define calls that should be made after its instantiated.

Addresses part of #197