### PR TITLE
Allow customizing trusted proxy header names

### DIFF
--- a/src/components/framework/docs/guides/proxies.md
+++ b/src/components/framework/docs/guides/proxies.md
@@ -49,4 +49,18 @@ That's it! It's critical that you prevent traffic from all non-trusted sources. 
 
 <!-- ## Reverse Proxy in a Subpath -->
 
-<!-- ## Custom Headers -->
+## Custom Headers
+
+Some reverse proxies do not use the common `x-forwarded-*` header names and may force you to use a custom header.
+In such cases you can use the [`framework.trusted_header_overrides`](/Framework/Bundle/Schema/#Athena::Framework::Bundle::Schema#trusted_header_overrides) configuration property to handle this:
+
+```crystal
+ATH.configure({
+  framework: {
+    # Tell Athena to look for `cloudfront-forwarded-proto` instead of the default `x-forwarded-proto`.
+    trusted_header_overrides: {
+      :forwarded_proto => "cloudfront-forwarded-proto",
+    },
+  },
+})
+```

--- a/src/components/framework/spec/request_spec.cr
+++ b/src/components/framework/spec/request_spec.cr
@@ -3,6 +3,7 @@ require "./spec_helper"
 struct ATH::RequestTest < ASPEC::TestCase
   def tear_down : Nil
     ATH::Request.set_trusted_proxies [] of String, :none
+    ATH::Request.trusted_header_overrides.clear
   end
 
   # This spec tests the built-in `#hostname` method
@@ -434,5 +435,15 @@ struct ATH::RequestTest < ASPEC::TestCase
 
     request.remote_address = Socket::IPAddress.v4 1, 1, 1, 1, port: 1
     request.port.should eq 80
+  end
+
+  def test_proxy_header_header_default : Nil
+    ATH::Request::ProxyHeader::FORWARDED_PROTO.header.should eq "x-forwarded-proto"
+  end
+
+  def test_proxy_header_header_override : Nil
+    ATH::Request.override_trusted_header :forwarded_proto, "foo-proto"
+
+    ATH::Request::ProxyHeader::FORWARDED_PROTO.header.should eq "foo-proto"
   end
 end

--- a/src/components/framework/src/athena.cr
+++ b/src/components/framework/src/athena.cr
@@ -216,8 +216,12 @@ module Athena::Framework
 
     def start : Nil
       # TODO: Is there a better place to do this?
-      {% if (trusted_proxies = ADI::CONFIG["parameters"]["framework.trusted_proxies"]) && (trusted_headers = ADI::CONFIG["parameters"]["framework.trusted_headers"]) %}
+      {% if (trusted_proxies = ADI::CONFIG["framework"]["trusted_proxies"]) && (trusted_headers = ADI::CONFIG["framework"]["trusted_headers"]) %}
         ATH::Request.set_trusted_proxies({{trusted_proxies}}, {{trusted_headers}})
+      {% end %}
+
+      {% for header, name in ADI::CONFIG["framework"]["trusted_header_overrides"] %}
+        ATH::Request.override_trusted_header({{header}}, {{name}})
       {% end %}
 
       {% if flag?(:without_openssl) %}

--- a/src/components/framework/src/bundle.cr
+++ b/src/components/framework/src/bundle.cr
@@ -29,6 +29,11 @@ struct Athena::Framework::Bundle < Athena::Framework::AbstractBundle
     # See the [external documentation](/Framework/guides/proxies) for more information.
     property trusted_headers : Athena::Framework::Request::ProxyHeader = Athena::Framework::Request::ProxyHeader[:forwarded_for, :forwarded_port, :forwarded_proto]
 
+    # Allows overriding the header name to use for a given `ATH::Request::ProxyHeader`.
+    #
+    # See the [external documentation](/Framework/guides/proxies/#custom-headers) for more information.
+    property trusted_header_overrides : Hash(Athena::Framework::Request::ProxyHeader, String) = {} of NoReturn => NoReturn
+
     # Configuration related to the `ATH::Listeners::Format` listener.
     #
     # If enabled, the rules are used to determine the best format for the current request based on its
@@ -187,11 +192,6 @@ struct Athena::Framework::Bundle < Athena::Framework::AbstractBundle
             parameters = CONFIG["parameters"]
 
             parameters["framework.default_locale"] = cfg["default_locale"]
-
-            if (trusted_proxies = cfg["trusted_proxies"]) && (trusted_headers = cfg["trusted_headers"])
-              parameters["framework.trusted_proxies"] = trusted_proxies
-              parameters["framework.trusted_headers"] = trusted_headers
-            end
 
             debug = parameters["framework.debug"]
 


### PR DESCRIPTION
## Context

Not all proxies use the de-facto standard `x-forwarded-*` header names. E.g. CloudFront uses `cloudfront-forwarded-proto`. This PR enables the header names to be overridden for a specific `ATH::Request::ProxyHeader` to support this use case.

## Changelog

* Allow customizing trusted proxy header names

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
