### PR TITLE
Wire up framework router via new alias annotations

### DIFF
--- a/src/components/framework/src/bundle.cr
+++ b/src/components/framework/src/bundle.cr
@@ -238,9 +238,8 @@ struct Athena::Framework::Bundle < Athena::Framework::AbstractBundle
             parameters["framework.request_listener.https_port"] = cfg["https_port"]
 
             # TODO: Make this `default_router` with a public alias of `router` instead.
-            SERVICE_HASH[router_id = "router"] = {
+            SERVICE_HASH[router_id = "default_router"] = {
               class:      ATH::Routing::Router,
-              aliases:    [ART::Generator::Interface, ART::Matcher::URLMatcherInterface, ART::RouterInterface],
               public:     true,
               parameters: {
                 default_locale:      {value: "%framework.default_locale%"},

--- a/src/components/framework/src/ext/routing/router.cr
+++ b/src/components/framework/src/ext/routing/router.cr
@@ -1,4 +1,9 @@
 # :nodoc:
+@[ADI::AsAlias(ART::Generator::Interface)]
+@[ADI::AsAlias(ART::Matcher::URLMatcherInterface)]
+@[ADI::AsAlias(ART::RouterInterface)]
+@[ADI::AsAlias(ART::RequestContextAwareInterface)]
+@[ADI::AsAlias("router", public: true)]
 class Athena::Framework::Routing::Router < Athena::Routing::Router
   getter matcher : ART::Matcher::URLMatcherInterface do
     ATH::Routing::RedirectableURLMatcher.new(@context)


### PR DESCRIPTION
CI passed in #389 due to there only being 1 implementation of these interfaces, so it was chosen by default.