### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,19 +20,18 @@ jobs:
       - name: Check Spelling
         uses: crate-ci/typos@v1.22.1
   check_format:
+    strategy:
+      matrix:
+        crystal:
+          - latest
+          - nightly
     runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal:latest-alpine
     steps:
       - uses: actions/checkout@v4
-      - name: Check Format
-        run: crystal tool format --check
-  check_format_nightly:
-    runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal:nightly-alpine
-    steps:
-      - uses: actions/checkout@v4
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal }}
       - name: Check Format
         run: crystal tool format --check
   coding_standards:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,19 @@ jobs:
       - name: Ameba
         run: ./bin/ameba
   test_compiled:
+    strategy:
+      fail-fast: false
+      matrix:
+        crystal:
+          - latest
+          - nightly
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal }}
       - name: Install Dependencies
         run: shards install --skip-postinstall --skip-executables
         env:


### PR DESCRIPTION
## Context

I'd rather be safe than sorry and run compiled specs against nightly as well, just in case something not capture by the nightly unit test coverage breaks unintentionally.

## Changelog

* Run compiled specs against nightlies too
* Do not fail-fast either
* Consolidate `check_format` jobs using a matrix
