### PR TITLE
Be more strict when it comes to resolving interface based services

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,8 +3,6 @@ extend-ignore-re = ["(?Rm)^.*#\\s*spellchecker:disable-line$"]
 
 [default.extend-words]
 referer = "referrer"
-alternateively = "alternatively"
-improvemnets = "improvements"
 
 [files]
 extend-exclude = [

--- a/src/components/dependency_injection/spec/compiler_passes/define_getters_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/define_getters_spec.cr
@@ -15,14 +15,6 @@ private def assert_error(message : String, code : String, *, line : Int32 = __LI
   CR
 end
 
-private def assert_success(code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_success <<-CR, codegen: true, line: line
-    require "../spec_helper.cr"
-    #{code}
-    ADI::ServiceContainer.new
-  CR
-end
-
 describe ADI::ServiceContainer::DefineGetters, tags: "compiled" do
   describe "compiler errors" do
     describe "aliases" do

--- a/src/components/dependency_injection/spec/compiler_passes/namespaced_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/namespaced_spec.cr
@@ -1,6 +1,6 @@
 require "../spec_helper"
 
-@[ADI::Register(public: true)]
+@[ADI::Register]
 class MyApp::Models::Foo
 end
 

--- a/src/components/framework/src/controller/argument_resolver.cr
+++ b/src/components/framework/src/controller/argument_resolver.cr
@@ -4,6 +4,7 @@ require "./argument_resolver_interface"
 ADI.bind value_resolvers : Array(Athena::Framework::Controller::ValueResolvers::Interface), "!athena.controller.value_resolver"
 
 @[ADI::Register]
+@[ADI::AsAlias]
 # The default implementation of `ATH::Controller::ArgumentResolverInterface`.
 struct Athena::Framework::Controller::ArgumentResolver
   include Athena::Framework::Controller::ArgumentResolverInterface

--- a/src/components/framework/src/controller_resolver.cr
+++ b/src/components/framework/src/controller_resolver.cr
@@ -4,6 +4,7 @@ module Athena::Framework::ControllerResolverInterface
 end
 
 @[ADI::Register]
+@[ADI::AsAlias]
 # :nodoc:
 class Athena::Framework::ControllerResolver
   include Athena::Framework::ControllerResolverInterface

--- a/src/components/framework/src/ext/serializer.cr
+++ b/src/components/framework/src/ext/serializer.cr
@@ -1,6 +1,7 @@
 require "athena-serializer"
 
 @[ADI::Register]
+@[ADI::AsAlias]
 struct Athena::Serializer::Serializer; end
 
 @[ADI::Register]

--- a/src/components/framework/src/ext/validator.cr
+++ b/src/components/framework/src/ext/validator.cr
@@ -3,6 +3,7 @@ require "athena-validator"
 require "./validator/validation_failed_exception"
 
 @[ADI::Register]
+@[ADI::AsAlias]
 class Athena::Validator::Validator::RecursiveValidator; end
 
 @[ADI::Autoconfigure(tags: ["athena.validator.constraint_validator"])]

--- a/src/components/framework/src/params/param_fetcher.cr
+++ b/src/components/framework/src/params/param_fetcher.cr
@@ -1,6 +1,7 @@
 require "./param_fetcher_interface"
 
 @[ADI::Register]
+@[ADI::AsAlias]
 # Basic implementation of `ATH::Params::ParamFetcherInterface`.
 #
 # WARNING: May only be used _after_ the related `ATH::Action` has been resolved.

--- a/src/components/framework/src/view/view_handler.cr
+++ b/src/components/framework/src/view/view_handler.cr
@@ -3,6 +3,8 @@ require "./configurable_view_handler_interface"
 ADI.bind format_handlers : Array(Athena::Framework::View::FormatHandlerInterface), "!athena.format_handler"
 
 @[ADI::Register]
+@[ADI::AsAlias(ATH::View::ConfigurableViewHandlerInterface)]
+@[ADI::AsAlias(ATH::View::ViewHandlerInterface)]
 # Default implementation of `ATH::View::ConfigurableViewHandlerInterface`.
 class Athena::Framework::View::ViewHandler
   include Athena::Framework::View::ConfigurableViewHandlerInterface


### PR DESCRIPTION
## Context

When auto wiring service dependencies, if there was only one service that is compatible with a parameter's type restriction, that service would be used. This PR makes this logic a bit more strict by not doing this if the parameter's type restriction is a module, i.e. an interface.

The reasoning for this change is to prevent the surprise error when you define an interface with a single default implementation. When a parameter was typed as this interface, things would work fine. However, if another implementation of that interface was introduced, you would now have an error.

This change forces you to explicitly alias the default implementation, which can most likely be accomplished by simply annotating the default service with `@[ADI::AsAlias]`.

## Changes

* **Breaking:** Require services to be explicitly aliased
