### PR TITLE
Codecov tuning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,6 @@ jobs:
       - name: Compiled Specs
         run: ./scripts/test.sh all compiled
         shell: bash
-        env:
-          WITH_CODE_COVERAGE: ${{ matrix.crystal == 'latest' && '1' || '0' }}
       - uses: codecov/codecov-action@v4
         if: matrix.crystal == 'latest' # Only want to upload coverage report once in the matrix
         with:
@@ -92,7 +90,7 @@ jobs:
           flags: compiled
           verbose: true
       - uses: codecov/test-results-action@v1
-        if: matrix.crystal == 'latest'
+        if: matrix.crystal == 'latest' # Only want to upload coverage report once in the matrix
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -143,8 +141,6 @@ jobs:
       - name: Specs
         run: ./scripts/test.sh all unit
         shell: bash
-        env:
-          WITH_CODE_COVERAGE: ${{ (matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest') && '1' || '0' }}
       - uses: codecov/codecov-action@v4
         if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest' # Only want to upload coverage report once in the matrix
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,15 @@
 comment:
   layout: "condensed_header, flags, components, condensed_files, condensed_footer"
 
+coverage:
+  status:
+    project:
+      default:
+        target: auto # Prevent total coverage from decreasing due to a PR
+    patch:
+      default:
+        target: 100% # Enforce all _new_ code is fully tested
+
 flag_management:
   default_rules:
     carryforward: true

--- a/src/components/clock/spec/athena-clock_spec.cr
+++ b/src/components/clock/spec/athena-clock_spec.cr
@@ -3,6 +3,14 @@ require "./spec_helper"
 struct ClockTest < ASPEC::TestCase
   include ACLK::Spec::ClockSensitive
 
+  def test_functions_as_a_clock : Nil
+    self.mock_time Time.utc 2023, 9, 16
+
+    clock = ACLK.new
+
+    clock.now.to_s("%F").should eq "2023-09-16"
+  end
+
   def test_supports_mock_clock : Nil
     ACLK.clock.should be_a ACLK::Native
 

--- a/src/components/clock/spec/athena-clock_spec.cr
+++ b/src/components/clock/spec/athena-clock_spec.cr
@@ -11,6 +11,28 @@ struct ClockTest < ASPEC::TestCase
     clock.now.to_s("%F").should eq "2023-09-16"
   end
 
+  def test_accepts_an_existing_clock : Nil
+    clock = ACLK.new ACLK::Spec::MockClock.new Time.utc 2023, 9, 16, 23, 53, 0
+    clock.now.to_s("%F").should eq "2023-09-16"
+  end
+
+  def test_in_location : Nil
+    clock = ACLK.new location: Time::Location.load("America/New_York")
+    utc_clock = clock.in_location Time::Location::UTC
+
+    clock.should_not eq utc_clock
+    utc_clock.now.location.should eq Time::Location::UTC
+  end
+
+  def test_sleep : Nil
+    clock = ACLK.new ACLK::Spec::MockClock.new Time.utc 2023, 9, 16, 23, 53, 0, nanosecond: 999_000_000
+    location = clock.now.location
+
+    clock.sleep 2.002_001.seconds
+    clock.now.to_s("%F %H:%M:%S.%6N").should eq "2023-09-16 23:53:03.001001"
+    clock.now.location.should eq location
+  end
+
   def test_supports_mock_clock : Nil
     ACLK.clock.should be_a ACLK::Native
 


### PR DESCRIPTION
## Context

Using this to tune codecov, both in regards to the script integration and its settings to improve its usefulness and DX of using it locally.

## Changelog

* Automatically detect `kcov`
* Generate full reports outside of CI
* Add some extra test coverage to `ACLK`

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
