### PR TITLE
Enable prod doc updates without release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   repository_dispatch:
     types: [docs]
 
@@ -16,6 +17,8 @@ jobs:
         uses: crystal-lang/install-crystal@v1
       - name: Install Components
         run: shards install --without-development
+        env:
+          SHARDS_OVERRIDE: shard.prod.yml
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -46,6 +46,10 @@ function tag()
   git tag -asm "$MESSAGE" $TAG
   git push --quiet origin $TAG
 
+  # Be sure to reset `docs` branch back to current state of `master` as a release assumes the previously cherry-picked commits are now inherently included
+  git branch --quiet --force docs master
+  git push --quiet origin docs --force
+
   printf "Tagged \e]8;;https://github.com/athena-framework/%s/releases/tag/%s\e\\%s\e]8;;\e\\ \n" $1 $TAG "$MESSAGE"
 
   cd $OLDPWD

--- a/shard.prod.yml
+++ b/shard.prod.yml
@@ -1,0 +1,39 @@
+# Used for prod builds of the docs to ensure API docs can be updated w/o a dedicated release
+# $ SHARDS_OVERRIDE=shard.prod.yml shards update
+dependencies:
+  athena:
+    github: athena-framework/framework
+    branch: docs
+  athena-clock:
+    github: athena-framework/clock
+    branch: docs
+  athena-console:
+    github: athena-framework/console
+    branch: docs
+  athena-dependency_injection:
+    github: athena-framework/dependency-injection
+    branch: docs
+  athena-dotenv:
+    github: athena-framework/dotenv
+    branch: docs
+  athena-event_dispatcher:
+    github: athena-framework/event-dispatcher
+    branch: docs
+  athena-image_size:
+    github: athena-framework/image-size
+    branch: docs
+  athena-negotiation:
+    github: athena-framework/negotiation
+    branch: docs
+  athena-routing:
+    github: athena-framework/routing
+    branch: docs
+  athena-serializer:
+    github: athena-framework/serializer
+    branch: docs
+  athena-spec:
+    github: athena-framework/spec
+    branch: docs
+  athena-validator:
+    github: athena-framework/validator
+    branch: docs

--- a/shard.prod.yml
+++ b/shard.prod.yml
@@ -22,6 +22,9 @@ dependencies:
   athena-image_size:
     github: athena-framework/image-size
     branch: docs
+  athena-mercure:
+    github: athena-framework/mercure
+    branch: docs
   athena-negotiation:
     github: athena-framework/negotiation
     branch: docs


### PR DESCRIPTION
Production builds of the doc site now uses a dedicated shards override file that builds from `docs` branch of each component repo. This makes it possible to cherry pick commits from master into `docs`, then manually trigger a build without needing to do a release just to pull the latest change.

When a release does happen, `docs` is reset back to what `master` is as the two should now be in-sync.