### PR TITLE
Run compiled tests on faster arm64 mac OS vs ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Ameba
         run: ./bin/ameba
   test_compiled:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Crystal


### PR DESCRIPTION
`macos-latest` is and will now be arm64 based, which seems to be quite a bit faster than the other options. Because `test_compiled` is just testing compile time errors we can make this switch for the faster compile times to speed up this job.

Seemed to finish ~3min faster. I'll take that.