### PR TITLE
Handle `framework` landing page differently

### DIFF
--- a/gen_doc_stubs.py
+++ b/gen_doc_stubs.py
@@ -33,7 +33,8 @@ for typ in root.lookup("Athena").walk_types():
     filename = '/'.join(typ.abs_id.split('::')[2:] + ['index.md'])
 
     # Rename the root `index.md` to `top_level.md` so that the user lands on the introduction page instead of the root component module docs.
-    if filename == 'index.md':
+    # But only do this for non-framework components as the site itself is the contextual docs for the framework.
+    if typ.full_name != 'Athena::Framework' and filename == 'index.md':
         filename = 'top_level.md'
 
     with mkdocs_gen_files.open(filename, 'w') as f:

--- a/src/components/framework/docs/README.md
+++ b/src/components/framework/docs/README.md
@@ -1,1 +1,0 @@
-Root Docs

--- a/src/components/framework/mkdocs.yml
+++ b/src/components/framework/mkdocs.yml
@@ -5,11 +5,10 @@ site_url: https://athenaframework.org/Framework/
 repo_url: https://github.com/athena-framework/framework
 
 nav:
-  - Introduction: README.md
   - Back to Manual: project://.
   - API:
     - Aliases: aliases.md
-    - Top Level: top_level.md
+    - Top Level: index.md
     - '*'
 
 plugins:

--- a/src/components/framework/src/ext/clock.cr
+++ b/src/components/framework/src/ext/clock.cr
@@ -1,4 +1,5 @@
 @[ADI::Register(name: "clock", alias: ACLK::Interface, factory: "create")]
+# :nodoc:
 class Athena::Clock
   # :nodoc:
   #


### PR DESCRIPTION
Given the `framework` component docs are the root site itself, I don't think there needs to be a introduction landing page for this component. This PR updates things to make it land directly on top level API type.