### PR TITLE
More robust auto redirection

### DIFF
--- a/src/components/framework/spec/controller/redirect_spec.cr
+++ b/src/components/framework/spec/controller/redirect_spec.cr
@@ -32,6 +32,22 @@ struct RedirectControllerTest < ASPEC::TestCase
     response.status.found?.should be_true
   end
 
+  def test_non_standard_port : Nil
+    request = ATH::Request.new "GET", "/", headers: HTTP::Headers{"host" => "example.com"}
+    controller = ATH::Controller::Redirect.new
+
+    self.assert_redirect_url controller.redirect_url(request, "/foo", scheme: "http", http_port: 90), "http://example.com:90/foo"
+    self.assert_redirect_url controller.redirect_url(request, "/foo", scheme: "https", https_port: 90), "https://example.com:90/foo"
+  end
+
+  def test_falls_back_on_controller_ports : Nil
+    request = ATH::Request.new "GET", "/", headers: HTTP::Headers{"host" => "example.com"}
+    controller = ATH::Controller::Redirect.new 100, 200
+
+    self.assert_redirect_url controller.redirect_url(request, "/foo", scheme: "http"), "http://example.com:100/foo"
+    self.assert_redirect_url controller.redirect_url(request, "/foo", scheme: "https"), "https://example.com:200/foo"
+  end
+
   def test_full_url_with_method_keep : Nil
     request = ATH::Request.new "GET", "/"
     controller = ATH::Controller::Redirect.new

--- a/src/components/framework/spec/controller/redirect_spec.cr
+++ b/src/components/framework/spec/controller/redirect_spec.cr
@@ -22,4 +22,53 @@ struct RedirectControllerTest < ASPEC::TestCase
 
     ex.status_code.should eq 404
   end
+
+  def test_full_url : Nil
+    request = ATH::Request.new "GET", "/"
+    controller = ATH::Controller::Redirect.new
+
+    response = controller.redirect_url request, "http://foo.com/"
+    self.assert_redirect_url response, "http://foo.com/"
+    response.status.found?.should be_true
+  end
+
+  def test_full_url_with_method_keep : Nil
+    request = ATH::Request.new "GET", "/"
+    controller = ATH::Controller::Redirect.new
+
+    response = controller.redirect_url request, "http://foo.com/", keep_request_method: true
+    self.assert_redirect_url response, "http://foo.com/"
+    response.status.temporary_redirect?.should be_true
+  end
+
+  # def test_url_redirect_default_ports : Nil
+  # end
+
+  # def test_url_redirect : Nil
+  # end
+
+  @[TestWith(
+    {"http://www.example.com/redirect-path", "/redirect-path", ""},
+    {"http://www.example.com/redirect-path?foo=bar", "/redirect-path?foo=bar", ""},
+    {"http://www.example.com/redirect-path?f.o=bar", "/redirect-path", "f.o=bar"},
+    {"http://www.example.com/redirect-path?f.o=bar&a.c=example", "/redirect-path?f.o=bar", "a.c=example"},
+    {"http://www.example.com/redirect-path?f.o=bar&a.c=example&b.z=def", "/redirect-path?f.o=bar", "a.c=example&b.z=def"},
+    {"http://www.example.com/redirect-path?val=one&val=two", "/redirect-path?val=one", "val=two"},
+  )]
+  def test_path_query_params(expected : String, path : String, query_string : String) : Nil
+    scheme = "http"
+    host = "www.example.com"
+    port = 80
+
+    request = ATH::Request.new "GET", "/", headers: HTTP::Headers{"host" => "#{host}:#{port}"}
+    request.query = query_string if query_string != ""
+
+    controller = ATH::Controller::Redirect.new
+
+    self.assert_redirect_url controller.redirect_url(request, path, scheme: scheme, http_port: port), expected
+  end
+
+  private def assert_redirect_url(response : ATH::Response, expected : String) : Nil
+    response.redirect?(expected).should be_true, failure_message: "Expected: '#{expected}'\n Got: '#{response.headers["location"]}'."
+  end
 end

--- a/src/components/framework/spec/request_spec.cr
+++ b/src/components/framework/spec/request_spec.cr
@@ -69,4 +69,18 @@ struct ATH::RequestTest < ASPEC::TestCase
     ATH::Request.new("POST", "/").safe?.should be_false
     ATH::Request.new("PUT", "/").safe?.should be_false
   end
+
+  def test_port_no_host_header : Nil
+    ATH::Request.new("GET", "/").port.should be_nil
+  end
+
+  @[TestWith(
+    domain: {"test.com:90", 90},
+    ipv4: {"127.0.0.1:90", 90},
+    ipv6: {"[::1]:90", 90},
+    no_port: {"test.com", nil},
+  )]
+  def test_port(host : String, port : Int32?) : Nil
+    ATH::Request.new("GET", "/", headers: HTTP::Headers{"host" => host}).port.should eq port
+  end
 end

--- a/src/components/framework/spec/response_spec.cr
+++ b/src/components/framework/spec/response_spec.cr
@@ -288,4 +288,26 @@ describe ATH::Response do
       response.last_modified.should be_nil
     end
   end
+
+  describe "#redirect?" do
+    it "valid redirection response" do
+      [301, 302, 303, 307].each do |status|
+        response = ATH::Response.new status: status
+        response.redirect?.should be_true
+      end
+    end
+
+    it "invalid redirection status" do
+      [304, 200, 404].each do |status|
+        ATH::Response.new(status: status).redirect?.should be_false
+      end
+    end
+
+    it "with specific redirect location" do
+      response = ATH::Response.new status: 301, headers: HTTP::Headers{"location" => "/good-uri"}
+      response.redirect?.should be_true
+      response.redirect?("/bad-uri").should be_false
+      response.redirect?("/good-uri").should be_true
+    end
+  end
 end

--- a/src/components/framework/src/bundle.cr
+++ b/src/components/framework/src/bundle.cr
@@ -259,6 +259,15 @@ struct Athena::Framework::Bundle < Athena::Framework::AbstractBundle
               },
             }
 
+            SERVICE_HASH["athena_framework_controllers_redirect"] = {
+              class:      Athena::Framework::Controller::Redirect,
+              public:     true,
+              parameters: {
+                http_port:  {value: "%framework.request_listener.http_port%"},
+                https_port: {value: "%framework.request_listener.https_port%"},
+              },
+            }
+
             if default_uri = cfg["default_uri"]
               SERVICE_HASH[request_context_id]["parameters"]["uri"]["value"] = default_uri
             end

--- a/src/components/framework/src/controller/redirect.cr
+++ b/src/components/framework/src/controller/redirect.cr
@@ -47,22 +47,18 @@ class Athena::Framework::Controller::Redirect
         http_port = @http_port
       end
 
-      if !http_port.nil? && 80 != http_port
-        uri.port = http_port
-      end
+      uri.port = http_port
     elsif "https" == scheme
       if https_port.nil?
         # TODO: Get the port off the request once we know scheme
         https_port = @https_port
       end
 
-      if !https_port.nil? && 443 != https_port
-        uri.port = https_port
-      end
+      uri.port = https_port
     end
 
     uri.host = request.hostname
 
-    ATH::RedirectResponse.new uri.to_s, status
+    ATH::RedirectResponse.new uri.normalize!.to_s, status
   end
 end

--- a/src/components/framework/src/controller/redirect.cr
+++ b/src/components/framework/src/controller/redirect.cr
@@ -43,7 +43,7 @@ class Athena::Framework::Controller::Redirect
 
     if "http" == scheme
       if http_port.nil?
-        # TOOD: Get the port off the request once we know scheme
+        # TODO: Get the port off the request once we know scheme
         http_port = @http_port
       end
 
@@ -52,7 +52,7 @@ class Athena::Framework::Controller::Redirect
       end
     elsif "https" == scheme
       if https_port.nil?
-        # TOOD: Get the port off the request once we know scheme
+        # TODO: Get the port off the request once we know scheme
         https_port = @https_port
       end
 

--- a/src/components/framework/src/controller/redirect.cr
+++ b/src/components/framework/src/controller/redirect.cr
@@ -1,5 +1,11 @@
 # :nodoc:
 class Athena::Framework::Controller::Redirect
+  def initialize(
+    @http_port : Int32? = nil,
+    @https_port : Int32? = nil
+  ); end
+
+  # ameba:disable Metrics/CyclomaticComplexity:
   def redirect_url(
     request : ATH::Request,
     path : String,
@@ -14,14 +20,49 @@ class Athena::Framework::Controller::Redirect
     end
 
     status = if keep_request_method
-               permanent ? HTTP::Status::TEMPORARY_REDIRECT : HTTP::Status::PERMANENT_REDIRECT
+               permanent ? HTTP::Status::PERMANENT_REDIRECT : HTTP::Status::TEMPORARY_REDIRECT
              else
                permanent ? HTTP::Status::MOVED_PERMANENTLY : HTTP::Status::FOUND
              end
 
-    # TODO: Handle redirecting to full URLs
-    # TODO: Handle customizing scheme/ports/qs
+    uri = URI.parse path
 
-    ATH::RedirectResponse.new path, status
+    # If the path has a scheme, assume it is a full URI
+    if uri.scheme.presence
+      return ATH::RedirectResponse.new path, status
+    end
+
+    # TODO: Get the scheme off of the request
+    uri.scheme = scheme
+
+    # If the request has query params of its own, be sure to retain both sets of params.
+    if request.query.presence
+      # Don't use `merge!` here so the query string is correctly refreshed on the uri.
+      uri.query_params = uri.query_params.merge request.query_params, replace: false
+    end
+
+    if "http" == scheme
+      if http_port.nil?
+        # TOOD: Get the port off the request once we know scheme
+        http_port = @http_port
+      end
+
+      if !http_port.nil? && 80 != http_port
+        uri.port = http_port
+      end
+    elsif "https" == scheme
+      if https_port.nil?
+        # TOOD: Get the port off the request once we know scheme
+        https_port = @https_port
+      end
+
+      if !https_port.nil? && 443 != https_port
+        uri.port = https_port
+      end
+    end
+
+    uri.host = request.hostname
+
+    ATH::RedirectResponse.new uri.to_s, status
   end
 end

--- a/src/components/framework/src/ext/routing/annotation_route_loader.cr
+++ b/src/components/framework/src/ext/routing/annotation_route_loader.cr
@@ -532,7 +532,7 @@ module Athena::Framework::Routing::AnnotationRouteLoader
     {% if base == nil %}
       @@actions["Athena::Framework::Controller::Redirect#redirect_url"] = ATH::Action.new(
         action: Proc(Tuple(ATH::Request, String, Bool, String?, Int32?, Int32?, Bool), ATH::RedirectResponse).new do |arguments|
-          Athena::Framework::Controller::Redirect.new.redirect_url *arguments
+          ADI.container.get(Athena::Framework::Controller::Redirect).redirect_url *arguments
         end,
         parameters: {
           ATH::Controller::ParameterMetadata(ATH::Request).new("request"),

--- a/src/components/framework/src/response.cr
+++ b/src/components/framework/src/response.cr
@@ -214,6 +214,18 @@ class Athena::Framework::Response
     @headers["last-modified"] = HTTP.format_time time
   end
 
+  # Returns `true` if this response is a redirect, optionally to the provided *location*.
+  # Otherwise, returns `false`.
+  def redirect?(location : String? = nil) : Bool
+    case @status
+    when .created?, .moved_permanently?, .found?, .see_other?, .temporary_redirect?, .permanent_redirect?
+      # valid redirections statuses
+    else return false
+    end
+
+    location ? location == @headers["location"] : location.nil?
+  end
+
   protected def write(output : IO) : Nil
     @writer.write(output, &.print(@content))
   end


### PR DESCRIPTION
## Context

Follow up to #307 to provide a more robust implementation. Mainly ensuring query params are included in the redirection. Also adds some related utility methods used within the implementation.

## Changelog

* Add `ATH::Request#port`
* Add `ATH::Response#redirect?`
* Fix query parameters being dropped when redirecting to a trailing/non-trailing slash endpoint
