### PR TITLE
Handle Crystal 1.13 deprecation

### DIFF
--- a/src/components/dotenv/src/athena-dotenv.cr
+++ b/src/components/dotenv/src/athena-dotenv.cr
@@ -506,7 +506,14 @@ class Athena::Dotenv
 
   private def load(override_existing_vars : Bool, paths : Enumerable(String | ::Path)) : Nil
     paths.each do |path|
-      if !File.readable?(path) || File.directory?(path)
+      # TODO: Inline this again once 1.13.0 is the new min version
+      {% if compare_versions(Crystal::VERSION, "1.13.0-dev") >= 0 %}
+        is_file_readable = File::Info.readable? path
+      {% else %}
+        is_file_readable = File.readable? path
+      {% end %}
+
+      if !is_file_readable || File.directory?(path)
         raise Athena::Dotenv::Exceptions::Path.new path
       end
 

--- a/src/components/dotenv/src/athena-dotenv.cr
+++ b/src/components/dotenv/src/athena-dotenv.cr
@@ -507,15 +507,17 @@ class Athena::Dotenv
   private def load(override_existing_vars : Bool, paths : Enumerable(String | ::Path)) : Nil
     paths.each do |path|
       # TODO: Inline this again once 1.13.0 is the new min version
-      {% if compare_versions(Crystal::VERSION, "1.13.0-dev") >= 0 %}
-        is_file_readable = File::Info.readable? path
-      {% else %}
-        is_file_readable = File.readable? path
-      {% end %}
+      {% begin %}
+        {% if compare_versions(Crystal::VERSION, "1.13.0-dev") >= 0 %}
+          is_file_readable = File::Info.readable? path
+        {% else %}
+          is_file_readable = File.readable? path
+        {% end %}
 
-      if !is_file_readable || File.directory?(path)
-        raise Athena::Dotenv::Exceptions::Path.new path
-      end
+        if !is_file_readable || File.directory?(path)
+          raise Athena::Dotenv::Exceptions::Path.new path
+        end
+      {% end %}
 
       self.populate(self.parse(File.read(path), path), override_existing_vars)
     end

--- a/src/components/framework/src/binary_file_response.cr
+++ b/src/components/framework/src/binary_file_response.cr
@@ -58,13 +58,15 @@ class Athena::Framework::BinaryFileResponse < Athena::Framework::Response
     super nil, status, headers
 
     # TODO: Inline this again once 1.13.0 is the new min version
-    {% if compare_versions(Crystal::VERSION, "1.13.0-dev") >= 0 %}
-      is_file_readable = File::Info.readable? file_path
-    {% else %}
-      is_file_readable = File.readable? file_path
-    {% end %}
+    {% begin %}
+      {% if compare_versions(Crystal::VERSION, "1.13.0-dev") >= 0 %}
+        is_file_readable = File::Info.readable? file_path
+      {% else %}
+        is_file_readable = File.readable? file_path
+      {% end %}
 
-    raise File::Error.new("File '#{file_path}' must be readable.", file: file_path) unless is_file_readable
+      raise File::Error.new("File '#{file_path}' must be readable.", file: file_path) unless is_file_readable
+    {% end %}
 
     @file_path = Path.new(file_path).expand
 

--- a/src/components/framework/src/binary_file_response.cr
+++ b/src/components/framework/src/binary_file_response.cr
@@ -57,7 +57,14 @@ class Athena::Framework::BinaryFileResponse < Athena::Framework::Response
   )
     super nil, status, headers
 
-    raise File::Error.new("File '#{file_path}' must be readable.", file: file_path) unless File.readable? file_path
+    # TODO: Inline this again once 1.13.0 is the new min version
+    {% if compare_versions(Crystal::VERSION, "1.13.0-dev") >= 0 %}
+      is_file_readable = File::Info.readable? file_path
+    {% else %}
+      is_file_readable = File.readable? file_path
+    {% end %}
+
+    raise File::Error.new("File '#{file_path}' must be readable.", file: file_path) unless is_file_readable
 
     @file_path = Path.new(file_path).expand
 

--- a/src/components/validator/src/constraints/file.cr
+++ b/src/components/validator/src/constraints/file.cr
@@ -242,21 +242,23 @@ class Athena::Validator::Constraints::File < Athena::Validator::Constraint
       end
 
       # TODO: Inline this again once 1.13.0 is the new min version
-      {% if compare_versions(Crystal::VERSION, "1.13.0-dev") >= 0 %}
-        is_file_readable = ::File::Info.readable? path
-      {% else %}
-        is_file_readable = ::File.readable? path
+      {% begin %}
+        {% if compare_versions(Crystal::VERSION, "1.13.0-dev") >= 0 %}
+          is_file_readable = ::File::Info.readable? path
+        {% else %}
+          is_file_readable = ::File.readable? path
+        {% end %}
+
+        unless is_file_readable
+          self
+            .context
+            .build_violation(constraint.not_readable_message, NOT_READABLE_ERROR)
+            .add_parameter("{{ file }}", path)
+            .add
+
+          return
+        end
       {% end %}
-
-      unless is_file_readable
-        self
-          .context
-          .build_violation(constraint.not_readable_message, NOT_READABLE_ERROR)
-          .add_parameter("{{ file }}", path)
-          .add
-
-        return
-      end
 
       size_in_bytes = ::File.size path
       base_name = ::File.basename path

--- a/src/components/validator/src/constraints/file.cr
+++ b/src/components/validator/src/constraints/file.cr
@@ -253,7 +253,7 @@ class Athena::Validator::Constraints::File < Athena::Validator::Constraint
           self
             .context
             .build_violation(constraint.not_readable_message, NOT_READABLE_ERROR)
-            .add_parameter("{{ file }}", path)
+            .add_parameter("\{{ file }}", path)
             .add
 
           return

--- a/src/components/validator/src/constraints/file.cr
+++ b/src/components/validator/src/constraints/file.cr
@@ -242,7 +242,14 @@ class Athena::Validator::Constraints::File < Athena::Validator::Constraint
         return
       end
 
-      unless ::File.readable? path
+      # TODO: Inline this again once 1.13.0 is the new min version
+      {% if compare_versions(Crystal::VERSION, "1.13.0-dev") >= 0 %}
+        is_file_readable = ::File::Info.readable? path
+      {% else %}
+        is_file_readable = ::File.readable? path
+      {% end %}
+
+      unless is_file_readable
         self
           .context
           .build_violation(constraint.not_readable_message, NOT_READABLE_ERROR)

--- a/src/components/validator/src/constraints/file.cr
+++ b/src/components/validator/src/constraints/file.cr
@@ -219,7 +219,6 @@ class Athena::Validator::Constraints::File < Athena::Validator::Constraint
 
   class Validator < Athena::Validator::ConstraintValidator
     # :inherit:
-    # ameba:disable Metrics/CyclomaticComplexity
     def validate(value : _, constraint : AVD::Constraints::File) : Nil
       return if value.nil? || value == ""
 


### PR DESCRIPTION
## Context

https://github.com/crystal-lang/crystal/pull/14484 deprecation some File related methods. This PR updates the usages of those to use the new non-deprecation method if using Crystal >=1.13.

## Changelog

* Fix usage of deprecation `::File` method in Crystal nightly
