### PR TITLE
`.from_parameter` Improvements

### DIFF
--- a/src/components/framework/spec/athena_spec.cr
+++ b/src/components/framework/spec/athena_spec.cr
@@ -34,10 +34,16 @@ describe Athena::Framework do
     describe Bool do
       it "true" do
         Bool.from_parameter("true").should be_true
+        Bool.from_parameter("on").should be_true
+        Bool.from_parameter("1").should be_true
+        Bool.from_parameter("yes").should be_true
       end
 
       it "false" do
         Bool.from_parameter("false").should be_false
+        Bool.from_parameter("off").should be_false
+        Bool.from_parameter("0").should be_false
+        Bool.from_parameter("no").should be_false
       end
 
       it "invalid" do
@@ -72,6 +78,72 @@ describe Athena::Framework do
         expect_raises ArgumentError, "Invalid Nil" do
           Nil.from_parameter("foo")
         end
+      end
+    end
+  end
+
+  describe ".from_parameter?" do
+    describe Number do
+      it Int64 do
+        Int64.from_parameter?("123").should eq 123_i64
+      end
+
+      it "Int with whitespace" do
+        Int32.from_parameter?("   123").should be_nil
+      end
+
+      it Float32 do
+        Float32.from_parameter?("3.14").should eq 3.14_f32
+      end
+
+      it "Float with whitespace" do
+        Float64.from_parameter?("   123.5").should be_nil
+      end
+    end
+
+    describe Bool do
+      it "true" do
+        Bool.from_parameter?("true").should be_true
+        Bool.from_parameter?("on").should be_true
+        Bool.from_parameter?("1").should be_true
+        Bool.from_parameter?("yes").should be_true
+      end
+
+      it "false" do
+        Bool.from_parameter?("false").should be_false
+        Bool.from_parameter?("off").should be_false
+        Bool.from_parameter?("0").should be_false
+        Bool.from_parameter?("no").should be_false
+      end
+
+      it "invalid" do
+        Bool.from_parameter?("foo").should be_nil
+      end
+    end
+
+    it Object do
+      str = "foo"
+
+      String.from_parameter?(str).should be str
+    end
+
+    describe Array do
+      it "single type" do
+        Array(Int32).from_parameter?([1, 2]).should eq [1, 2]
+      end
+
+      it "Union type" do
+        Array(Int32 | Bool).from_parameter?([1, false]).should eq [1, false]
+      end
+    end
+
+    describe Nil do
+      it "valid" do
+        Nil.from_parameter?("null").should be_nil
+      end
+
+      it "invalid" do
+        Nil.from_parameter?("foo").should be_nil
       end
     end
   end

--- a/src/components/framework/src/ext/conversion_types.cr
+++ b/src/components/framework/src/ext/conversion_types.cr
@@ -14,10 +14,9 @@ end
 
 # :nodoc:
 def Bool.from_parameter(value : String) : Bool
-  if value == "true"
-    true
-  elsif value == "false"
-    false
+  case value
+  when "true", "1", "yes", "on"  then true
+  when "false", "0", "no", "off" then false
   else
     raise ArgumentError.new "Invalid Bool: #{value}"
   end
@@ -25,12 +24,9 @@ end
 
 # :nodoc:
 def Bool.from_parameter?(value : String) : Bool?
-  if value == "true"
-    true
-  elsif value == "false"
-    false
-  else
-    nil
+  case value
+  when "true", "1", "yes", "on"  then true
+  when "false", "0", "no", "off" then false
   end
 end
 
@@ -60,4 +56,8 @@ end
 # :nodoc:
 def Nil.from_parameter(value : String) : Nil
   raise ArgumentError.new "Invalid Nil: #{value}" unless value == "null"
+end
+
+# :nodoc:
+def Nil.from_parameter?(value : String) : Nil
 end


### PR DESCRIPTION
## Context

This PR makes resolving `Bool` properties a bit more user friendly by supporting more values than strictly `true` or `false`.

## Changelog

* Support additional `Bool` conversion values
* Add spec coverage to `.from_parameter?`