### PR TITLE
Fix content negotiation implementation

### DIFF
--- a/src/components/framework/src/bundle.cr
+++ b/src/components/framework/src/bundle.cr
@@ -312,9 +312,13 @@ struct Athena::Framework::Bundle < Athena::Framework::AbstractBundle
                 )".id}}
               end
 
-              SERVICE_HASH["athena_framework_listeners_format"] = {
+              SERVICE_HASH["athena_framework_view_format_negotiator"] = {
                 class: ATH::View::FormatNegotiator,
                 calls: calls,
+              }
+
+              SERVICE_HASH["athena_framework_listeners_format"] = {
+                class: ATH::Listeners::Format,
               }
             end
           %}

--- a/src/components/framework/src/bundle.cr
+++ b/src/components/framework/src/bundle.cr
@@ -285,7 +285,7 @@ struct Athena::Framework::Bundle < Athena::Framework::AbstractBundle
                   end
 
                   if v = rule["host"]
-                    matchers << "ATH::RequestMatcher::Host.new(#{v})".id
+                    matchers << "ATH::RequestMatcher::Hostname.new(#{v})".id
                   end
 
                   if v = rule["methods"]

--- a/src/components/framework/src/request_matcher/method.cr
+++ b/src/components/framework/src/request_matcher/method.cr
@@ -2,13 +2,13 @@
 struct Athena::Framework::RequestMatcher::Method
   include Interface
 
-  @methods : Enumerable(String)
+  @methods : Array(String)
 
   def self.new(*methods : String)
     new methods.to_a
   end
 
-  def initialize(@methods : Enumerable(String))
+  def initialize(@methods : Array(String))
     methods.map! &.upcase
   end
 


### PR DESCRIPTION
## Context

Prior to this PR, the `Format` listener was not being registered and thus the format of the request was always `json`. This was preventing content negotiation from working.

After adding test coverage, there was also an issue using the `host` request matcher filter that I fixed.

## Changelog

* **Breaking:** `ATH::RequestMatcher::Method` now requires an `Array(String)`
* Fix content negotiation not working
