### PR TITLE
Make `ASPEC.assert_error` spec less strict

### DIFF
--- a/src/components/spec/spec/methods_spec.cr
+++ b/src/components/spec/spec/methods_spec.cr
@@ -6,7 +6,7 @@ describe ASPEC::Methods do
       begin
         ENV["CRYSTAL"] = "/path/to/crystal"
 
-        expect_raises File::NotFoundError, "'/path/to/crystal': No such file or directory" do
+        expect_raises File::NotFoundError do
           assert_error "", ""
         end
       ensure


### PR DESCRIPTION
## Context

Makes this test a bit less strict so that it can run on multiple OSs as per: https://github.com/crystal-lang/test-ecosystem/pull/56.

## Changelog

* Make `ASPEC.assert_error` spec less strict

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
