### PR TITLE
Add `rebuildDocs` helper script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -73,8 +73,9 @@ function rebuildDocs()
 
 # Helper script to assist in component release tasks
 #
-# tag     - Creates a signed git tag at the latest commit for the provided component(s). ./scripts/release.sh tag clock:0.1.0 console:0.4.0
-# docPick - Cherry-picks a commit to the docs branch of the provided component. ./scripts/release.sh docPick dotenv abc123
+# tag       - Creates a signed git tag at the latest commit for the provided component(s). ./scripts/release.sh tag clock:0.1.0 console:0.4.0
+# docPick   - Cherry-picks a commit to the docs branch of the provided component. ./scripts/release.sh docPick dotenv abc123
+# buildDocs - Triggers a re-build of https://athenaframework.org/ for the production environment.
 
 METHOD=$1
 


### PR DESCRIPTION
## Context

Make it easier to trigger re-builds of the API docs. Also removes the need to remember to manually trigger one after tagging component(s).

Test build: https://github.com/athena-framework/athena/actions/runs/9025245937

## Changelog

* Add script to trigger a rebuild of the Athena docs
* Call it after tagging components