### PR TITLE
Support new `Process.on_terminate` method

### DIFF
--- a/src/components/framework/src/athena.cr
+++ b/src/components/framework/src/athena.cr
@@ -218,7 +218,11 @@ module Athena::Framework
       {% end %}
 
       # Handle exiting correctly on interrupt signals
-      Process.on_interrupt { self.stop }
+      {% if compare_versions(Crystal::VERSION, "1.12.0") >= 0 %}
+        Process.on_terminate { self.stop }
+      {% else %}
+        Process.on_interrupt { self.stop }
+      {% end %}
 
       Log.info { %(Server has started and is listening at #{@ssl_context ? "https" : "http"}://#{@server.addresses.first}) }
 


### PR DESCRIPTION
Avoids a deprecation warning once `1.12` is released.