### PR TITLE
Add nightly CI format job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check Format
         run: crystal tool format --check
+  check_format_nightly:
+    runs-on: ubuntu-latest
+    container:
+      image: crystallang/crystal:nightly-alpine
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check Format
+        run: crystal tool format --check
   coding_standards:
     runs-on: ubuntu-latest
     container:

--- a/src/components/routing/src/requirement/enum.cr
+++ b/src/components/routing/src/requirement/enum.cr
@@ -14,9 +14,7 @@
 # class ExampleController < ATH::Controller
 #   @[ARTA::Get(
 #     "/color/{color}",
-#     requirements: {
-#       "color" => ART::Requirement::Enum(Color).new,
-#     }
+#     requirements: {"color" => ART::Requirement::Enum(Color).new},
 #   )]
 #   def get_color(color : Color) : Color
 #     color
@@ -24,9 +22,7 @@
 #
 #   @[ARTA::Get(
 #     "/rgb-color/{color}",
-#     requirements: {
-#       "color" => ART::Requirement::Enum(Color).new(:red, :green, :blue),
-#     }
+#     requirements: {"color" => ART::Requirement::Enum(Color).new(:red, :green, :blue)},
 #   )]
 #   def get_rgb_color(color : Color) : Color
 #     color

--- a/src/components/routing/src/requirement/requirement.cr
+++ b/src/components/routing/src/requirement/requirement.cr
@@ -6,9 +6,7 @@
 # class ExampleController < ATH::Controller
 #   @[ARTA::Get(
 #     "/user/{id}",
-#     requirements: {
-#       "id" => ART::Requirement::DIGITS,
-#     }
+#     requirements: {"id" => ART::Requirement::DIGITS},
 #   )]
 #   def get_user(id : Int64) : Int64
 #     id
@@ -16,9 +14,7 @@
 #
 #   @[ARTA::Get(
 #     "/article/{slug}",
-#     requirements: {
-#       "slug" => ART::Requirement::ASCII_SLUG,
-#     }
+#     requirements: {"slug" => ART::Requirement::ASCII_SLUG},
 #   )]
 #   def get_article(slug : String) : String
 #     slug

--- a/src/components/spec/spec/athena-spec_spec.cr
+++ b/src/components/spec/spec/athena-spec_spec.cr
@@ -137,7 +137,7 @@ struct TestWithTest < ASPEC::TestCase
   @[TestWith(
     two: {2, 4},
     three: {3, 9},
-    "with spaces": {4, 16}
+    "with spaces": {4, 16},
   )]
   def test_squares(value : Int32, expected : Int32) : Nil
     (value ** 2).should eq expected


### PR DESCRIPTION
Will enable catching regressions like https://github.com/crystal-lang/crystal/issues/14470 earlier to avoid blocking merges. Also adjusts formatting a bit to avoid the bug.