### PR TITLE
Provide utility method to run a console application

### DIFF
--- a/docs/getting_started/commands.md
+++ b/docs/getting_started/commands.md
@@ -49,7 +49,7 @@ end
 ```
 
 From here, if the application was created using the [skeleton](https://github.com/athena-framework/skeleton), commands can be executed via `shards run console -- admin:create-user 12 "George Dietrich" --admin`.
-Otherwise see [Athena::Console](/Console) for how to setup your CLI entry point.
+Otherwise [ATH.run_console](/Framework/#Athena::Framework.run_console) can be used for your [entrypoint](/Console/#entrypoint) file.
 
 NOTE: During *development* the console binary needs to re-build the application in order to have access to the changes made since last execution.
 When deploying a *production* console binary, or if not doing any new console command dev, build it with the `--release` flag for increased performance.

--- a/src/components/framework/src/athena.cr
+++ b/src/components/framework/src/athena.cr
@@ -165,6 +165,13 @@ module Athena::Framework
     ATH::Server.new(port, host, reuse_port, ssl_context, prepend_handlers).start
   end
 
+  # Runs an `ATH::Console::Application` as the entrypoint of `Athena::Console`.
+  #
+  # Checkout the [Getting Started](/getting_started/commands) docs for more information.
+  def self.run_console : Nil
+    ADI.container.athena_console_application.run
+  end
+
   # :nodoc:
   #
   # Currently an implementation detail. In the future could be exposed to allow having separate "groups" of controllers that a `Server` instance handles.

--- a/src/components/framework/src/ext/console/application.cr
+++ b/src/components/framework/src/ext/console/application.cr
@@ -1,13 +1,12 @@
 @[ADI::Register(public: true, name: "athena_console_application")]
 # Entrypoint for the `Athena::Console` integration.
-# This service should be fetched via `ADI.container` within your console CLI file.
 #
 # ```
 # # Require your code
 # require "./main"
 #
 # # Run the application
-# ADI.container.athena_console_application.run
+# ATH.run_console
 # ```
 #
 # Checkout the [Getting Started](/getting_started/commands) docs for more information.


### PR DESCRIPTION
## Context

When using the framework's `Athena::Console` integration, you needed to access and run a specific service from the container via `ADI.container.athena_console_application.run`. This isn't the most user friendly, so this PR adds `ATH.run_console`, similar to `ATH.run`, but for the console context.

This also provides a level of abstraction in case something changes in the future, the user won't have to update their code.