### PR TITLE
Map `multipart/form-data` mime type to `form` format

### DIFF
--- a/src/components/framework/spec/request_spec.cr
+++ b/src/components/framework/spec/request_spec.cr
@@ -66,6 +66,7 @@ struct ATH::RequestTest < ASPEC::TestCase
       {"xml", {"text/xml", "application/xml", "application/x-xml"}},
       {"rdf", {"application/rdf+xml"}},
       {"atom", {"application/atom+xml"}},
+      {"form", {"application/x-www-form-urlencoded", "multipart/form-data"}},
     }
   end
 

--- a/src/components/framework/src/request.cr
+++ b/src/components/framework/src/request.cr
@@ -62,7 +62,7 @@ class Athena::Framework::Request
     "atom"   => Set{"application/atom+xml"},
     "css"    => Set{"text/css"},
     "csv"    => Set{"text/csv"},
-    "form"   => Set{"application/x-www-form-urlencoded"},
+    "form"   => Set{"application/x-www-form-urlencoded", "multipart/form-data"},
     "html"   => Set{"text/html", "application/xhtml+xml"},
     "js"     => Set{"application/javascript", "application/x-javascript", "text/javascript"},
     "json"   => Set{"application/json", "application/x-json"},


### PR DESCRIPTION
## Context

As per the [RFC](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.2):

> The content type "multipart/form-data" should be used for submitting forms that contain files, non-ASCII data, and binary data.

It makes sense to map this mime type to `form`.

## Changelog

* Map `multipart/form-data` mime type to `form` format