### PR TITLE
Address `::sleep(Number)` deprecation

### DIFF
--- a/src/components/clock/docs/README.md
+++ b/src/components/clock/docs/README.md
@@ -36,6 +36,6 @@ berlin_clock = clock.in_location Time::Location.load "Europe/Berlin"
 # From here, get the current time as a `Time` instance
 now = clock.now # : ::Time
 
-# and sleep for any period of time
-clock.sleep 2
+# and sleep for any span of time
+clock.sleep 2.seconds
 ```

--- a/src/components/clock/spec/mock_clock_spec.cr
+++ b/src/components/clock/spec/mock_clock_spec.cr
@@ -31,7 +31,7 @@ struct MockClockTest < ASPEC::TestCase
     clock = ACLK::Spec::MockClock.new Time.utc 2023, 9, 16, 23, 53, 0, nanosecond: 999_000_000
     location = clock.now.location
 
-    clock.sleep 2.002_001
+    clock.sleep 2.002_001.seconds
     clock.now.to_s("%F %H:%M:%S.%6N").should eq "2023-09-16 23:53:03.001001"
     clock.now.location.should eq location
   end

--- a/src/components/clock/spec/monotonic_spec.cr
+++ b/src/components/clock/spec/monotonic_spec.cr
@@ -27,7 +27,7 @@ struct MonotonicClockTest < ASPEC::TestCase
     location = clock.now.location
 
     before = Time.local.to_unix_ms
-    clock.sleep 0.5
+    clock.sleep 0.5.seconds
     now = clock.now.to_unix_ms
     sleep 100.milliseconds
     after = Time.local.to_unix_ms

--- a/src/components/clock/spec/native_spec.cr
+++ b/src/components/clock/spec/native_spec.cr
@@ -27,7 +27,7 @@ struct NativeClockTest < ASPEC::TestCase
     location = clock.now.location
 
     before = Time.local.to_unix_ms
-    clock.sleep 0.5
+    clock.sleep 0.5.seconds
     now = clock.now.to_unix_ms
     sleep 10.milliseconds
     after = Time.local.to_unix_ms

--- a/src/components/clock/src/athena-clock.cr
+++ b/src/components/clock/src/athena-clock.cr
@@ -42,9 +42,4 @@ class Athena::Clock
   def sleep(span : Time::Span) : Nil
     (@clock || self.class.clock).sleep span
   end
-
-  # :inherit:
-  def sleep(seconds : Number) : Nil
-    (@clock || self.class.clock).sleep seconds
-  end
 end

--- a/src/components/clock/src/interface.cr
+++ b/src/components/clock/src/interface.cr
@@ -8,7 +8,4 @@ module Athena::Clock::Interface
 
   # Sleeps for the provided *span* of time.
   abstract def sleep(span : Time::Span) : Nil
-
-  # Sleeps for the provided amount of *seconds*.
-  abstract def sleep(seconds : Number) : Nil
 end

--- a/src/components/clock/src/monotonic.cr
+++ b/src/components/clock/src/monotonic.cr
@@ -28,9 +28,4 @@ class Athena::Clock::Monotonic
   def sleep(span : Time::Span) : Nil
     ::sleep span
   end
-
-  # :inherit:
-  def sleep(seconds : Number) : Nil
-    ::sleep seconds
-  end
 end

--- a/src/components/clock/src/native.cr
+++ b/src/components/clock/src/native.cr
@@ -35,9 +35,4 @@ struct Athena::Clock::Native
   def sleep(span : Time::Span) : Nil
     ::sleep span
   end
-
-  # :inherit:
-  def sleep(seconds : Number) : Nil
-    ::sleep seconds
-  end
 end

--- a/src/components/clock/src/spec.cr
+++ b/src/components/clock/src/spec.cr
@@ -77,11 +77,6 @@ module Athena::Clock::Spec
     def sleep(span : Time::Span) : Nil
       @now += span
     end
-
-    # :inherit:
-    def sleep(seconds : Number) : Nil
-      self.sleep seconds.seconds
-    end
   end
 
   # An `Athena::Spec::TestCase` mix-in that allows freezing time and restoring the global clock after each test.

--- a/src/components/console/spec/helper/progress_bar_spec.cr
+++ b/src/components/console/spec/helper/progress_bar_spec.cr
@@ -61,7 +61,7 @@ struct ProgressBarTest < ASPEC::TestCase
     bar.advance
     bar.advance
 
-    @clock.sleep 1
+    @clock.sleep 1.second
 
     bar.estimated.should eq 600
   end
@@ -72,7 +72,7 @@ struct ProgressBarTest < ASPEC::TestCase
     bar.start at: 599
     bar.advance
 
-    @clock.sleep 1
+    @clock.sleep 1.second
 
     bar.estimated.should eq 1_200
     bar.remaining.should eq 600
@@ -888,9 +888,9 @@ struct ProgressBarTest < ASPEC::TestCase
 
     bar.start
     bar.progress = 1
-    @clock.sleep 10
+    @clock.sleep 10.seconds
     bar.progress = 2
-    @clock.sleep 20
+    @clock.sleep 20.seconds
     bar.progress = 3
 
     self.assert_output(
@@ -908,14 +908,14 @@ struct ProgressBarTest < ASPEC::TestCase
 
     bar.progress = 1 # No threshold hit, no redraw
     bar.maximum_seconds_between_redraws = 2
-    @clock.sleep 1
+    @clock.sleep 1.second
     bar.progress = 2 # Still no redraw because it takes 2 seconds for a redraw
-    @clock.sleep 1
+    @clock.sleep 1.second
     bar.progress = 3 # 1 + 1 = 2 -> redraw
     bar.progress = 4 # step based redraw freq hit, redraw even without sleep
     bar.progress = 5 # No threshold hit, no redraw
     bar.maximum_seconds_between_redraws = 3
-    @clock.sleep 2
+    @clock.sleep 2.seconds
     bar.progress = 6 # No redraw even though 2 seconds passed. Throttling has priority
     bar.maximum_seconds_between_redraws = 2
     bar.progress = 7 # Throttling relaxed, draw
@@ -936,12 +936,12 @@ struct ProgressBarTest < ASPEC::TestCase
     bar.start
 
     bar.progress = 1 # Too fast, should not draw
-    @clock.sleep 1
+    @clock.sleep 1.second
     bar.progress = 2 # 1 second passed, draw
     bar.minimum_seconds_between_redraws = 2
-    @clock.sleep 1
+    @clock.sleep 1.second
     bar.progress = 3 # 1 second passed, but the threshold was changed, should not draw
-    @clock.sleep 1
+    @clock.sleep 1.second
     bar.progress = 4 # 1 + 1 seconds = 2 seconds passed, draw
     bar.progress = 5 # No threshold hit, should not draw
 

--- a/src/components/console/src/helper/progress_bar.cr
+++ b/src/components/console/src/helper/progress_bar.cr
@@ -272,7 +272,7 @@ require "../output/interface"
 #   bar1.advance
 #   bar2.advance(4) if idx.divisible_by? 2
 #
-#   sleep 0.05
+#   sleep 0.05.seconds
 # end
 # ```
 #

--- a/src/components/console/src/helper/question.cr
+++ b/src/components/console/src/helper/question.cr
@@ -201,7 +201,7 @@ class Athena::Console::Helper::Question < Athena::Console::Helper
         error = ex
       ensure
         attempts -= 1 if attempts
-        sleep 0
+        Fiber.yield
       end
     end
 

--- a/src/components/console/src/output/section.cr
+++ b/src/components/console/src/output/section.cr
@@ -16,19 +16,19 @@ require "./io"
 #   section2.puts "World!"
 #   # Output contains "Hello\nWorld!\n"
 #
-#   sleep 1
+#   sleep 1.second
 #
 #   # Replace "Hello" with "Goodbye!"
 #   section1.overwrite "Goodbye!"
 #   # Output now contains "Goodbye\nWorld!\n"
 #
-#   sleep 1
+#   sleep 1.second
 #
 #   # Clear "World!"
 #   section2.clear
 #   # Output now contains "Goodbye!\n"
 #
-#   sleep 1
+#   sleep 1.second
 #
 #   # Delete the last 2 lines of the first section
 #   section1.clear 2


### PR DESCRIPTION
## Context

Addresses deprecation warnings resulting from https://github.com/crystal-lang/crystal/pull/14962. Outright remove the one interface overload to keep the APIs consistent.

## Changelog

* **Breaking:** Remove `Athena::Clock::Interface#sleep(Number)` overload
* Updates usages of `sleep` to use the `Time::Span` overload

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
