### PR TITLE
Doc fixes

### DIFF
--- a/docs/css/monorepo.css
+++ b/docs/css/monorepo.css
@@ -1,0 +1,4 @@
+/* Hide latest release since the monorepo is the old framework repo and still has tags */
+.md-source__fact--version {
+    display: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ repo_url: https://github.com/athena-framework/athena
 
 extra_css:
   - css/index.css
+  - css/monorepo.css
 
 plugins:
   - search

--- a/src/components/framework/CHANGELOG.md
+++ b/src/components/framework/CHANGELOG.md
@@ -161,12 +161,12 @@ _Last release in the [athena-framework/athena](https://github.com/athena-framewo
 - Fix incorrect ivar type on `AVD::Exceptions::Exceptions::ValidationFailed#violations` ([#116](https://github.com/athena-framework/athena/pull/116)) (George Dietrich)
 - Correctly reject requests with whitespace when converting numeric inputs ([#117](https://github.com/athena-framework/athena/pull/117)) (George Dietrich)
 
-[0.19.0]: https://github.com/athena-framework/athena/releases/tag/v0.19.0
-[0.18.2]: https://github.com/athena-framework/athena/releases/tag/v0.18.2
-[0.18.1]: https://github.com/athena-framework/athena/releases/tag/v0.18.1
-[0.18.0]: https://github.com/athena-framework/athena/releases/tag/v0.18.0
-[0.17.1]: https://github.com/athena-framework/athena/releases/tag/v0.17.1
-[0.17.0]: https://github.com/athena-framework/athena/releases/tag/v0.17.0
-[0.16.0]: https://github.com/athena-framework/athena/releases/tag/v0.16.0
+[0.19.0]: https://github.com/athena-framework/framework/releases/tag/v0.19.0
+[0.18.2]: https://github.com/athena-framework/framework/releases/tag/v0.18.2
+[0.18.1]: https://github.com/athena-framework/framework/releases/tag/v0.18.1
+[0.18.0]: https://github.com/athena-framework/framework/releases/tag/v0.18.0
+[0.17.1]: https://github.com/athena-framework/framework/releases/tag/v0.17.1
+[0.17.0]: https://github.com/athena-framework/framework/releases/tag/v0.17.0
+[0.16.0]: https://github.com/athena-framework/framework/releases/tag/v0.16.0
 [0.15.1]: https://github.com/athena-framework/athena/releases/tag/v0.15.1
 [0.15.0]: https://github.com/athena-framework/athena/releases/tag/v0.15.0


### PR DESCRIPTION
* Hide GH release version from root docs GH integration
* Fix links to the more modern framework relases