### PR TITLE
Fix missing default/nil values related to `object_of` and `array_of` in bundle extensions

### DIFF
--- a/src/components/dependency_injection/spec/extension_spec.cr
+++ b/src/components/dependency_injection/spec/extension_spec.cr
@@ -289,13 +289,13 @@ describe ADI::Extension do
       assert_success <<-CR
         module Schema
           include ADI::Extension::Schema
-          array_of rules = [{id: 10, stop: true}], id : Int32, stop : Bool = false
+          array_of rules = [{id: 10}], id : Int32, stop : Bool = false
           def self.validate
             it do
               {{OPTIONS.size}}.should eq 1
               {{OPTIONS[0]["name"].stringify}}.should eq "rules"
               {{OPTIONS[0]["type"].stringify}}.should eq "Array(T)"
-              {{OPTIONS[0]["default"].stringify}}.should eq "[{id: 10, stop: true}]"
+              {{OPTIONS[0]["default"].stringify}}.should eq "[{id: 10, stop: false}]"
               {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
               {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
               {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
@@ -303,7 +303,7 @@ describe ADI::Extension do
               {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
 
               {{CONFIG_DOCS.stringify}}.should eq <<-JSON
-              [{"name":"rules","type":"`Array(T)`","default":"`[{id: 10, stop: true}]`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil
+              [{"name":"rules","type":"`Array(T)`","default":"`[{id: 10}]`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil
               JSON
             end
           end

--- a/src/components/dependency_injection/src/compiler_passes/validate_arguments.cr
+++ b/src/components/dependency_injection/src/compiler_passes/validate_arguments.cr
@@ -137,20 +137,6 @@ module Athena::DependencyInjection::ServiceContainer::ValidateArguments
                                           prop_type = member_map
                                         end
 
-                                        # The prop type is from an (array|object)_of, so we need to fill in defaults
-                                        if prop_type.is_a?(NamedTupleLiteral)
-                                          provided_keys = cfv.keys
-
-                                          prop_type.keys.reject { |k| k.stringify == "__nil" || provided_keys.includes? k }.each do |k|
-                                            decl = prop_type[k]
-
-                                            # Skip setting required values so that it results in a missing error vs type mismatch error
-                                            cfv[k] = decl.value unless decl.value.is_a?(Nop)
-                                          end
-
-                                          # Use the member_map as is if not processing an `array_of` object so that missing required properties are properly enforced.
-                                        end
-
                                         cfv.each do |k, v|
                                           nt_key_type = prop_type[k]
 


### PR DESCRIPTION
## Context

Noticed this while working on #431. It seems the logic that was populating unprovided values, either default or `nil`, to the named tuple ended up in `ValidateArguments`. This made it so that the values _appeared_ correct when printing the final `CONFIG` value, but was not done in time to be present at the time extensions are executed. 

## Changelog

* Fix missing default/nil values related to `object_of` or `array_of` in bundle extensions
