### PR TITLE
Improve output when using a namespace as a command name

### DIFF
--- a/src/components/console/spec/fixtures/text/application_filtered_namespace.txt
+++ b/src/components/console/spec/fixtures/text/application_filtered_namespace.txt
@@ -11,5 +11,5 @@ My Athena application <info>1.0.0</info>
   <info>-n, --no-interaction</info>  Do not ask any interactive question
   <info>-v|vv|vvv, --verbose</info>  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
-<comment>Available commands for the "command4" namespace:</comment>
+<comment>Available commands for the 'command4' namespace:</comment>
   <info>command4:descriptor</info>

--- a/src/components/console/spec/spec_helper.cr
+++ b/src/components/console/spec/spec_helper.cr
@@ -13,4 +13,35 @@ require "./fixtures/**"
 # Override that given there are specs based on ansi output.
 Colorize.enabled = true
 
+struct MockCommandLoader
+  include Athena::Console::Loader::Interface
+
+  def initialize(
+    *,
+    @command_or_exception : ACON::Command | ::Exception? = nil,
+    @has : Bool = true,
+    @names : Array(String) | ::Exception = [] of String
+  )
+  end
+
+  def get(name : String) : ACON::Command
+    case v = @command_or_exception
+    in ::Exception   then raise v
+    in ACON::Command then v
+    in Nil           then raise "BUG: no command or exception was set"
+    end
+  end
+
+  def has?(name : String) : Bool
+    @has
+  end
+
+  def names : Array(String)
+    case v = @names
+    in ::Exception   then raise v
+    in Array(String) then v
+    end
+  end
+end
+
 ASPEC.run_all

--- a/src/components/console/src/descriptor/text.cr
+++ b/src/components/console/src/descriptor/text.cr
@@ -45,7 +45,7 @@ class Athena::Console::Descriptor::Text < Athena::Console::Descriptor
     )
 
     if described_namespace
-      self.write_text %(<comment>Available commands for the "#{described_namespace}" namespace:</comment>), context
+      self.write_text %(<comment>Available commands for the '#{described_namespace}' namespace:</comment>), context
     else
       self.write_text "<comment>Available commands:</comment>", context
     end


### PR DESCRIPTION
## Context

Previously if you were to try an execute a command that is the name of a namespace you'd get output like:

```sh
  Command 'foo' is not defined.

  Did you mean one of these?
      afoobar
      afoobar1
      afoobar2
      foo1:bar
      foo:bar
      foo:bar1
```
Which isn't all that helpful. This PR makes it better handle this context by displaying the commands in that namespace:

```sh
MyCLI 1.2.3

Usage:
  command [options] [arguments]

Options:
  -h, --help            Display help for the given command. When no command is given display help for the list command
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Available commands for the 'foo' namespace:
  foo:bar   [afoobar] The foo:bar command
  foo:bar1  [afoobar1] The foo:bar1 command
```

## Changelog

* List commands in a namespace when using it as the command name
* Use single quotes in text descriptor to quote values in the output
