### PR TITLE
Relax `ACON::Application` version to accept any String

### DIFF
--- a/src/components/console/spec/application_spec.cr
+++ b/src/components/console/spec/application_spec.cr
@@ -32,6 +32,10 @@ struct ApplicationTest < ASPEC::TestCase
     ACON::Application.new("foo", "1.2.3").long_version.should eq "foo <info>1.2.3</info>"
   end
 
+  def test_long_version_non_semver : Nil
+    ACON::Application.new("foo", "2024.1.2").long_version.should eq "foo <info>2024.1.2</info>"
+  end
+
   def test_help : Nil
     ACON::Application.new("foo", "1.2.3").help.should eq "foo <info>1.2.3</info>"
   end

--- a/src/components/console/spec/commands/list_spec.cr
+++ b/src/components/console/spec/commands/list_spec.cr
@@ -39,7 +39,7 @@ struct ListCommandTest < ASPEC::TestCase
     tester.execute command: "list", decorated: false
 
     tester.display(true).should eq normalize <<-OUTPUT
-      foo 0.1.0
+      foo UNKNOWN
 
       Usage:
         command [options] [arguments]

--- a/src/components/console/spec/fixtures/applications/descriptor2.cr
+++ b/src/components/console/spec/fixtures/applications/descriptor2.cr
@@ -1,6 +1,6 @@
 class DescriptorApplication2 < ACON::Application
   def initialize
-    super "My Athena application", SemanticVersion.new 1, 0, 0
+    super "My Athena application", "1.0.0"
 
     self.add DescriptorCommand1.new
     self.add DescriptorCommand2.new

--- a/src/components/console/spec/fixtures/text/application_1.txt
+++ b/src/components/console/spec/fixtures/text/application_1.txt
@@ -1,4 +1,4 @@
-foo <info>0.1.0</info>
+foo <info>UNKNOWN</info>
 
 <comment>Usage:</comment>
   command [options] [arguments]

--- a/src/components/console/spec/fixtures/text/application_run1.txt
+++ b/src/components/console/spec/fixtures/text/application_run1.txt
@@ -1,4 +1,4 @@
-foo 0.1.0
+foo UNKNOWN
 
 Usage:
   command \[options\] \[arguments\]

--- a/src/components/console/spec/fixtures/text/application_run4.txt
+++ b/src/components/console/spec/fixtures/text/application_run4.txt
@@ -1,1 +1,1 @@
-foo 0.1.0
+foo UNKNOWN

--- a/src/components/console/src/application.cr
+++ b/src/components/console/src/application.cr
@@ -1,4 +1,3 @@
-require "semantic_version"
 require "levenshtein"
 
 # A container for a collection of multiple `ACON::Command`, and serves as the entry point of a CLI application.
@@ -25,7 +24,7 @@ require "levenshtein"
 # override the array of default commands, or customize the default input options, etc.
 class Athena::Console::Application
   # Returns the version of this CLI application.
-  getter version : SemanticVersion
+  getter version : String
 
   # Returns the name of this CLI application.
   getter name : String
@@ -96,11 +95,7 @@ class Athena::Console::Application
   @terminal : ACON::Terminal
   @wants_help : Bool = false
 
-  def self.new(name : String, version : String = "0.1.0") : self
-    new name, SemanticVersion.parse version
-  end
-
-  def initialize(@name : String, @version : SemanticVersion = SemanticVersion.new(0, 1, 0))
+  def initialize(@name : String, @version : String = "UNKNOWN")
     @terminal = ACON::Terminal.new
 
     # TODO: Emit events when certain signals are triggered.

--- a/src/components/console/src/athena-console.cr
+++ b/src/components/console/src/athena-console.cr
@@ -1,4 +1,5 @@
 require "ecr"
+require "semantic_version"
 
 require "athena-clock"
 

--- a/src/components/framework/src/ext/console/application.cr
+++ b/src/components/framework/src/ext/console/application.cr
@@ -16,7 +16,7 @@ class Athena::Framework::Console::Application < ACON::Application
     event_dipatcher : AED::EventDispatcherInterface? = nil,
     eager_commands : Enumerable(ACON::Command)? = nil
   )
-    super "Athena", SemanticVersion.parse ATH::VERSION
+    super "Athena", ATH::VERSION
 
     self.command_loader = command_loader
     # TODO: set event dispatcher when that's implemented in the console component.


### PR DESCRIPTION
## Context

`ACON::Application` allows providing a version representing the version of the application. This was previously needlessly strict in requiring a semver string. This PR relaxes this to allow any String, enabling calver, or whatever other format is desired.

This PR also makes the default version `UNKNOWN`, which is more accurate as we don't want to assume the versioning pattern of the application. This maybe will also encourage people to properly version it.

## Changelog

* **Breaking:** Make `ACON::Application#version` getter and ivar a `String`
* Default to `UNKNOWN` as we do not want to assume semver anymore
* Update `framework` integration to not try to still pass a `SemanticVersion`
