### PR TITLE
Use `utf-8` as lowercase is preferred

### DIFF
--- a/src/components/framework/spec/binary_file_response_spec.cr
+++ b/src/components/framework/spec/binary_file_response_spec.cr
@@ -44,7 +44,7 @@ struct ATH::BinaryFileResponseTest < ASPEC::TestCase
     response = ATH::BinaryFileResponse.new __FILE__
     response.set_content_disposition :attachment, "föö.html", "FILE"
 
-    response.headers["content-disposition"]?.should eq %(attachment; filename=FILE; filename*=UTF-8''f%C3%B6%C3%B6.html)
+    response.headers["content-disposition"]?.should eq %(attachment; filename=FILE; filename*=utf-8''f%C3%B6%C3%B6.html)
   end
 
   def test_set_content_disposition_custom_filename : Nil

--- a/src/components/framework/spec/error_renderer_spec.cr
+++ b/src/components/framework/spec/error_renderer_spec.cr
@@ -19,7 +19,7 @@ describe ATH::ErrorRenderer do
     response = renderer.render exception
 
     response.headers["retry-after"].should eq "42"
-    response.headers["content-type"].should eq "application/json; charset=UTF-8"
+    response.headers["content-type"].should eq "application/json; charset=utf-8"
     response.status.should eq HTTP::Status::TOO_MANY_REQUESTS
     response.content.should eq %({"code":429,"message":"cool your jets"})
   end
@@ -31,7 +31,7 @@ describe ATH::ErrorRenderer do
 
     response = renderer.render exception
 
-    response.headers["content-type"].should eq "application/json; charset=UTF-8"
+    response.headers["content-type"].should eq "application/json; charset=utf-8"
     response.headers["x-debug-exception-message"]?.should be_nil
     response.headers["x-debug-exception-class"]?.should be_nil
     response.headers["x-debug-exception-file"]?.should be_nil
@@ -49,7 +49,7 @@ describe ATH::ErrorRenderer do
 
       response = renderer.render exception
 
-      response.headers["content-type"].should eq "application/json; charset=UTF-8"
+      response.headers["content-type"].should eq "application/json; charset=utf-8"
       response.headers["x-debug-exception-message"].should eq "ERR"
       response.headers["x-debug-exception-class"].should eq "MockException"
       response.headers["x-debug-exception-file"].should match /#{URI.encode_path path.to_s}:\d+:\d+$/
@@ -66,7 +66,7 @@ describe ATH::ErrorRenderer do
 
       response = renderer.render exception
 
-      response.headers["content-type"].should eq "application/json; charset=UTF-8"
+      response.headers["content-type"].should eq "application/json; charset=utf-8"
       response.headers["x-debug-exception-message"].should eq "ERR"
       response.headers["x-debug-exception-class"].should eq "MockException"
       response.headers["x-debug-exception-file"].should match /#{URI.encode_path path.to_s}:\d+$/

--- a/src/components/framework/spec/header_utils_spec.cr
+++ b/src/components/framework/spec/header_utils_spec.cr
@@ -30,8 +30,8 @@ struct ATH::HeaderUtilsTest < ASPEC::TestCase
       {ATH::BinaryFileResponse::ContentDisposition::Attachment, "foo.html", nil, "attachment; filename=foo.html"},
       {ATH::BinaryFileResponse::ContentDisposition::Attachment, "foo bar.html", nil, "attachment; filename=foo\\ bar.html"},
       {ATH::BinaryFileResponse::ContentDisposition::Attachment, %(foo "bar".html), nil, %(attachment; filename=foo\\ \\"bar\\".html)},
-      {ATH::BinaryFileResponse::ContentDisposition::Attachment, "foo%20bar.html", "foo bar.html", "attachment; filename=foo\\ bar.html; filename*=UTF-8''foo%2520bar.html"},
-      {ATH::BinaryFileResponse::ContentDisposition::Attachment, "föö.html", "foo.html", "attachment; filename=foo.html; filename*=UTF-8''f%C3%B6%C3%B6.html"},
+      {ATH::BinaryFileResponse::ContentDisposition::Attachment, "foo%20bar.html", "foo bar.html", "attachment; filename=foo\\ bar.html; filename*=utf-8''foo%2520bar.html"},
+      {ATH::BinaryFileResponse::ContentDisposition::Attachment, "föö.html", "foo.html", "attachment; filename=foo.html; filename*=utf-8''f%C3%B6%C3%B6.html"},
     }
   end
 

--- a/src/components/framework/spec/response_spec.cr
+++ b/src/components/framework/spec/response_spec.cr
@@ -112,11 +112,11 @@ describe ATH::Response do
     it "does not override content-type if already set" do
       request = ATH::Request.new "GET", "/"
       request.request_format = "json"
-      response = ATH::Response.new "CONTENT", headers: HTTP::Headers{"content-type" => "application/json; charset=UTF-8"}
+      response = ATH::Response.new "CONTENT", headers: HTTP::Headers{"content-type" => "application/json; charset=utf-8"}
 
       response.prepare request
 
-      response.headers["content-type"].should eq "application/json; charset=UTF-8"
+      response.headers["content-type"].should eq "application/json; charset=utf-8"
     end
 
     it "adds the charset to text based formats" do
@@ -126,7 +126,7 @@ describe ATH::Response do
 
       response.prepare request
 
-      response.headers["content-type"].should eq "text/csv; charset=UTF-8"
+      response.headers["content-type"].should eq "text/csv; charset=utf-8"
     end
 
     it "allows customizing the charset" do

--- a/src/components/framework/spec/view/format_negotiator_spec.cr
+++ b/src/components/framework/spec/view/format_negotiator_spec.cr
@@ -57,7 +57,7 @@ struct FormatNegotiatorTest < ASPEC::TestCase
 
   def test_best : Nil
     @request.headers["accept"] = "application/xhtml+xml, text/html, application/xml;q=0.9, */*;q=0.8"
-    priorities = ["text/html; charset=UTF-8", "html", "application/json"]
+    priorities = ["text/html; charset=utf-8", "html", "application/json"]
     self.add_rule priorities: priorities
 
     @negotiator.best("").should eq ANG::Accept.new "text/html;charset=utf-8"

--- a/src/components/framework/src/controller.cr
+++ b/src/components/framework/src/controller.cr
@@ -33,7 +33,7 @@
 #   # useful if the content is too large to fit into memory.
 #   @[ARTA::Get(path: "/users")]
 #   def users : ATH::Response
-#     ATH::StreamedResponse.new headers: HTTP::Headers{"content-type" => "application/json; charset=UTF-8"} do |io|
+#     ATH::StreamedResponse.new headers: HTTP::Headers{"content-type" => "application/json; charset=utf-8"} do |io|
 #       User.all.to_json io
 #     end
 #   end

--- a/src/components/framework/src/error_renderer.cr
+++ b/src/components/framework/src/error_renderer.cr
@@ -16,7 +16,7 @@ struct Athena::Framework::ErrorRenderer
       headers = HTTP::Headers.new
     end
 
-    headers["content-type"] = "application/json; charset=UTF-8"
+    headers["content-type"] = "application/json; charset=utf-8"
 
     # TODO: Use a better API to get the file/line/column info.
     if @debug && (backtrace = exception.backtrace?.try(&.first).to_s.presence)

--- a/src/components/framework/src/header_utils.cr
+++ b/src/components/framework/src/header_utils.cr
@@ -8,8 +8,8 @@ module Athena::Framework::HeaderUtils
   #
   # ```
   # ATH::HeaderUtils.make_disposition :attachment, "download.txt"         # => attachment; filename="download.txt"
-  # ATH::HeaderUtils.make_disposition :attachment, "föö.html"             # => attachment; filename="f__.html"; filename*=UTF-8''f%C3%B6%C3%B6.html
-  # ATH::HeaderUtils.make_disposition :attachment, "föö.html", "foo.html" # => attachment; filename="foo.html"; filename*=UTF-8''f%C3%B6%C3%B6.html
+  # ATH::HeaderUtils.make_disposition :attachment, "föö.html"             # => attachment; filename="f__.html"; filename*=utf-8''f%C3%B6%C3%B6.html
+  # ATH::HeaderUtils.make_disposition :attachment, "föö.html", "foo.html" # => attachment; filename="foo.html"; filename*=utf-8''f%C3%B6%C3%B6.html
   # ```
   #
   # This method can be used to enable downloads of dynamically generated files.
@@ -49,7 +49,7 @@ module Athena::Framework::HeaderUtils
     }
 
     if filename != fallback_filename
-      params["filename*"] = "UTF-8''#{URI.encode_path_segment filename}"
+      params["filename*"] = "utf-8''#{URI.encode_path_segment filename}"
     end
 
     String.build do |io|

--- a/src/components/framework/src/response.cr
+++ b/src/components/framework/src/response.cr
@@ -78,7 +78,7 @@ class Athena::Framework::Response
   getter status : HTTP::Status
 
   # Returns the character set this response is encoded as.
-  property charset : String = "UTF-8"
+  property charset : String = "utf-8"
 
   # Returns the response headers of this response.
   getter headers : ATH::Response::Headers

--- a/src/components/framework/src/streamed_response.cr
+++ b/src/components/framework/src/streamed_response.cr
@@ -17,7 +17,7 @@ class Athena::Framework::StreamedResponse < Athena::Framework::Response
   # class ExampleController < ATH::Controller
   #   @[ARTA::Get("/users")]
   #   def users : ATH::Response
-  #     ATH::StreamedResponse.new headers: HTTP::Headers{"content-type" => "application/json; charset=UTF-8"} do |io|
+  #     ATH::StreamedResponse.new headers: HTTP::Headers{"content-type" => "application/json; charset=utf-8"} do |io|
   #       User.all.to_json io
   #     end
   #   end

--- a/src/components/negotiation/docs/README.md
+++ b/src/components/negotiation/docs/README.md
@@ -24,12 +24,12 @@ Each negotiator exposes two methods: [ANG::AbstractNegotiator#best][] and [ANG::
 negotiator = ANG.negotiator
 
 accept_header = "text/html, application/xhtml+xml, application/xml;q=0.9"
-priorities = ["text/html; charset=UTF-8", "application/json", "application/xml;q=0.5"]
+priorities = ["text/html; charset=utf-8", "application/json", "application/xml;q=0.5"]
 
 accept = negotiator.best(accept_header, priorities).not_nil!
 
 accept.media_range # => "text/html"
-accept.parameters  # => {"charset" => "UTF-8"}
+accept.parameters  # => {"charset" => "utf-8"}
 ```
 
 The [ANG::Negotiator][] type returns an [ANG::Accept][], or `nil` if negotiating the best media type has failed.
@@ -39,7 +39,7 @@ The [ANG::Negotiator][] type returns an [ANG::Accept][], or `nil` if negotiating
 ```crystal
 negotiator = ANG.charset_negotiator
 
-accept_header = "ISO-8859-1, UTF-8; q=0.9"
+accept_header = "ISO-8859-1, utf-8; q=0.9"
 priorities = ["iso-8859-1;q=0.3", "utf-8;q=0.9", "utf-16;q=1.0"]
 
 accept = negotiator.best(accept_header, priorities).not_nil!

--- a/src/components/negotiation/spec/negotiator_spec.cr
+++ b/src/components/negotiation/spec/negotiator_spec.cr
@@ -71,9 +71,9 @@ struct NegotiatorTest < NegotiatorTestCase
       {"image/png, text/plain, audio/ogg", {"baz/asdf"}, nil},
       {"image/png, text/plain, audio/ogg", {"audio/ogg"}, {"audio/ogg", nil}},
       {"image/png, text/plain, audio/ogg", {"YO/SuP"}, nil},
-      {"text/html; charset=UTF-8, application/pdf", {"text/html; charset=UTF-8"}, {"text/html", {"charset" => "UTF-8"}}},
-      {"text/html; charset=UTF-8, application/pdf", {"text/html"}, nil},
-      {"text/html, application/pdf", {"text/html; charset=UTF-8"}, {"text/html", {"charset" => "UTF-8"}}},
+      {"text/html; charset=utf-8, application/pdf", {"text/html; charset=utf-8"}, {"text/html", {"charset" => "utf-8"}}},
+      {"text/html; charset=utf-8, application/pdf", {"text/html"}, nil},
+      {"text/html, application/pdf", {"text/html; charset=utf-8"}, {"text/html", {"charset" => "utf-8"}}},
 
       # PHP"s PEAR HTTP2 assertions I took from the other lib.
       {php_pear_header, {"image/gif", "image/png", "application/xhtml+xml", "application/xml", "text/html", "image/jpeg", "text/plain"}, {"image/png", nil}},

--- a/src/components/negotiation/src/accept.cr
+++ b/src/components/negotiation/src/accept.cr
@@ -3,11 +3,11 @@ require "./base_accept"
 # Represents an [Accept](https://tools.ietf.org/html/rfc7231#section-5.3.2) header media type.
 #
 # ```
-# accept = ANG::Accept.new "application/json; q = 0.75; charset = UTF-8"
+# accept = ANG::Accept.new "application/json; q = 0.75; charset = utf-8"
 #
-# accept.header            # => "application/json; q = 0.75; charset = UTF-8"
-# accept.normalized_header # => "application/json; charset=UTF-8"
-# accept.parameters        # => {"charset" => "UTF-8"}
+# accept.header            # => "application/json; q = 0.75; charset = utf-8"
+# accept.normalized_header # => "application/json; charset=utf-8"
+# accept.parameters        # => {"charset" => "utf-8"}
 # accept.quality           # => 0.75
 # accept.type              # => "application"
 # accept.sub_type          # => "json"

--- a/src/components/negotiation/src/base_accept.cr
+++ b/src/components/negotiation/src/base_accept.cr
@@ -10,7 +10,7 @@ abstract struct Athena::Negotiation::BaseAccept
   getter normalized_header : String
 
   # Returns any extension parameters included in the header `self` represents.
-  # E.x. `charset=UTF-8` or `version=2`.
+  # E.x. `charset=utf-8` or `version=2`.
   getter parameters : Hash(String, String) = Hash(String, String).new
 
   # Returns the [quality value](https://tools.ietf.org/html/rfc7231#section-5.3.1) of the header `self` represents.


### PR DESCRIPTION
## Context

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type#charset Calls out that:

> The character encoding standard. Case insensitive, lowercase is preferred.

This PR updates the casing to be the preferred casing.