### PR TITLE
Prep work for query/request parameter refactor

### DIFF
--- a/docs/why_athena.md
+++ b/docs/why_athena.md
@@ -296,7 +296,7 @@ class UserController < ATH::Controller
   @[ARTA::Post("/user")]
   @[ATHA::View(status: :created)]
   def new_user(
-    @[ATHR::RequestBody::Extract]
+    @[ATHA::MapRequestBody]
     user_create : UserCreate
   ) : UserCreate
     # Use the provided UserCreate instance to create an actual User DB record.

--- a/src/components/framework/shard.yml
+++ b/src/components/framework/shard.yml
@@ -2,7 +2,7 @@ name: athena
 
 version: 0.19.1
 
-crystal: ~> 1.11
+crystal: ~> 1.13
 
 license: MIT
 

--- a/src/components/framework/spec/compiler_spec.cr
+++ b/src/components/framework/spec/compiler_spec.cr
@@ -379,12 +379,12 @@ describe Athena::Framework do
 
     describe ATHR::RequestBody do
       it "when the action parameter is not serializable" do
-        assert_error " The annotation '@[ATHR::RequestBody::Extract]' cannot be applied to 'CompileController#action:foo : Foo' since the 'Athena::Framework::Controller::ValueResolvers::RequestBody' resolver only supports parameters of type 'Athena::Serializer::Serializable | JSON::Serializable'.", <<-CODE
+        assert_error " The annotation '@[ATHA::MapRequestBody]' cannot be applied to 'CompileController#action:foo : Foo' since the 'Athena::Framework::Controller::ValueResolvers::RequestBody' resolver only supports parameters of type 'Athena::Serializer::Serializable | JSON::Serializable'.", <<-CODE
           record Foo, text : String
 
           class CompileController < ATH::Controller
             @[ARTA::Get(path: "/")]
-            def action(@[ATHR::RequestBody::Extract] foo : Foo) : Foo
+            def action(@[ATHA::MapRequestBody] foo : Foo) : Foo
               foo
             end
           end

--- a/src/components/framework/spec/controller/value_resolvers/request_body_spec.cr
+++ b/src/components/framework/spec/controller/value_resolvers/request_body_spec.cr
@@ -103,8 +103,8 @@ struct RequestBodyResolverTest < ASPEC::TestCase
     ATH::Controller::ParameterMetadata(T).new(
       "foo",
       annotation_configurations: ADI::AnnotationConfigurations.new({
-        ATHR::RequestBody::Extract => [
-          ATHR::RequestBody::ExtractConfiguration.new,
+        ATHA::MapRequestBody => [
+          ATHA::MapRequestBodyConfiguration.new,
         ] of ADI::AnnotationConfigurations::ConfigurationBase,
       } of ADI::AnnotationConfigurations::Classes => Array(ADI::AnnotationConfigurations::ConfigurationBase))
     )

--- a/src/components/framework/spec/controller/value_resolvers/time_spec.cr
+++ b/src/components/framework/spec/controller/value_resolvers/time_spec.cr
@@ -74,8 +74,8 @@ describe ATHR::Time do
       parameter = ATH::Controller::ParameterMetadata(::Time).new(
         "foo",
         annotation_configurations: ADI::AnnotationConfigurations.new({
-          ATHR::Time::Format => [
-            ATHR::Time::FormatConfiguration.new(format: "%Y--%m//%d  %T"),
+          ATHA::MapTime => [
+            ATHA::MapTimeConfiguration.new(format: "%Y--%m//%d  %T"),
           ] of ADI::AnnotationConfigurations::ConfigurationBase,
         } of ADI::AnnotationConfigurations::Classes => Array(ADI::AnnotationConfigurations::ConfigurationBase))
       )
@@ -90,8 +90,8 @@ describe ATHR::Time do
       parameter = ATH::Controller::ParameterMetadata(::Time).new(
         "foo",
         annotation_configurations: ADI::AnnotationConfigurations.new({
-          ATHR::Time::Format => [
-            ATHR::Time::FormatConfiguration.new(format: "%Y--%m//%d  %T", location: Time::Location.fixed(9001)),
+          ATHA::MapTime => [
+            ATHA::MapTimeConfiguration.new(format: "%Y--%m//%d  %T", location: Time::Location.fixed(9001)),
           ] of ADI::AnnotationConfigurations::ConfigurationBase,
         } of ADI::AnnotationConfigurations::Classes => Array(ADI::AnnotationConfigurations::ConfigurationBase))
       )

--- a/src/components/framework/spec/controllers/argument_resolver_controller.cr
+++ b/src/components/framework/spec/controllers/argument_resolver_controller.cr
@@ -2,16 +2,16 @@
 class GenericAnnotationEnabledCustomResolver
   include ATHR::Interface
 
-  configuration Enable
+  configuration ::MyResolverAnnotation
 
   def resolve(request : ATH::Request, parameter : ATH::Controller::ParameterMetadata(Float64)) : Float64?
-    return unless parameter.annotation_configurations.has? Enable
+    return unless parameter.annotation_configurations.has? MyResolverAnnotation
 
     3.14
   end
 
   def resolve(request : ATH::Request, parameter : ATH::Controller::ParameterMetadata(String)) : String?
-    return unless parameter.annotation_configurations.has? Enable
+    return unless parameter.annotation_configurations.has? MyResolverAnnotation
 
     "fooo"
   end
@@ -24,7 +24,7 @@ end
 class ArgumentResolverController < ATH::Controller
   @[ARTA::Post("/float")]
   def happy_path1(
-    @[GenericAnnotationEnabledCustomResolver::Enable]
+    @[MyResolverAnnotation]
     value : Float64
   ) : Float64
     value
@@ -32,7 +32,7 @@ class ArgumentResolverController < ATH::Controller
 
   @[ARTA::Post("/string")]
   def happy_path2(
-    @[GenericAnnotationEnabledCustomResolver::Enable]
+    @[MyResolverAnnotation]
     value : String
   ) : String
     value

--- a/src/components/framework/spec/controllers/query_param_controller.cr
+++ b/src/components/framework/spec/controllers/query_param_controller.cr
@@ -61,7 +61,7 @@ class QueryParamController < ATH::Controller
   @[ATHA::QueryParam("value")]
   @[ARTA::Get("/param/enabled/resolver")]
   def annotation_enabled_resolver_on_query_param_parameter(
-    @[GenericAnnotationEnabledCustomResolver::Enable]
+    @[MyResolverAnnotation]
     value : String
   ) : String
     value
@@ -71,7 +71,7 @@ class QueryParamController < ATH::Controller
   @[ATHA::QueryParam("time")]
   @[ARTA::Get("/nt_time")]
   def nt_time(
-    @[ATHR::Time::Format(format: "%Y--%m//%d  %T")]
+    @[ATHA::MapTime(format: "%Y--%m//%d  %T")]
     time : Time
   ) : String
     "Today is: #{time}"

--- a/src/components/framework/src/athena.cr
+++ b/src/components/framework/src/athena.cr
@@ -76,7 +76,7 @@ module Athena::Framework
   #
   # 1. `ATHR::Time` (105) - Attempts to resolve a value from the request attributes into a `::Time` instance,
   # defaulting to [RFC 3339](https://crystal-lang.org/api/Time.html#parse_rfc3339%28time:String%29-class-method).
-  # Format/location can be customized via the `ATHR::Time::Format` annotation.
+  # Format/location can be customized via the `ATHA::MapTime` annotation.
   #
   # 1. `ATHR::UUID` (105) - Attempts to resolve a value from the request attributes into a `::UUID` instance.
   #

--- a/src/components/framework/src/controller/value_resolvers/interface.cr
+++ b/src/components/framework/src/controller/value_resolvers/interface.cr
@@ -273,13 +273,17 @@
 # This feature pairs nicely with the [free var][Athena::Framework::Controller::ValueResolvers::Interface--free-vars] section as it essentially allows
 # scoping the possible types of `T` to the set of types defined as part of the module.
 module Athena::Framework::Controller::ValueResolvers::Interface
+  # :nodoc:
+  ANNOTATION_RESOLVER_MAP = {} of Nil => Nil
+
   # The tag name for `ATHR::Interface` services.
   TAG = "athena.controller.value_resolver"
 
   # Helper macro around `ADI.configuration_annotation` that allows defining resolver specific annotations.
   # See the underlying macro and the [configuration][Athena::Framework::Controller::ValueResolvers::Interface--configuration] section for more information.
   macro configuration(name, *args)
-    ADI.configuration_annotation ::{{@type}}::{{name.id}}{% unless args.empty? %}, {{args.splat}}{% end %}
+    ADI.configuration_annotation {{name.id}}{% unless args.empty? %}, {{args.splat}}{% end %}
+    {% ANNOTATION_RESOLVER_MAP[name.id] = @type.resolve %}
   end
 
   # Represents an `ATHR::Interface` that only supports a subset of types.

--- a/src/components/framework/src/controller/value_resolvers/request_body.cr
+++ b/src/components/framework/src/controller/value_resolvers/request_body.cr
@@ -1,5 +1,5 @@
 @[ADI::Register(tags: [{name: ATHR::Interface::TAG, priority: 105}])]
-# Attempts to resolve the value of any parameter with the `ATHR::RequestBody::Extract` annotation by
+# Attempts to resolve the value of any parameter with the `ATHA::MapRequestBody` annotation by
 # deserializing the request body into an object of the type of the related parameter.
 # Also handles running any validations defined on it, if it is `AVD::Validatable`.
 # Requires the type of the related parameter to include either `ASR::Serializable` or `JSON::Serializable`.
@@ -31,7 +31,7 @@
 #   @[ARTA::Post("/user")]
 #   @[ATHA::View(status: :created)]
 #   def new_user(
-#     @[ATHR::RequestBody::Extract]
+#     @[ATHA::MapRequestBody]
 #     user_create : UserCreate
 #   ) : UserCreate
 #     # Use the provided UserCreate instance to create an actual User DB record.

--- a/src/components/framework/src/controller/value_resolvers/request_body.cr
+++ b/src/components/framework/src/controller/value_resolvers/request_body.cr
@@ -89,7 +89,7 @@ struct Athena::Framework::Controller::ValueResolvers::RequestBody
 
   # Enables the `ATHR::RequestBody` resolver for the parameter this annotation is applied to.
   # See the related resolver documentation for more information.
-  configuration Extract
+  configuration ::Athena::Framework::Annotations::MapRequestBody
 
   def initialize(
     @serializer : ASR::SerializerInterface,
@@ -97,25 +97,17 @@ struct Athena::Framework::Controller::ValueResolvers::RequestBody
   ); end
 
   # :inherit:
-  def resolve(request : ATH::Request, parameter : ATH::Controller::ParameterMetadata(T)) : T? forall T
-    return unless parameter.annotation_configurations.has? Extract
+  def resolve(request : ATH::Request, parameter : ATH::Controller::ParameterMetadata)
+    return unless parameter.annotation_configurations.has? ATHA::MapRequestBody
 
     if !(body = request.body) || body.peek.try &.empty?
       raise ATH::Exceptions::BadRequest.new "Request does not have a body."
     end
 
-    object = nil
-
     begin
-      {% begin %}
-        {% if T.instance <= ASR::Serializable %}
-          object = @serializer.deserialize T, body, :json
-        {% elsif T.instance <= JSON::Serializable %}
-          object = T.from_json body
-        {% else %}
-          return
-        {% end %}
-      {% end %}
+      unless object = self.map_request_body body, parameter.type
+        return
+      end
     rescue ex : JSON::ParseException | ASR::Exceptions::DeserializationException
       raise ATH::Exceptions::BadRequest.new "Malformed JSON payload.", cause: ex
     end
@@ -125,6 +117,17 @@ struct Athena::Framework::Controller::ValueResolvers::RequestBody
       raise AVD::Exceptions::ValidationFailed.new errors unless errors.empty?
     end
 
-    object.as T
+    object
+  end
+
+  def map_request_body(body : IO, klass : ASR::Serializable.class)
+    @serializer.deserialize klass, body, :json
+  end
+
+  def map_request_body(body : IO, klass : JSON::Serializable.class)
+    klass.from_json body
+  end
+
+  def map_request_body(body : IO, klass : _) : Nil
   end
 end

--- a/src/components/framework/src/controller/value_resolvers/request_body.cr
+++ b/src/components/framework/src/controller/value_resolvers/request_body.cr
@@ -120,14 +120,14 @@ struct Athena::Framework::Controller::ValueResolvers::RequestBody
     object
   end
 
-  def map_request_body(body : IO, klass : ASR::Serializable.class)
+  private def map_request_body(body : IO, klass : ASR::Serializable.class)
     @serializer.deserialize klass, body, :json
   end
 
-  def map_request_body(body : IO, klass : JSON::Serializable.class)
+  private def map_request_body(body : IO, klass : JSON::Serializable.class)
     klass.from_json body
   end
 
-  def map_request_body(body : IO, klass : _) : Nil
+  private def map_request_body(body : IO, klass : _) : Nil
   end
 end

--- a/src/components/framework/src/controller/value_resolvers/time.cr
+++ b/src/components/framework/src/controller/value_resolvers/time.cr
@@ -33,7 +33,7 @@ struct Athena::Framework::Controller::ValueResolvers::Time
 
   # Allows customing the time format and/or location used to parse the string datetime as part of the `ATHR::Time` resolver.
   # See the related resolver documentation for more information.
-  configuration Format, format : String? = nil, location : ::Time::Location = ::Time::Location::UTC
+  configuration ::Athena::Framework::Annotations::MapTime, format : String? = nil, location : ::Time::Location = ::Time::Location::UTC
 
   # :inherit:
   def resolve(request : ATH::Request, parameter : ATH::Controller::ParameterMetadata) : ::Time?
@@ -45,7 +45,7 @@ struct Athena::Framework::Controller::ValueResolvers::Time
 
     return unless value = request.attributes.get? parameter.name, String?
 
-    if !(configuration = parameter.annotation_configurations[Format]?) || !(format = configuration.format)
+    if !(configuration = parameter.annotation_configurations[ATHA::MapTime]?) || !(format = configuration.format)
       return ::Time.parse_rfc3339(value)
     end
 

--- a/src/components/framework/src/controller/value_resolvers/time.cr
+++ b/src/components/framework/src/controller/value_resolvers/time.cr
@@ -1,7 +1,7 @@
 @[ADI::Register(tags: [{name: ATHR::Interface::TAG, priority: 105}])]
 # Attempts to parse a date(time) string into a `::Time` instance.
 #
-# Optionally allows specifying the *format* and *location* to use when parsing the string via the `ATHR::Time::Format` annotation.
+# Optionally allows specifying the *format* and *location* to use when parsing the string via the `ATHA::MapTime` annotation.
 # If no *format* is specified, defaults to [RFC 3339](https://crystal-lang.org/api/Time.html#parse_rfc3339%28time:String%29-class-method).
 # Defaults to `UTC` if no *location* is specified with the annotation.
 #
@@ -15,7 +15,7 @@
 # class ExampleController < ATH::Controller
 #   @[ARTA::Get(path: "/event/{start_time}/{end_time}")]
 #   def event(
-#     @[ATHR::Time::Format("%F", location: Time::Location.load("Europe/Berlin"))]
+#     @[ATHA::MapTime("%F", location: Time::Location.load("Europe/Berlin"))]
 #     start_time : Time,
 #     end_time : Time
 #   ) : Nil

--- a/src/components/framework/src/ext/routing/annotation_route_loader.cr
+++ b/src/components/framework/src/ext/routing/annotation_route_loader.cr
@@ -197,16 +197,12 @@ module Athena::Framework::Routing::AnnotationRouteLoader
 
                 # Process custom annotation types
                 ADI::CUSTOM_ANNOTATIONS.each do |ann_class|
-                  ann_class = ann_class.resolve
                   annotations = [] of Nil
 
-                  (arg.annotations ann_class).each do |ann|
+                  (arg.annotations ann_class.resolve).each do |ann|
                     # See if this annotation relates to a typed resolver interface,
                     # checking the namespace the configuration annotation was defined in for the interface.
-                    #
-                    # If there is only 1 part to the annotation's name, we know it was defined in the top level,
-                    # and as such, does not related to a resolver type
-                    resolver = 1 == ann.name.names.size ? false : parse_type(ann.name.names[0..-2].join "::").resolve
+                    resolver = ATH::Controller::ValueResolvers::Interface::ANNOTATION_RESOLVER_MAP[ann_class.id]
 
                     if resolver && (interface = resolver.resolve.ancestors.find &.<=(ATHR::Interface::Typed))
                       supported_types = interface.type_vars.first.type_vars
@@ -219,7 +215,7 @@ module Athena::Framework::Routing::AnnotationRouteLoader
                     annotations << "#{ann_class}Configuration.new(#{ann.args.empty? ? "".id : "#{ann.args.splat},".id}#{ann.named_args.double_splat})".id
                   end
 
-                  parameter_annotation_configurations[ann_class] = "(#{annotations} of ADI::AnnotationConfigurations::ConfigurationBase)".id unless annotations.empty?
+                  parameter_annotation_configurations[ann_class.resolve] = "(#{annotations} of ADI::AnnotationConfigurations::ConfigurationBase)".id unless annotations.empty?
                 end
 
                 arg.raise "Route action parameter '#{klass.name}##{m.name}:#{arg.name}' must have a type restriction." if arg.restriction.is_a? Nop


### PR DESCRIPTION
## Context

Prepares for #418 by addressing my thoughts in the [latest comment](https://github.com/athena-framework/athena/issues/418#issuecomment-2171033914). Sets things up well for the next pass to actually implement some of the resolver/annotation logic.

## Changelog

* **Breaking:** Make `ATHR::Interfae.configuration` macro no longer scoped to resolver namespace
  * If defining the annotation in a different namespace, prefix it with `::` and use the FQN
* **Breaking:** Rename `ATHR::RequestBody::Extract` to `ATHA::MapRequestBody`
* **Breaking:** Rename `ATHR::Time::Format` to `ATHA::MapTime`