### PR TITLE
Enable `Lint/UselessAssign` ameba rule again but excluding type declarations

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -7,7 +7,7 @@ Lint/NotNil:
 Lint/Typos:
   Enabled: false # This has its own dedicated CI job
 Lint/UselessAssign:
-  Enabled: false # TODO: Enable once https://github.com/crystal-ameba/ameba/issues/447 is resolved
+  ExcludeTypeDeclarations: true # TODO: Disable this once https://github.com/crystal-ameba/ameba/issues/447 is resolved
 Naming/AccessorMethodName:
   Enabled: false
 Naming/BlockParameterName:

--- a/shard.yml
+++ b/shard.yml
@@ -15,7 +15,7 @@ authors:
 
 dependencies:
   athena:
-    github: athena-framework/athena
+    github: athena-framework/framework
   athena-clock:
     github: athena-framework/clock
   athena-console:
@@ -44,7 +44,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.6.0
+    version: ~> 1.6.1
   athena-spec:
     github: athena-framework/spec
     version: ~> 0.3.2

--- a/src/components/dependency_injection/spec/compiler_passes/process_auto_configurations_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/process_auto_configurations_spec.cr
@@ -348,7 +348,7 @@ describe ADI::ServiceContainer::ProcessAutoconfigureAnnotations do
     end
 
     it "handles a non service abstract parent type with service child types" do
-      collection = ADI.container.non_service_abstract_client.services.should eq [NonServiceChild1.new, NonServiceChild2.new]
+      ADI.container.non_service_abstract_client.services.should eq [NonServiceChild1.new, NonServiceChild2.new]
     end
 
     it "provides an empty array if there were no services configured with the desired tag" do

--- a/src/components/dotenv/src/athena-dotenv.cr
+++ b/src/components/dotenv/src/athena-dotenv.cr
@@ -220,6 +220,7 @@ class Athena::Dotenv
       self.load override_existing_vars, {dist_path}
     end
 
+    # ameba:disable Lint/UselessAssign
     unless env = ENV[env_key]?
       self.populate({env_key => env = default_environment}, override_existing_vars)
     end

--- a/src/components/framework/spec/controller_spec.cr
+++ b/src/components/framework/spec/controller_spec.cr
@@ -3,6 +3,7 @@ require "./spec_helper"
 describe ATH::Controller do
   describe ".render" do
     it "creates a proper response for the template" do
+      # ameba:disable Lint/UselessAssign
       name = "TEST"
       response = ATH::Controller.render "#{__DIR__}/assets/greeting.ecr"
 
@@ -12,6 +13,7 @@ describe ATH::Controller do
     end
 
     it "creates a proper response for the template with a layout" do
+      # ameba:disable Lint/UselessAssign
       name = "TEST"
       response = ATH::Controller.render "#{__DIR__}/assets/greeting.ecr", "#{__DIR__}/assets/layout.ecr"
 

--- a/src/components/framework/spec/custom_annotation_spec.cr
+++ b/src/components/framework/spec/custom_annotation_spec.cr
@@ -2,21 +2,21 @@ require "./spec_helper"
 
 struct CustomAnnotationControllerTest < ATH::Spec::APITestCase
   def test_with_annotation : Nil
-    self.get("/with-ann")
+    self.get "/with-ann"
 
     self.assert_response_header_equals "ANNOTATION", "true"
     self.assert_response_header_equals "ANNOTATION_VALUE", "1"
   end
 
   def test_without_annotation : Nil
-    self.get("/without-ann")
+    self.get "/without-ann"
 
     self.assert_response_not_has_header "ANNOTATION"
     self.assert_response_header_equals "ANNOTATION_VALUE", "1"
   end
 
   def test_overriding_class_annotation : Nil
-    headers = self.get("/with-ann-override").headers
+    self.get "/with-ann-override"
 
     self.assert_response_not_has_header "ANNOTATION"
     self.assert_response_header_equals "ANNOTATION_VALUE", "2"

--- a/src/components/framework/src/ip_utils.cr
+++ b/src/components/framework/src/ip_utils.cr
@@ -83,7 +83,6 @@ module Athena::Framework::IPUtils
         return self.set_cached_result cache_key, false
       end
 
-      address = ip
       netmask = 128
     end
 

--- a/src/components/framework/src/request.cr
+++ b/src/components/framework/src/request.cr
@@ -316,15 +316,12 @@ class Athena::Framework::Request
     end
 
     if @@trusted_header_set.includes?(ProxyHeader::FORWARDED) && (forwarded_param = type.forwarded_param) && (forwarded = @request.headers[ProxyHeader::FORWARDED.header]?)
-      parts = ATH::HeaderUtils.split forwarded, ",;="
-      param = type.forwarded_param
-
-      parts.each do |sub_parts|
+      ATH::HeaderUtils.split(forwarded, ",;=").each do |sub_parts|
         # In this particular context compiler gets confused, so lets make it happy by skipping unexpected typed parts, which should never happen.
         next if sub_parts.is_a?(String)
         next if sub_parts.nil?
 
-        unless v = HeaderUtils.combine(sub_parts)[param]?.as?(String?)
+        unless v = HeaderUtils.combine(sub_parts)[forwarded_param]?.as?(String?)
           next
         end
 


### PR DESCRIPTION
## Context

Follow up to https://github.com/athena-framework/athena/pull/344 to leverage the new `ExcludeTypeDeclarations` configuration option added via https://github.com/crystal-ameba/ameba/pull/430 instead of totally disabling the rule. Allows retaining actual useless assignments without also flagging all the bundle property macro calls.

## Changelog

* Enable `Lint/UselessAssign` ameba rule again but excluding type declarations
  * Fix new errors

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
