### PR TITLE
Allow using `CRYSTAL` env var to customize Crystal binary

### DIFF
--- a/src/components/spec/spec/methods_spec.cr
+++ b/src/components/spec/spec/methods_spec.cr
@@ -2,6 +2,18 @@ require "./spec_helper"
 
 describe ASPEC::Methods do
   describe ".assert_error", tags: "compiled" do
+    it "allows customizing crystal binary via CRYSTAL env var" do
+      begin
+        ENV["CRYSTAL"] = "/path/to/crystal"
+
+        expect_raises File::NotFoundError, "'/path/to/crystal': No such file or directory" do
+          assert_error "", ""
+        end
+      ensure
+        ENV.delete "CRYSTAL"
+      end
+    end
+
     describe "no codegen" do
       it do
         assert_error "can't instantiate abstract class Foo", <<-CR

--- a/src/components/spec/src/methods.cr
+++ b/src/components/spec/src/methods.cr
@@ -72,7 +72,7 @@ module Athena::Spec::Methods
 
     args << "--no-codegen" unless codegen
 
-    Process.run("crystal", args, input: input.rewind, output: buffer, error: buffer)
+    Process.run(ENV["CRYSTAL"]? || "crystal", args, input: input.rewind, output: buffer, error: buffer)
   end
 
   # Runs the executable at the given *path*, optionally with the provided *args*.


### PR DESCRIPTION
## Context

In some cases you may want to run compiled tests using `assert_error` and `assert_success` using a different build of Crystal. Similar to how https://github.com/crystal-lang/crystal/blob/bcb5aeb5d2c432ccb1e5e2385189ed15599e8ba8/Makefile#L24 does it, this PR will use the value of `CRYSTAL` env var if present, otherwise fallback on `crystal` binary in PATH.

This is a follow up to https://github.com/athena-framework/athena/pull/252 to propagate that value down to `athena-spec` methods. 

## Changelog

* Pass through `CRYSTAL` ENV var to `ASPEC::Methods.assert_error` and `ASPEC::Methods.assert_success`
