### PR TITLE
Add reminder to PR template to add the PR number prefix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,7 @@
 ## Changelog
 
 <!-- List out the high level changes this PR makes, especially those that are breaking -->
+
+---
+
+_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_


### PR DESCRIPTION
## Context

I realized a while ago that adding `athena-framework/athena` to the PR number in the PR title allowed GH to create a link to the real PR from each commit within each component's repo: https://github.com/athena-framework/framework/commits/master/. However I haven't been the greatest at remembering to always add it :see_no_evil:. Hopefully this reminder will help.
