### PR TITLE
Scaffold out code coverage reporting implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           mkdir build &&
           cd build &&
           cmake .. &&
-          make &&
+          make -j$(nproc) &&
           sudo make install
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
@@ -88,7 +88,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          directory: ./coverage/**
+          files: ./coverage/**/cov.xml
           flags: compiled
           verbose: true
   test_unit:
@@ -122,7 +122,7 @@ jobs:
           mkdir build &&
           cd build &&
           cmake .. &&
-          make &&
+          make -j$(nproc) &&
           sudo make install
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
@@ -142,6 +142,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          directory: ./coverage/**
+          files: ./coverage/**/cov.xml
           flags: unit
           verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,14 @@ jobs:
           files: ./coverage/**/cov.xml
           flags: compiled
           verbose: true
+      - uses: codecov/test-results-action@v1
+        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest' # Only want to upload coverage report once in the matrix
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          files: ./coverage/**/junit.xml
+          flags: compiled
+          verbose: true
   test_unit:
     strategy:
       fail-fast: false
@@ -143,5 +151,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           files: ./coverage/**/cov.xml
+          flags: unit
+          verbose: true
+      - uses: codecov/test-results-action@v1
+        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest' # Only want to upload coverage report once in the matrix
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          files: ./coverage/**/junit.xml
           flags: unit
           verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install kcov
+        run: brew install kcov
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
@@ -68,7 +70,7 @@ jobs:
         run: ./scripts/test.sh all compiled
         shell: bash
       - uses: codecov/codecov-action@v4
-        if: ${{ matrix.crystal == 'latest' }}
+        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest' # Only want to upload coverage report once in the matrix
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -94,6 +96,9 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           fetch-depth: 0
+      - name: Install kcov
+        if: matrix.os == 'macos-latest' && matrix.crystal == 'latest'
+        run: brew install kcov
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
@@ -105,8 +110,10 @@ jobs:
       - name: Specs
         run: ./scripts/test.sh all unit
         shell: bash
+        env:
+          WITH_CODE_COVERAGE: {{ (matrix.os == 'macos-latest' && matrix.crystal == 'latest') && '1' || '0' }}
       - uses: codecov/codecov-action@v4
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest' }}
+        if: matrix.os == 'macos-latest' && matrix.crystal == 'latest' # Only want to upload coverage report once in the matrix
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install kcov
+        if: matrix.crystal == 'latest'
         run: brew install kcov
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
@@ -70,9 +71,9 @@ jobs:
         run: ./scripts/test.sh all compiled
         shell: bash
         env:
-          WITH_CODE_COVERAGE: ${{ (matrix.os == 'macos-latest' && matrix.crystal == 'latest') && '1' || '0' }}
+          WITH_CODE_COVERAGE: ${{ matrix.crystal == 'latest' && '1' || '0' }}
       - uses: codecov/codecov-action@v4
-        if: matrix.os == 'macos-latest' && matrix.crystal == 'latest' # Only want to upload coverage report once in the matrix
+        if: matrix.crystal == 'latest' # Only want to upload coverage report once in the matrix
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,10 @@ jobs:
       - name: Compiled Specs
         run: ./scripts/test.sh all compiled
         shell: bash
+        env:
+          WITH_CODE_COVERAGE: ${{ (matrix.os == 'macos-latest' && matrix.crystal == 'latest') && '1' || '0' }}
       - uses: codecov/codecov-action@v4
-        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest' # Only want to upload coverage report once in the matrix
+        if: matrix.os == 'macos-latest' && matrix.crystal == 'latest' # Only want to upload coverage report once in the matrix
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         run: ./scripts/test.sh all unit
         shell: bash
         env:
-          WITH_CODE_COVERAGE: {{ (matrix.os == 'macos-latest' && matrix.crystal == 'latest') && '1' || '0' }}
+          WITH_CODE_COVERAGE: ${{ (matrix.os == 'macos-latest' && matrix.crystal == 'latest') && '1' || '0' }}
       - uses: codecov/codecov-action@v4
         if: matrix.os == 'macos-latest' && matrix.crystal == 'latest' # Only want to upload coverage report once in the matrix
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         run: ./scripts/test.sh all compiled
         shell: bash
       - uses: codecov/codecov-action@v4
+        if: ${{ matrix.crystal == 'latest' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          directory: ./coverage/
+          directory: ./coverage/**
           flags: compiled
           verbose: true
   test_unit:
@@ -142,6 +142,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          directory: ./coverage/
+          directory: ./coverage/**
           flags: unit
           verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,13 @@ jobs:
       - name: Compiled Specs
         run: ./scripts/test.sh all compiled
         shell: bash
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          directory: ./coverage/
+          flags: compiled
+          verbose: true
   test_unit:
     strategy:
       fail-fast: false
@@ -97,3 +104,11 @@ jobs:
       - name: Specs
         run: ./scripts/test.sh all unit
         shell: bash
+      - uses: codecov/codecov-action@v4
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest' }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          directory: ./coverage/
+          flags: unit
+          verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,23 @@ jobs:
         crystal:
           - latest
           - nightly
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install kcov
         if: matrix.crystal == 'latest'
-        run: brew install kcov
+        run: |
+          sudo apt-get update &&
+          sudo apt-get install binutils-dev libssl-dev libcurl4-openssl-dev libelf-dev libstdc++-12-dev zlib1g-dev libdw-dev libiberty-dev
+          curl -L -o ./kcov.tar.gz https://github.com/SimonKagstrom/kcov/archive/refs/tags/v43.tar.gz &&
+          mkdir kcov-source &&
+          tar xzf kcov.tar.gz -C kcov-source --strip-components=1 &&
+          cd kcov-source &&
+          mkdir build &&
+          cd build &&
+          cmake .. &&
+          make &&
+          sudo make install
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
@@ -100,8 +111,19 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install kcov
-        if: matrix.os == 'macos-latest' && matrix.crystal == 'latest'
-        run: brew install kcov
+        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest'
+        run: |
+          sudo apt-get update &&
+          sudo apt-get install binutils-dev libssl-dev libcurl4-openssl-dev libelf-dev libstdc++-12-dev zlib1g-dev libdw-dev libiberty-dev
+          curl -L -o ./kcov.tar.gz https://github.com/SimonKagstrom/kcov/archive/refs/tags/v43.tar.gz &&
+          mkdir kcov-source &&
+          tar xzf kcov.tar.gz -C kcov-source --strip-components=1 &&
+          cd kcov-source &&
+          mkdir build &&
+          cd build &&
+          cmake .. &&
+          make &&
+          sudo make install
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
@@ -114,9 +136,9 @@ jobs:
         run: ./scripts/test.sh all unit
         shell: bash
         env:
-          WITH_CODE_COVERAGE: ${{ (matrix.os == 'macos-latest' && matrix.crystal == 'latest') && '1' || '0' }}
+          WITH_CODE_COVERAGE: ${{ (matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest') && '1' || '0' }}
       - uses: codecov/codecov-action@v4
-        if: matrix.os == 'macos-latest' && matrix.crystal == 'latest' # Only want to upload coverage report once in the matrix
+        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest' # Only want to upload coverage report once in the matrix
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           flags: compiled
           verbose: true
       - uses: codecov/test-results-action@v1
-        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest' # Only want to upload coverage report once in the matrix
+        if: matrix.crystal == 'latest'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ __pycache__
 .cache
 .venv
 site/
+
+coverage/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,57 @@
+comment:
+    layout: "condensed_header, flags, components, condensed_files, condensed_footer"
+
+component_management:
+  individual_components:
+    - component_id: clock_component
+      name: clock
+      paths:
+        - src/components/clock/**
+    - component_id: console_component
+      name: console
+      paths:
+        - src/components/console/**
+    - component_id: dependency_injection_component
+      name: dependency_injection
+      paths:
+        - src/components/dependency_injection/**
+    - component_id: dotenv_component
+      name: dotenv
+      paths:
+        - src/components/dotenv/**
+    - component_id: event_dispatcher_component
+      name: event_dispatcher
+      paths:
+        - src/components/event_dispatcher/**
+    - component_id: framework_component
+      name: framework
+      paths:
+        - src/components/framework/**
+    - component_id: image_size_component
+      name: image_size
+      paths:
+        - src/components/image_size/**
+    - component_id: mercure_component
+      name: mercure
+      paths:
+        - src/components/mercure/**
+    - component_id: negotiation_component
+      name: negotiation
+      paths:
+        - src/components/negotiation/**
+    - component_id: routing_component
+      name: routing
+      paths:
+        - src/components/routing/**
+    - component_id: serializer_component
+      name: serializer
+      paths:
+        - src/components/serializer/**
+    - component_id: spec_component
+      name: spec
+      paths:
+        - src/components/spec/**
+    - component_id: validator_component
+      name: validator
+      paths:
+        - src/components/validator/**

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,9 @@
 comment:
-    layout: "condensed_header, flags, components, condensed_files, condensed_footer"
+  layout: "condensed_header, flags, components, condensed_files, condensed_footer"
+
+flag_management:
+  default_rules:
+    carryforward: true
 
 component_management:
   individual_components:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -44,7 +44,6 @@ EXIT_CODE=0
 
 # Coverage generation logic based on https://hannes.kaeufler.net/posts/measuring-code-coverage-in-crystal-with-kcov
 mkdir -p coverage/bin
-mkdir -p /tmp/athena/
 
 if [ $COMPONENT != "all" ]
 then

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,7 +17,7 @@ function runSpecsWithCoverage()
 DEFAULT_BUILD_OPTIONS=(-Dstrict_multi_assign -Dpreview_overload_order --error-on-warnings)
 DEFAULT_OPTIONS=(--order=random)
 CRYSTAL=${CRYSTAL:=crystal}
-WITH_CODE_COVERAGE=${WITH_CODE_COVERAGE:=1}
+WITH_CODE_COVERAGE=${WITH_CODE_COVERAGE:=0}
 
 # Runs the specs for all, or optionally a single component.
 # Optionally generates code coverage report data as well.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-DEFAULT_OPTIONS=(-Dstrict_multi_assign -Dpreview_overload_order --order=random --error-on-warnings)
+DEFAULT_BUILD_OPTIONS=(-Dstrict_multi_assign -Dpreview_overload_order --error-on-warnings)
+DEFAULT_OPTIONS=(--order=random)
 CRYSTAL=${CRYSTAL:=crystal}
+WITH_CODE_COVERAGE=${WITH_CODE_COVERAGE:=1}
 
-# Runs the specs for all, or optionally a single component
+# Runs the specs for all, or optionally a single component.
+# Optionally generates code coverage report data as well.
 #
 # $1 - (optional) component name to runs specs for, or "all". Defaults to "all".
 # $2 - (optional) "type" of specs to run: "unit", "compiled", or "all". Defaults to "all".
@@ -23,17 +26,47 @@ then
   exit 1
 fi
 
+# $1 component name
+function runSpecs()
+{
+  $CRYSTAL spec "${DEFAULT_BUILD_OPTIONS[@]}" "${DEFAULT_OPTIONS[@]}" "src/components/$1/spec"
+}
+
+# $1 component name
+function runSpecsWithCoverage()
+{
+  echo "require \"../../src/components/$1/spec/**\"" > "./coverage/bin/$1.cr" && \
+  crystal build "${DEFAULT_BUILD_OPTIONS[@]}" "./coverage/bin/$1.cr" -o "./coverage/bin/$1" && \
+  kcov --clean --cobertura-only --include-path="./src/components/$1/src" "./coverage/$1" "./coverage/bin/$1" "${DEFAULT_OPTIONS[@]}" || EXIT_CODE=1
+}
+
 if [ $COMPONENT != "all" ]
 then
-  $CRYSTAL spec "${DEFAULT_OPTIONS[@]}" "src/components/$1/spec"
+  if [ $WITH_CODE_COVERAGE == "1" ]
+  then
+    runSpecsWithCoverage $COMPONENT
+  else
+    runSpecs $COMPONENT
+  fi
   exit $?
 fi
 
 EXIT_CODE=0
 
-for component in $(find src/components/ -maxdepth 2 -type f -name shard.yml | xargs -I{} dirname {} | sort); do
+# Coverage generation logic based on https://hannes.kaeufler.net/posts/measuring-code-coverage-in-crystal-with-kcov
+mkdir -p coverage/bin
+mkdir -p /tmp/athena/
+
+for component in $(find src/components/ -maxdepth 2 -type f -name shard.yml | xargs -I{} dirname {} | xargs -I{} basename {} | sort); do
   echo "::group::$component"
-  $CRYSTAL spec "${DEFAULT_OPTIONS[@]}" $component/spec || EXIT_CODE=1
+
+  if [ $WITH_CODE_COVERAGE == "1" ]
+  then
+    runSpecsWithCoverage $component || EXIT_CODE=1
+  else
+    runSpecs $component
+  fi
+
   echo "::endgroup::"
 done
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,7 +11,7 @@ function runSpecsWithCoverage()
 {
   echo "require \"../../src/components/$1/spec/**\"" > "./coverage/bin/$1.cr" && \
   crystal build "${DEFAULT_BUILD_OPTIONS[@]}" "./coverage/bin/$1.cr" -o "./coverage/bin/$1" && \
-  kcov --debug=31 --clean --include-path="./src/components/$1/src" "./coverage/$1" "./coverage/bin/$1" "${DEFAULT_OPTIONS[@]}" || EXIT_CODE=1
+  kcov --clean --cobertura-only --include-path="./src/components/$1/src" "./coverage/$1" "./coverage/bin/$1" "${DEFAULT_OPTIONS[@]}" || EXIT_CODE=1
 }
 
 DEFAULT_BUILD_OPTIONS=(-Dstrict_multi_assign -Dpreview_overload_order --error-on-warnings)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,7 +11,7 @@ function runSpecsWithCoverage()
 {
   echo "require \"../../src/components/$1/spec/**\"" > "./coverage/bin/$1.cr" && \
   crystal build "${DEFAULT_BUILD_OPTIONS[@]}" "./coverage/bin/$1.cr" -o "./coverage/bin/$1" && \
-  kcov --clean --cobertura-only --include-path="./src/components/$1/src" "./coverage/$1" "./coverage/bin/$1" "${DEFAULT_OPTIONS[@]}" || EXIT_CODE=1
+  kcov --clean --cobertura-only --include-path="./src/components/$1/src" "./coverage/$1" "./coverage/bin/$1" --junit_output="./coverage/$1/junit.xml" "${DEFAULT_OPTIONS[@]}" || EXIT_CODE=1
 }
 
 DEFAULT_BUILD_OPTIONS=(-Dstrict_multi_assign -Dpreview_overload_order --error-on-warnings)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,9 +6,12 @@ function runSpecs()
   $CRYSTAL spec "${DEFAULT_BUILD_OPTIONS[@]}" "${DEFAULT_OPTIONS[@]}" "src/components/$1/spec"
 }
 
+# Coverage generation logic based on https://hannes.kaeufler.net/posts/measuring-code-coverage-in-crystal-with-kcov
+#
 # $1 component name
 function runSpecsWithCoverage()
 {
+  mkdir -p coverage/bin
   echo "require \"../../src/components/$1/spec/**\"" > "./coverage/bin/$1.cr" && \
   crystal build "${DEFAULT_BUILD_OPTIONS[@]}" "./coverage/bin/$1.cr" -o "./coverage/bin/$1" && \
   kcov --clean --cobertura-only --include-path="./src/components/$1/src" "./coverage/$1" "./coverage/bin/$1" --junit_output="./coverage/$1/junit.xml" "${DEFAULT_OPTIONS[@]}" || EXIT_CODE=1
@@ -41,9 +44,6 @@ then
 fi
 
 EXIT_CODE=0
-
-# Coverage generation logic based on https://hannes.kaeufler.net/posts/measuring-code-coverage-in-crystal-with-kcov
-mkdir -p coverage/bin
 
 if [ $COMPONENT != "all" ]
 then


### PR DESCRIPTION
## Context

Resolves #450.

## Changelog

* Update `scripts/test.sh` to optionally allow generating of code coverage
* Revert https://github.com/athena-framework/athena/pull/406
  * This just makes things easier for generating the reports, can follow up to improve again if needed. Either by seeing about building on `macos-latest` itself again, or using `actions/cache` to not build it every time
* Configure https://app.codecov.io/gh/athena-framework/athena

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
