### PR TITLE
Ensure built-in error renderer is properly aliased to the interface

### DIFF
--- a/src/components/dependency_injection/spec/compiler_passes/auto_wire_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/auto_wire_spec.cr
@@ -17,7 +17,8 @@ record AutoWireService, auto_wire_two : AutoWireInterface
 
 module SameInstanceAliasInterface; end
 
-@[ADI::Register(alias: SameInstanceAliasInterface)]
+@[ADI::Register]
+@[ADI::AsAlias]
 class SameInstancePrimary
   include SameInstanceAliasInterface
 end

--- a/src/components/framework/src/error_renderer.cr
+++ b/src/components/framework/src/error_renderer.cr
@@ -1,4 +1,5 @@
-@[ADI::Register(_debug: "%framework.debug%", alias: Athena::Framework::ErrorRendererInterface)]
+@[ADI::Register(_debug: "%framework.debug%")]
+@[ADI::AsAlias]
 # The default `ATH::ErrorRendererInterface`, JSON serializes the exception.
 struct Athena::Framework::ErrorRenderer
   include Athena::Framework::ErrorRendererInterface

--- a/src/components/framework/src/error_renderer_interface.cr
+++ b/src/components/framework/src/error_renderer_interface.cr
@@ -7,7 +7,8 @@
 # require "athena"
 #
 # # Alias this service to be used when the `ATH::ErrorRendererInterface` type is encountered.
-# @[ADI::Register(alias: ATH::ErrorRendererInterface)]
+# @[ADI::Register]
+# @[ADI::AsAlias]
 # struct Athena::Framework::CustomErrorRenderer
 #   include Athena::Framework::ErrorRendererInterface
 #


### PR DESCRIPTION
* Also update docs to use new `AsAlias` annotation