### PR TITLE
Bump min Crystal version for `framework`, `dotenv`, and `validator`

### DIFF
--- a/src/components/dotenv/shard.yml
+++ b/src/components/dotenv/shard.yml
@@ -2,7 +2,7 @@ name: athena-dotenv
 
 version: 0.1.2
 
-crystal: '>= 0.36.0'
+crystal: ~> 1.13
 
 license: MIT
 

--- a/src/components/dotenv/src/athena-dotenv.cr
+++ b/src/components/dotenv/src/athena-dotenv.cr
@@ -506,18 +506,9 @@ class Athena::Dotenv
 
   private def load(override_existing_vars : Bool, paths : Enumerable(String | ::Path)) : Nil
     paths.each do |path|
-      # TODO: Inline this again once 1.13.0 is the new min version
-      {% begin %}
-        {% if compare_versions(Crystal::VERSION, "1.13.0-dev") >= 0 %}
-          is_file_readable = File::Info.readable? path
-        {% else %}
-          is_file_readable = File.readable? path
-        {% end %}
-
-        if !is_file_readable || File.directory?(path)
-          raise Athena::Dotenv::Exceptions::Path.new path
-        end
-      {% end %}
+      if !File::Info.readable?(path) || File.directory?(path)
+        raise Athena::Dotenv::Exceptions::Path.new path
+      end
 
       self.populate(self.parse(File.read(path), path), override_existing_vars)
     end

--- a/src/components/framework/shard.yml
+++ b/src/components/framework/shard.yml
@@ -2,7 +2,7 @@ name: athena
 
 version: 0.19.1
 
-crystal: ~> 1.11
+crystal: ~> 1.13
 
 license: MIT
 

--- a/src/components/framework/src/athena.cr
+++ b/src/components/framework/src/athena.cr
@@ -225,11 +225,7 @@ module Athena::Framework
       {% end %}
 
       # Handle exiting correctly on interrupt signals
-      {% if compare_versions(Crystal::VERSION, "1.12.0") >= 0 %}
-        Process.on_terminate { self.stop }
-      {% else %}
-        Process.on_interrupt { self.stop }
-      {% end %}
+      Process.on_terminate { self.stop }
 
       Log.info { %(Server has started and is listening at #{@ssl_context ? "https" : "http"}://#{@server.addresses.first}) }
 

--- a/src/components/framework/src/binary_file_response.cr
+++ b/src/components/framework/src/binary_file_response.cr
@@ -57,16 +57,7 @@ class Athena::Framework::BinaryFileResponse < Athena::Framework::Response
   )
     super nil, status, headers
 
-    # TODO: Inline this again once 1.13.0 is the new min version
-    {% begin %}
-      {% if compare_versions(Crystal::VERSION, "1.13.0-dev") >= 0 %}
-        is_file_readable = File::Info.readable? file_path
-      {% else %}
-        is_file_readable = File.readable? file_path
-      {% end %}
-
-      raise File::Error.new("File '#{file_path}' must be readable.", file: file_path) unless is_file_readable
-    {% end %}
+    raise File::Error.new("File '#{file_path}' must be readable.", file: file_path) unless File::Info.readable? file_path
 
     @file_path = Path.new(file_path).expand
 

--- a/src/components/validator/shard.yml
+++ b/src/components/validator/shard.yml
@@ -2,7 +2,7 @@ name: athena-validator
 
 version: 0.3.3
 
-crystal: ~> 1.6
+crystal: ~> 1.13
 
 license: MIT
 

--- a/src/components/validator/src/constraints/file.cr
+++ b/src/components/validator/src/constraints/file.cr
@@ -241,24 +241,15 @@ class Athena::Validator::Constraints::File < Athena::Validator::Constraint
         return
       end
 
-      # TODO: Inline this again once 1.13.0 is the new min version
-      {% begin %}
-        {% if compare_versions(Crystal::VERSION, "1.13.0-dev") >= 0 %}
-          is_file_readable = ::File::Info.readable? path
-        {% else %}
-          is_file_readable = ::File.readable? path
-        {% end %}
+      unless ::File::Info.readable? path
+        self
+          .context
+          .build_violation(constraint.not_readable_message, NOT_READABLE_ERROR)
+          .add_parameter("{{ file }}", path)
+          .add
 
-        unless is_file_readable
-          self
-            .context
-            .build_violation(constraint.not_readable_message, NOT_READABLE_ERROR)
-            .add_parameter("\{{ file }}", path)
-            .add
-
-          return
-        end
-      {% end %}
+        return
+      end
 
       size_in_bytes = ::File.size path
       base_name = ::File.basename path

--- a/src/components/validator/src/constraints/file.cr
+++ b/src/components/validator/src/constraints/file.cr
@@ -219,6 +219,8 @@ class Athena::Validator::Constraints::File < Athena::Validator::Constraint
 
   class Validator < Athena::Validator::ConstraintValidator
     # :inherit:
+    #
+    # ameba:disable Metrics/CyclomaticComplexity
     def validate(value : _, constraint : AVD::Constraints::File) : Nil
       return if value.nil? || value == ""
 


### PR DESCRIPTION
## Context

Removes some TODOs and bumps the Crystal floor to `1.13`.

## Changelog

* Require Crystal `~> 1.13`
