### PR TITLE
Apply new upcoming formatting requirements

### DIFF
--- a/src/components/clock/src/athena-clock.cr
+++ b/src/components/clock/src/athena-clock.cr
@@ -22,7 +22,7 @@ class Athena::Clock
 
   def initialize(
     @clock : ACLK::Interface? = nil,
-    @location : Time::Location? = nil
+    @location : Time::Location? = nil,
   )
   end
 

--- a/src/components/clock/src/monotonic.cr
+++ b/src/components/clock/src/monotonic.cr
@@ -8,7 +8,7 @@ class Athena::Clock::Monotonic
   @nanosecond_offset : Int128
 
   def initialize(
-    location : Time::Location? = nil
+    location : Time::Location? = nil,
   )
     @location = location || Time::Location.local
     @nanosecond_offset = Time.utc.to_unix_ns - Time.monotonic.total_nanoseconds.to_i128

--- a/src/components/clock/src/native.cr
+++ b/src/components/clock/src/native.cr
@@ -16,7 +16,7 @@ struct Athena::Clock::Native
   @location : Time::Location
 
   def initialize(
-    location : Time::Location? = nil
+    location : Time::Location? = nil,
   )
     @location = location || Time::Location.local
   end

--- a/src/components/clock/src/spec.cr
+++ b/src/components/clock/src/spec.cr
@@ -49,7 +49,7 @@ module Athena::Clock::Spec
 
     def initialize(
       now : Time = Time.local,
-      location : Time::Location? = nil
+      location : Time::Location? = nil,
     )
       @location = location || Time::Location::UTC
       @now = now.in @location

--- a/src/components/console/spec/application_spec.cr
+++ b/src/components/console/spec/application_spec.cr
@@ -65,7 +65,7 @@ struct ApplicationTest < ASPEC::TestCase
     commands.size.should eq 1
 
     app.command_loader = ACON::Loader::Factory.new({
-      "foo:bar1" => ->{ Foo1Command.new.as ACON::Command },
+      "foo:bar1" => -> { Foo1Command.new.as ACON::Command },
     })
     commands = app.commands "foo"
     commands.size.should eq 2
@@ -112,7 +112,7 @@ struct ApplicationTest < ASPEC::TestCase
     app.get("afoobar").should be foo
 
     app.command_loader = ACON::Loader::Factory.new({
-      "foo:bar1" => ->{ Foo1Command.new.as ACON::Command },
+      "foo:bar1" => -> { Foo1Command.new.as ACON::Command },
     })
 
     app.has?("afoobar").should be_true
@@ -258,7 +258,7 @@ struct ApplicationTest < ASPEC::TestCase
     app = ACON::Application.new "foo"
 
     app.command_loader = ACON::Loader::Factory.new({
-      "foo:bar" => ->{ FooCommand.new.as ACON::Command },
+      "foo:bar" => -> { FooCommand.new.as ACON::Command },
     })
 
     app.find("foo:bar").should be_a FooCommand
@@ -479,7 +479,7 @@ struct ApplicationTest < ASPEC::TestCase
 
     app = ACON::Application.new "foo"
     app.command_loader = ACON::Loader::Factory.new({
-      "foo3" => ->{ foo_command.as ACON::Command },
+      "foo3" => -> { foo_command.as ACON::Command },
     })
     app.add foo_command
 
@@ -1048,12 +1048,12 @@ struct ApplicationTest < ASPEC::TestCase
     loaded = Hash(String, Bool).new
 
     app.command_loader = ACON::Loader::Factory.new({
-      "foo:bar" => ->do
+      "foo:bar" => -> do
         loaded["foo:bar"] = true
 
         ACON::Commands::Generic.new("foo:bar") { ACON::Command::Status::SUCCESS }.as ACON::Command
       end,
-      "foo" => ->do
+      "foo" => -> do
         loaded["foo"] = true
 
         ACON::Commands::Generic.new("foo") { ACON::Command::Status::SUCCESS }.as ACON::Command
@@ -1069,7 +1069,7 @@ struct ApplicationTest < ASPEC::TestCase
     app = ACON::Application.new "foo"
 
     app.command_loader = ACON::Loader::Factory.new({
-      "foo" => ->{ ACON::Commands::Generic.new("bar") { ACON::Command::Status::SUCCESS }.as ACON::Command },
+      "foo" => -> { ACON::Commands::Generic.new("bar") { ACON::Command::Status::SUCCESS }.as ACON::Command },
     })
 
     expect_raises ACON::Exception::CommandNotFound, "The 'foo' command cannot be found because it is registered under multiple names. Make sure you don't set a different name via constructor or 'name='." do

--- a/src/components/console/spec/commands/complete_spec.cr
+++ b/src/components/console/spec/commands/complete_spec.cr
@@ -48,7 +48,7 @@ struct CompleteCommandTest < ASPEC::TestCase
 
   def test_completes_command_name_with_loader : Nil
     @application.command_loader = ACON::Loader::Factory.new({
-      "foo:bar1" => ->{ Foo1Command.new.as ACON::Command },
+      "foo:bar1" => -> { Foo1Command.new.as ACON::Command },
     })
 
     self.execute({"--current" => "0", "--input" => [] of String})

--- a/src/components/console/spec/commands/lazy_spec.cr
+++ b/src/components/console/spec/commands/lazy_spec.cr
@@ -9,7 +9,7 @@ end
 
 describe ACON::Commands::Lazy do
   it "applies metadata to the instantiated command" do
-    lazy_command = ACON::Commands::Lazy.new "cmd_name", ["foo", "bar"], "description", true, ->{ MockCommand.new.as ACON::Command }
+    lazy_command = ACON::Commands::Lazy.new "cmd_name", ["foo", "bar"], "description", true, -> { MockCommand.new.as ACON::Command }
     command = lazy_command.command
 
     command.should be_a MockCommand
@@ -22,7 +22,7 @@ describe ACON::Commands::Lazy do
   it "forwards methods to the wrapped command instance" do
     mock_command = MockCommand.new
 
-    lazy_command = ACON::Commands::Lazy.new "cmd_name", ["foo", "bar"], "description", true, ->{ mock_command.as ACON::Command }
+    lazy_command = ACON::Commands::Lazy.new "cmd_name", ["foo", "bar"], "description", true, -> { mock_command.as ACON::Command }
     command = lazy_command.command
 
     command.helper_set = ACON::Helper::HelperSet.new ACON::Helper::Question.new

--- a/src/components/console/spec/spec_helper.cr
+++ b/src/components/console/spec/spec_helper.cr
@@ -20,7 +20,7 @@ struct MockCommandLoader
     *,
     @command_or_exception : ACON::Command | ::Exception? = nil,
     @has : Bool = true,
-    @names : Array(String) | ::Exception = [] of String
+    @names : Array(String) | ::Exception = [] of String,
   )
   end
 

--- a/src/components/console/src/command.cr
+++ b/src/components/console/src/command.cr
@@ -297,7 +297,7 @@ abstract class Athena::Console::Command
     mode : ACON::Input::Argument::Mode = :optional,
     description : String = "",
     default = nil,
-    suggested_values : Enumerable(String)? = nil
+    suggested_values : Enumerable(String)? = nil,
   ) : self
     @definition << ACON::Input::Argument.new name, mode, description, default, suggested_values.try &.to_a
 
@@ -401,7 +401,7 @@ abstract class Athena::Console::Command
     value_mode : ACON::Input::Option::Value = :none,
     description : String = "",
     default = nil,
-    suggested_values : Enumerable(String)? = nil
+    suggested_values : Enumerable(String)? = nil,
   ) : self
     @definition << ACON::Input::Option.new name, shortcut, value_mode, description, default, suggested_values.try &.to_a
 

--- a/src/components/console/src/commands/lazy.cr
+++ b/src/components/console/src/commands/lazy.cr
@@ -24,7 +24,7 @@ class Athena::Console::Commands::Lazy < Athena::Console::Command
     description : String,
     hidden : Bool,
     @command : Proc(ACON::Command),
-    @enabled : Bool = true
+    @enabled : Bool = true,
   )
     self
       .name(name)

--- a/src/components/console/src/descriptor/context.cr
+++ b/src/components/console/src/descriptor/context.cr
@@ -12,7 +12,7 @@ class Athena::Console::Descriptor::Context
     @raw_output : Bool? = nil,
     @namespace : String? = nil,
     @total_width : Int32? = nil,
-    @short : Bool = false
+    @short : Bool = false,
   )
   end
 

--- a/src/components/console/src/helper/progress_bar.cr
+++ b/src/components/console/src/helper/progress_bar.cr
@@ -476,7 +476,7 @@ class Athena::Console::Helper::ProgressBar
     minimum_seconds_between_redraws : Float64 = 0.04,
 
     # Use a monotonic clock by default since its better for measuring time
-    @clock : ACLK::Interface = ACLK::Monotonic.new
+    @clock : ACLK::Interface = ACLK::Monotonic.new,
   )
     if output.is_a? ACON::Output::ConsoleOutputInterface
       output = output.error_output

--- a/src/components/console/src/helper/progress_indicator.cr
+++ b/src/components/console/src/helper/progress_indicator.cr
@@ -185,7 +185,7 @@ class Athena::Console::Helper::ProgressIndicator
     indicator_values : Indexable(String)? = nil,
 
     # Use a monotonic clock by default since its better for measuring time
-    @clock : ACLK::Interface = ACLK::Monotonic.new
+    @clock : ACLK::Interface = ACLK::Monotonic.new,
   )
     indicator_values ||= ["-", "\\", "|", "/"]
 

--- a/src/components/console/src/helper/table.cr
+++ b/src/components/console/src/helper/table.cr
@@ -479,7 +479,7 @@ class Athena::Console::Helper::Table
       value : _ = "",
       @rowspan : Int32 = 1,
       @colspan : Int32 = 1,
-      @style : Table::CellStyle? = nil
+      @style : Table::CellStyle? = nil,
     )
       @value = value.to_s
     end
@@ -496,7 +496,7 @@ class Athena::Console::Helper::Table
     def initialize(
       rowspan : Int32 = 1,
       colspan : Int32 = 1,
-      style : Table::CellStyle? = nil
+      style : Table::CellStyle? = nil,
     )
       super "", rowspan, colspan, style
     end

--- a/src/components/console/src/helper/table_cell_style.cr
+++ b/src/components/console/src/helper/table_cell_style.cr
@@ -28,7 +28,7 @@ struct Athena::Console::Helper::Table::CellStyle
     @foreground : String = "default",
     @background : String = "default",
     @align : ACON::Helper::Table::Alignment = :left,
-    @format : String? = nil
+    @format : String? = nil,
   )
   end
 

--- a/src/components/console/src/helper/table_style.cr
+++ b/src/components/console/src/helper/table_style.cr
@@ -242,7 +242,7 @@ class Athena::Console::Helper::Table::Style
     middle_left : String | Char,
     top_left_bottom : String | Char | Nil = nil,
     top_middle_bottom : String | Char | Nil = nil,
-    top_right_bottom : String | Char | Nil = nil
+    top_right_bottom : String | Char | Nil = nil,
   ) : self
     @crossing_char = cross.to_s
     @crossing_top_left_char = top_left.to_s

--- a/src/components/console/src/input/argument.cr
+++ b/src/components/console/src/input/argument.cr
@@ -46,7 +46,7 @@ class Athena::Console::Input::Argument
     @mode : ACON::Input::Argument::Mode = :optional,
     @description : String = "",
     default = nil,
-    @suggested_values : Array(String) | Proc(ACON::Completion::Input, Array(String)) | Nil = nil
+    @suggested_values : Array(String) | Proc(ACON::Completion::Input, Array(String)) | Nil = nil,
   )
     raise ACON::Exception::InvalidArgument.new "An argument name cannot be blank." if name.blank?
 

--- a/src/components/console/src/input/option.cr
+++ b/src/components/console/src/input/option.cr
@@ -71,7 +71,7 @@ class Athena::Console::Input::Option
     @value_mode : ACON::Input::Option::Value = :none,
     @description : String = "",
     default = nil,
-    @suggested_values : Array(String) | Proc(ACON::Completion::Input, Array(String)) | Nil = nil
+    @suggested_values : Array(String) | Proc(ACON::Completion::Input, Array(String)) | Nil = nil,
   )
     @name = name.lchop "--"
 

--- a/src/components/console/src/output/console_output.cr
+++ b/src/components/console/src/output/console_output.cr
@@ -14,7 +14,7 @@ class Athena::Console::Output::ConsoleOutput < Athena::Console::Output::IO
   def initialize(
     verbosity : ACON::Output::Verbosity = :normal,
     decorated : Bool? = nil,
-    formatter : ACON::Formatter::Interface? = nil
+    formatter : ACON::Formatter::Interface? = nil,
   )
     super STDOUT, verbosity, decorated, formatter
 

--- a/src/components/console/src/output/io.cr
+++ b/src/components/console/src/output/io.cr
@@ -8,7 +8,7 @@ class Athena::Console::Output::IO < Athena::Console::Output
     @io : ::IO,
     verbosity : ACON::Output::Verbosity? = :normal,
     decorated : Bool? = nil,
-    formatter : ACON::Formatter::Interface? = nil
+    formatter : ACON::Formatter::Interface? = nil,
   )
     decorated = self.has_color_support? if decorated.nil?
 

--- a/src/components/console/src/output/output.cr
+++ b/src/components/console/src/output/output.cr
@@ -10,7 +10,7 @@ abstract class Athena::Console::Output
   def initialize(
     verbosity : ACON::Output::Verbosity? = :normal,
     decorated : Bool = false,
-    formatter : ACON::Formatter::Interface? = nil
+    formatter : ACON::Formatter::Interface? = nil,
   )
     @verbosity = verbosity || ACON::Output::Verbosity::NORMAL
     @formatter = formatter || ACON::Formatter::Output.new
@@ -79,7 +79,7 @@ abstract class Athena::Console::Output
     message : String | Enumerable(String),
     new_line : Bool,
     verbosity : ACON::Output::Verbosity,
-    output_type : ACON::Output::Type
+    output_type : ACON::Output::Type,
   )
     messages = message.is_a?(String) ? {message} : message
 

--- a/src/components/console/src/output/section.cr
+++ b/src/components/console/src/output/section.cr
@@ -50,7 +50,7 @@ class Athena::Console::Output::Section < Athena::Console::Output::IO
     @sections : Array(self),
     verbosity : ACON::Output::Verbosity,
     decorated : Bool,
-    formatter : ACON::Formatter::Interface
+    formatter : ACON::Formatter::Interface,
   )
     super io, verbosity, decorated, formatter
 

--- a/src/components/console/src/output/sized_buffer.cr
+++ b/src/components/console/src/output/sized_buffer.cr
@@ -7,7 +7,7 @@ class Athena::Console::Output::SizedBuffer < Athena::Console::Output
     @max_length : Int32,
     verbosity : ACON::Output::Verbosity? = :normal,
     decorated : Bool = false,
-    formatter : ACON::Formatter::Interface? = nil
+    formatter : ACON::Formatter::Interface? = nil,
   )
     if @max_length < 0
       raise ACON::Exception::InvalidArgument.new "'#{self.class}#max_length' must be a positive, got: '#{@max_length}'."

--- a/src/components/console/src/spec.cr
+++ b/src/components/console/src/spec.cr
@@ -56,7 +56,7 @@ module Athena::Console::Spec
       decorated : Bool? = nil,
       interactive : Bool? = nil,
       verbosity : ACON::Output::Verbosity? = nil,
-      @capture_stderr_separately : Bool = false
+      @capture_stderr_separately : Bool = false,
     ) : Nil
       if !@capture_stderr_separately
         @output = ACON::Output::IO.new IO::Memory.new
@@ -126,7 +126,7 @@ module Athena::Console::Spec
       interactive : Bool? = nil,
       capture_stderr_separately : Bool = false,
       verbosity : ACON::Output::Verbosity? = nil,
-      **input : _
+      **input : _,
     )
       self.run input.to_h.transform_keys(&.to_s), decorated: decorated, interactive: interactive, capture_stderr_separately: capture_stderr_separately, verbosity: verbosity
     end
@@ -138,7 +138,7 @@ module Athena::Console::Spec
       decorated : Bool? = nil,
       interactive : Bool? = nil,
       capture_stderr_separately : Bool = false,
-      verbosity : ACON::Output::Verbosity? = nil
+      verbosity : ACON::Output::Verbosity? = nil,
     ) : ACON::Command::Status
       @input = ACON::Input::Hash.new input
 
@@ -272,7 +272,7 @@ module Athena::Console::Spec
       interactive : Bool? = nil,
       capture_stderr_separately : Bool = false,
       verbosity : ACON::Output::Verbosity? = nil,
-      **input : _
+      **input : _,
     )
       self.execute input.to_h.transform_keys(&.to_s), decorated: decorated, interactive: interactive, capture_stderr_separately: capture_stderr_separately, verbosity: verbosity
     end
@@ -284,7 +284,7 @@ module Athena::Console::Spec
       decorated : Bool = false,
       interactive : Bool? = nil,
       capture_stderr_separately : Bool = false,
-      verbosity : ACON::Output::Verbosity? = nil
+      verbosity : ACON::Output::Verbosity? = nil,
     ) : ACON::Command::Status
       if !input.has_key?("command") && (application = @command.application?) && application.definition.has_argument?("command")
         input = input.merge({"command" => @command.name})

--- a/src/components/dependency_injection/spec/compiler_passes/optional_services_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/optional_services_spec.cr
@@ -14,7 +14,7 @@ class OptionalClient
   def initialize(
     @service_missing : OptionalMissingService?,
     @service_existing : OptionalExistingService?,
-    @service_default : OptionalMissingService | Int32 | Nil = 12
+    @service_default : OptionalMissingService | Int32 | Nil = 12,
   ); end
 end
 

--- a/src/components/dependency_injection/spec/compiler_passes/parameters_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/parameters_spec.cr
@@ -24,7 +24,7 @@ class ParametersClient
     array : Array(String),
     nested_array : Array(Array(String) | String),
     nested_hash : Hash(String, Bool | String | Array(String) | Array(Array(String) | String)),
-    non_string : Bool
+    non_string : Bool,
   )
     reference.should eq "google.com"
     with_percent.should eq "foo%bar"

--- a/src/components/dependency_injection/spec/compiler_passes/process_auto_configurations_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/process_auto_configurations_spec.cr
@@ -40,7 +40,7 @@ class PartnerNamedDefaultClient
 
   def initialize(
     @services : Array(FeedPartner),
-    @status : Status = Status::Active
+    @status : Status = Status::Active,
   )
   end
 end

--- a/src/components/dependency_injection/spec/compiler_passes/process_bindings_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/process_bindings_spec.cr
@@ -18,7 +18,7 @@ class BindingsPriorityClient
     id : Int64,    # Ann has highest priority
     name : String, # Global bind 2nd highest priority
     alive : Bool,  # Autoconfigure lowest priority
-    value : Float32
+    value : Float32,
   )
     id.should eq 30
     name.should eq "Fred"
@@ -57,7 +57,7 @@ class BindingsClient
     service_hash : Hash(String, SomeClassService | SomeStructService),
     service_array : Array(SomeClassService | SomeStructService),
     value : Float64,
-    proxy_service : ADI::Proxy(SomeStructService)
+    proxy_service : ADI::Proxy(SomeStructService),
   )
     some_service.value.should eq 123
     some_parameter.should eq "google.com"
@@ -72,7 +72,7 @@ end
 class Bindings2Client
   def initialize(
     value,
-    proxy_service : SomeStructService
+    proxy_service : SomeStructService,
   )
     value.should eq 88
     proxy_service.should eq SomeStructService.new

--- a/src/components/dependency_injection/spec/compiler_passes/proxy_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/proxy_spec.cr
@@ -29,7 +29,7 @@ class ServiceOne
     @service_two : ADI::Proxy(ServiceTwo),
     @service_three : ADI::Proxy(ServiceThree),
     @namespaced_service : ADI::Proxy(Some::Namespace::Service),
-    @service_two_extra : ADI::Proxy(ServiceTwo)
+    @service_two_extra : ADI::Proxy(ServiceTwo),
   )
   end
 

--- a/src/components/dependency_injection/spec/compiler_passes/resolve_values_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/resolve_values_spec.cr
@@ -40,7 +40,7 @@ class ValuePriorityService
     global_bind : Int32,
     auto_configure_bind : Int32,
     nilable_type : Int32?,
-    default_value : Int32 = 700
+    default_value : Int32 = 700,
   )
     ann_bind.should eq 1000
     global_bind.should eq 900
@@ -67,7 +67,7 @@ class ServiceValuePriorityService
     alias_overridden_by_auto_configure_bind : ResolveValuePriorityInterface,
 
     # Validates container rewrites the alias service ID to the real underlying service ID
-    alias_service_via_string_alias : ResolveValuePriorityInterface
+    alias_service_via_string_alias : ResolveValuePriorityInterface,
   )
     explicit_auto_wire.should be_a ServicePriorityThree
     service_priority_two.should be_a ServicePriorityTwo

--- a/src/components/dependency_injection/src/annotations.cr
+++ b/src/components/dependency_injection/src/annotations.cr
@@ -409,7 +409,7 @@ module Athena::DependencyInjection
   #   def initialize(
   #     @service_missing : OptionalMissingService?,
   #     @service_existing : OptionalExistingService?,
-  #     @service_default : OptionalMissingService | Int32 | Nil = 12
+  #     @service_default : OptionalMissingService | Int32 | Nil = 12,
   #   ); end
   # end
   #

--- a/src/components/dotenv/src/athena-dotenv.cr
+++ b/src/components/dotenv/src/athena-dotenv.cr
@@ -168,7 +168,7 @@ class Athena::Dotenv
   @line_number = 1
 
   def initialize(
-    @env_key : String = "APP_ENV"
+    @env_key : String = "APP_ENV",
   )
     # Can't use a `getter!` macro since that would return a copy of the reader each time :/
     @reader = uninitialized Char::Reader
@@ -212,7 +212,7 @@ class Athena::Dotenv
     env_key : String? = nil,
     default_environment : String = "dev",
     test_environments : Enumerable(String) = {"test"},
-    override_existing_vars : Bool = false
+    override_existing_vars : Bool = false,
   ) : Nil
     env_key = env_key || @env_key
 

--- a/src/components/dotenv/src/exception/format.cr
+++ b/src/components/dotenv/src/exception/format.cr
@@ -26,7 +26,7 @@ class Athena::Dotenv::Exception::Format < Athena::Dotenv::Exception::Logic
       @data : String,
       path : ::Path | String,
       @line_number : Int32,
-      @offset : Int32
+      @offset : Int32,
     )
       @path = path.to_s
     end

--- a/src/components/event_dispatcher/src/callable.cr
+++ b/src/components/event_dispatcher/src/callable.cr
@@ -49,7 +49,7 @@ abstract struct Athena::EventDispatcher::Callable
   def initialize(
     @event_class : AED::Event.class,
     name : String?,
-    @priority : Int32
+    @priority : Int32,
   )
     @name = name || "unknown callable"
   end
@@ -74,7 +74,7 @@ abstract struct Athena::EventDispatcher::Callable
       @callback : E -> Nil,
       priority : Int32 = 0,
       name : String? = nil,
-      event_class : E.class = E
+      event_class : E.class = E,
     )
       super event_class, name, priority
     end
@@ -104,7 +104,7 @@ abstract struct Athena::EventDispatcher::Callable
       @callback : E, AED::EventDispatcherInterface -> Nil,
       priority : Int32 = 0,
       name : String? = nil,
-      event_class : E.class = E
+      event_class : E.class = E,
     )
       super event_class, name, priority
     end
@@ -137,7 +137,7 @@ abstract struct Athena::EventDispatcher::Callable
       @instance : I,
       priority : Int32 = 0,
       name : String? = nil,
-      event_class : E.class = E
+      event_class : E.class = E,
     )
       super event_class, name || "unknown #{@instance.class} method", priority
     end

--- a/src/components/event_dispatcher/src/generic_event.cr
+++ b/src/components/event_dispatcher/src/generic_event.cr
@@ -37,7 +37,7 @@ class Athena::EventDispatcher::GenericEvent(S, V) < Athena::EventDispatcher::Eve
 
   def initialize(
     @subject : S,
-    @arguments : Hash(String, V)
+    @arguments : Hash(String, V),
   ); end
 
   # Returns the argument with the provided *key*, raising if it does not exist.

--- a/src/components/framework/spec/controller/value_resolvers/query_parameter_spec.cr
+++ b/src/components/framework/spec/controller/value_resolvers/query_parameter_spec.cr
@@ -5,7 +5,7 @@ private def parameter(
   *,
   name : String? = nil,
   validation_failed_status : HTTP::Status = :not_found,
-  default : T? = nil
+  default : T? = nil,
 ) forall T
   ATH::Controller::ParameterMetadata(T).new(
     "foo",

--- a/src/components/framework/spec/controllers/argument_resolver_controller.cr
+++ b/src/components/framework/spec/controllers/argument_resolver_controller.cr
@@ -25,7 +25,7 @@ class ArgumentResolverController < ATH::Controller
   @[ARTA::Post("/float")]
   def happy_path1(
     @[MyResolverAnnotation]
-    value : Float64
+    value : Float64,
   ) : Float64
     value
   end
@@ -33,7 +33,7 @@ class ArgumentResolverController < ATH::Controller
   @[ARTA::Post("/string")]
   def happy_path2(
     @[MyResolverAnnotation]
-    value : String
+    value : String,
   ) : String
     value
   end

--- a/src/components/framework/spec/ext/routing/annotation_route_loader_spec.cr
+++ b/src/components/framework/spec/ext/routing/annotation_route_loader_spec.cr
@@ -4,7 +4,7 @@ private def assert_route(
   route_collection : ART::RouteCollection,
   file : String = __FILE__,
   line : Int32 = __LINE__,
-  **args
+  **args,
 )
   route_collection.size.should eq 1
 
@@ -23,7 +23,7 @@ private def assert_route(
   condition : ART::Route::Condition? = nil,
   name : String? = nil,
   file : String = __FILE__,
-  line : Int32 = __LINE__
+  line : Int32 = __LINE__,
 ) : Nil
   route_name, route = route
 

--- a/src/components/framework/spec/spec_helper.cr
+++ b/src/components/framework/spec/spec_helper.cr
@@ -82,7 +82,7 @@ end
 def new_action(
   *,
   arguments : Tuple = Tuple.new,
-  annotation_configurations = nil
+  annotation_configurations = nil,
 ) : ATH::ActionBase
   ATH::Action.new(
     Proc(typeof(Tuple.new), String).new { test_controller = TestController.new; test_controller.get_test },
@@ -99,7 +99,7 @@ def new_request(
   method : String = "GET",
   action : ATH::ActionBase = new_action,
   body : String | IO | Nil = nil,
-  query : String? = nil
+  query : String? = nil,
 ) : ATH::Request
   request = ATH::Request.new method, path, body: body
   request.attributes.set "_controller", "TestController#test", String
@@ -123,7 +123,7 @@ def new_response(
   *,
   io : IO = IO::Memory.new,
   status : HTTP::Status = :ok,
-  headers : HTTP::Headers = HTTP::Headers.new
+  headers : HTTP::Headers = HTTP::Headers.new,
 ) : HTTP::Server::Response
   HTTP::Server::Response.new(io).tap do |resp|
     headers.each do |k, v|

--- a/src/components/framework/spec/view/view_handler_spec.cr
+++ b/src/components/framework/spec/view/view_handler_spec.cr
@@ -10,7 +10,7 @@ private class MockURLGenerator
   def initialize(
     @expected_route : String = "some_route",
     @expected_reference_type : ART::Generator::ReferenceType = :absolute_path,
-    @generated_url : String = "URL"
+    @generated_url : String = "URL",
   ); end
 
   def generate(route : String, params : Hash(String, String | ::Nil) = Hash(String, String | ::Nil).new, reference_type : ART::Generator::ReferenceType = :absolute_path) : String

--- a/src/components/framework/src/action.cr
+++ b/src/components/framework/src/action.cr
@@ -21,7 +21,7 @@ struct Athena::Framework::Action(Controller, ReturnType, ParameterTypeTuple, Par
     @annotation_configurations : ADI::AnnotationConfigurations,
     # Don't bother making these ivars since we just need them to set the generic types
     _controller : Controller.class,
-    _return_type : ReturnType.class
+    _return_type : ReturnType.class,
   ); end
 
   # Returns the type that this action returns.

--- a/src/components/framework/src/athena.cr
+++ b/src/components/framework/src/athena.cr
@@ -162,7 +162,7 @@ module Athena::Framework
     reuse_port : Bool = false,
     ssl_context : OpenSSL::SSL::Context::Server? = nil,
     *,
-    prepend_handlers : Array(HTTP::Handler) = [] of HTTP::Handler
+    prepend_handlers : Array(HTTP::Handler) = [] of HTTP::Handler,
   ) : Nil
     ATH::Server.new(port, host, reuse_port, ssl_context, prepend_handlers).start
   end
@@ -183,7 +183,7 @@ module Athena::Framework
       @host : String = "0.0.0.0",
       @reuse_port : Bool = false,
       @ssl_context : OpenSSL::SSL::Context::Server? = nil,
-      prepend_handlers handlers : Array(HTTP::Handler) = [] of HTTP::Handler
+      prepend_handlers handlers : Array(HTTP::Handler) = [] of HTTP::Handler,
     )
       handler_proc = HTTP::Handler::HandlerProc.new do |context|
         # Reinitialize the container since keep-alive requests reuse the same fiber.

--- a/src/components/framework/src/binary_file_response.cr
+++ b/src/components/framework/src/binary_file_response.cr
@@ -53,7 +53,7 @@ class Athena::Framework::BinaryFileResponse < Athena::Framework::Response
     public : Bool = true,
     content_disposition : ATH::BinaryFileResponse::ContentDisposition? = nil,
     auto_etag : Bool = false,
-    auto_last_modified : Bool = true
+    auto_last_modified : Bool = true,
   )
     super nil, status, headers
 

--- a/src/components/framework/src/commands/debug_event_dispatcher.cr
+++ b/src/components/framework/src/commands/debug_event_dispatcher.cr
@@ -44,7 +44,7 @@
 # TODO: Support dedicated `AED::EventDispatcherInterface` services other than the default.
 class Athena::Framework::Commands::DebugEventDispatcher < ACON::Command
   def initialize(
-    @dispatcher : AED::EventDispatcherInterface
+    @dispatcher : AED::EventDispatcherInterface,
   )
     super()
   end

--- a/src/components/framework/src/commands/debug_router.cr
+++ b/src/components/framework/src/commands/debug_router.cr
@@ -39,7 +39,7 @@
 # TIP: Checkout `ATH::Commands::DebugRouterMatch` to test which route a given path resolves to.
 class Athena::Framework::Commands::DebugRouter < ACON::Command
   def initialize(
-    @router : ART::RouterInterface
+    @router : ART::RouterInterface,
   )
     super()
   end

--- a/src/components/framework/src/commands/debug_router_match.cr
+++ b/src/components/framework/src/commands/debug_router_match.cr
@@ -33,7 +33,7 @@
 # ```
 class Athena::Framework::Commands::DebugRouterMatch < ACON::Command
   def initialize(
-    @router : ART::RouterInterface
+    @router : ART::RouterInterface,
   )
     super()
   end

--- a/src/components/framework/src/controller/parameter_metadata.cr
+++ b/src/components/framework/src/controller/parameter_metadata.cr
@@ -16,7 +16,7 @@ struct Athena::Framework::Controller::ParameterMetadata(T)
     @name : String,
     @has_default : Bool = false,
     @default_value : T? = nil,
-    @annotation_configurations : ADI::AnnotationConfigurations = ADI::AnnotationConfigurations.new
+    @annotation_configurations : ADI::AnnotationConfigurations = ADI::AnnotationConfigurations.new,
   ); end
 
   # If `nil` is a valid value for the parameter.

--- a/src/components/framework/src/controller/redirect.cr
+++ b/src/components/framework/src/controller/redirect.cr
@@ -2,7 +2,7 @@
 class Athena::Framework::Controller::Redirect
   def initialize(
     @http_port : Int32? = nil,
-    @https_port : Int32? = nil
+    @https_port : Int32? = nil,
   ); end
 
   # ameba:disable Metrics/CyclomaticComplexity:
@@ -13,7 +13,7 @@ class Athena::Framework::Controller::Redirect
     scheme : String? = nil,
     http_port : Int32? = nil,
     https_port : Int32? = nil,
-    keep_request_method : Bool = false
+    keep_request_method : Bool = false,
   ) : ATH::RedirectResponse
     if path.empty?
       raise ATH::Exception::HTTPException.new (permanent ? HTTP::Status::GONE : HTTP::Status::NOT_FOUND), ""

--- a/src/components/framework/src/controller/value_resolvers/interface.cr
+++ b/src/components/framework/src/controller/value_resolvers/interface.cr
@@ -79,7 +79,7 @@
 #   @[ARTA::Get("/{num}")]
 #   def multiply(
 #     @[Multiply::This]
-#     num : Int32
+#     num : Int32,
 #   ) : Int32
 #     num
 #   end
@@ -124,7 +124,7 @@
 #   @[ARTA::Get("/{num}")]
 #   def multiply(
 #     @[Multiply::This(multiplier: 50)]
-#     num : Int32
+#     num : Int32,
 #   ) : Int32
 #     num
 #   end
@@ -178,7 +178,7 @@
 #   @[ARTA::Get("/integer/{value}")]
 #   def integer(
 #     @[MyResolver::Enable]
-#     value : Int32
+#     value : Int32,
 #   ) : Int32
 #     value
 #   end
@@ -186,7 +186,7 @@
 #   @[ARTA::Get("/string/{value}")]
 #   def string(
 #     @[MyResolver::Enable]
-#     value : String
+#     value : String,
 #   ) : String
 #     value
 #   end
@@ -249,7 +249,7 @@
 #   @[ARTA::Get("/integer")]
 #   def integer(
 #     @[MyResolver::Enable]
-#     value : Int32
+#     value : Int32,
 #   ) : Int32
 #     value
 #   end
@@ -257,7 +257,7 @@
 #   @[ARTA::Get("/string")]
 #   def string(
 #     @[MyResolver::Enable]
-#     value : String
+#     value : String,
 #   ) : String
 #     value
 #   end

--- a/src/components/framework/src/controller/value_resolvers/query_parameter.cr
+++ b/src/components/framework/src/controller/value_resolvers/query_parameter.cr
@@ -26,7 +26,7 @@
 #     @[ATHA::MapQueryParameter] age : Int32,
 #     @[ATHA::MapQueryParameter] color : Color,
 #     @[ATHA::MapQueryParameter] category : String = "",
-#     @[ATHA::MapQueryParameter] theme : String? = nil
+#     @[ATHA::MapQueryParameter] theme : String? = nil,
 #   ) : Nil
 #     ids        # => [1, 2]
 #     first_name # => "Jon"

--- a/src/components/framework/src/controller/value_resolvers/request_body.cr
+++ b/src/components/framework/src/controller/value_resolvers/request_body.cr
@@ -32,7 +32,7 @@
 #   @[ATHA::View(status: :created)]
 #   def new_user(
 #     @[ATHA::MapRequestBody]
-#     user_create : UserCreate
+#     user_create : UserCreate,
 #   ) : UserCreate
 #     # Use the provided UserCreate instance to create an actual User DB record.
 #     # For purposes of this example, just return the instance.
@@ -93,7 +93,7 @@ struct Athena::Framework::Controller::ValueResolvers::RequestBody
 
   def initialize(
     @serializer : ASR::SerializerInterface,
-    @validator : AVD::Validator::ValidatorInterface
+    @validator : AVD::Validator::ValidatorInterface,
   ); end
 
   # :inherit:

--- a/src/components/framework/src/controller/value_resolvers/time.cr
+++ b/src/components/framework/src/controller/value_resolvers/time.cr
@@ -17,7 +17,7 @@
 #   def event(
 #     @[ATHA::MapTime("%F", location: Time::Location.load("Europe/Berlin"))]
 #     start_time : Time,
-#     end_time : Time
+#     end_time : Time,
 #   ) : Nil
 #     start_time # => 2020-04-07 00:00:00.0 +02:00 Europe/Berlin
 #     end_time   # => 2020-04-08 12:34:56.0 UTC

--- a/src/components/framework/src/exception/http_exception.cr
+++ b/src/components/framework/src/exception/http_exception.cr
@@ -25,7 +25,7 @@ class Athena::Framework::Exception::HTTPException < ::Exception
     status : Int32 | HTTP::Status,
     message : String = "",
     cause : ::Exception? = nil,
-    headers : HTTP::Headers = HTTP::Headers.new
+    headers : HTTP::Headers = HTTP::Headers.new,
   ) : self
     status = status.is_a?(HTTP::Status) ? status : HTTP::Status.new(status)
 

--- a/src/components/framework/src/exception/method_not_allowed.cr
+++ b/src/components/framework/src/exception/method_not_allowed.cr
@@ -5,7 +5,7 @@ class Athena::Framework::Exception::MethodNotAllowed < Athena::Framework::Except
     allow : Array(String),
     message : String,
     cause : ::Exception? = nil,
-    headers : HTTP::Headers = HTTP::Headers.new
+    headers : HTTP::Headers = HTTP::Headers.new,
   )
     headers["allow"] = allow.join ", ", &.upcase
 

--- a/src/components/framework/src/ext/console/application.cr
+++ b/src/components/framework/src/ext/console/application.cr
@@ -14,7 +14,7 @@ class Athena::Framework::Console::Application < ACON::Application
   protected def initialize(
     command_loader : ACON::Loader::Interface? = nil,
     event_dipatcher : AED::EventDispatcherInterface? = nil,
-    eager_commands : Enumerable(ACON::Command)? = nil
+    eager_commands : Enumerable(ACON::Command)? = nil,
   )
     super "Athena", ATH::VERSION
 

--- a/src/components/framework/src/ext/console/container_command_loader.cr
+++ b/src/components/framework/src/ext/console/container_command_loader.cr
@@ -6,7 +6,7 @@ class Athena::Framework::Console::ContainerCommandLoader
 
   def initialize(
     @command_map : Hash(String, ACON::Command.class),
-    @loader : ATH::Console::ContainerCommandLoaderLocator
+    @loader : ATH::Console::ContainerCommandLoaderLocator,
   ); end
 
   # :inherit:

--- a/src/components/framework/src/ext/console/descriptor/descriptor.cr
+++ b/src/components/framework/src/ext/console/descriptor/descriptor.cr
@@ -14,7 +14,7 @@ abstract class Athena::Framework::Console::Descriptor
       raw_output : Bool? = nil,
       namespace : String? = nil,
       total_width : Int32? = nil,
-      short : Bool = false
+      short : Bool = false,
     )
       super format, raw_text, raw_output, namespace, total_width, short
     end
@@ -33,7 +33,7 @@ abstract class Athena::Framework::Console::Descriptor
       raw_output : Bool? = nil,
       namespace : String? = nil,
       total_width : Int32? = nil,
-      short : Bool = false
+      short : Bool = false,
     )
       super output, format, raw_text, raw_output, namespace, total_width, short
     end
@@ -52,7 +52,7 @@ abstract class Athena::Framework::Console::Descriptor
       raw_output : Bool? = nil,
       namespace : String? = nil,
       total_width : Int32? = nil,
-      short : Bool = false
+      short : Bool = false,
     )
       super output, format, raw_text, raw_output, namespace, total_width, short
     end

--- a/src/components/framework/src/ext/console/descriptor/text.cr
+++ b/src/components/framework/src/ext/console/descriptor/text.cr
@@ -109,7 +109,7 @@ class Athena::Framework::Console::Descriptor::Text < Athena::Framework::Console:
   private def render_event_listener_table(
     output : ACON::Style::Athena,
     event_dispatcher : AED::EventDispatcherInterface,
-    event_listeners : Hash(AED::Event.class, Array(AED::Callable))
+    event_listeners : Hash(AED::Event.class, Array(AED::Callable)),
   ) : Nil
     sorted_listeners = event_listeners
       .to_a
@@ -125,7 +125,7 @@ class Athena::Framework::Console::Descriptor::Text < Athena::Framework::Console:
   private def render_event_listener_table(
     output : ACON::Style::Athena,
     event_dispatcher : AED::EventDispatcherInterface,
-    event_listeners : Array(AED::Callable)
+    event_listeners : Array(AED::Callable),
   ) : Nil
     table_headers = %w(Order Callable Priority)
     table_rows = [] of Array(String | Int32)

--- a/src/components/framework/src/ext/routing/router.cr
+++ b/src/components/framework/src/ext/routing/router.cr
@@ -12,7 +12,7 @@ class Athena::Framework::Routing::Router < Athena::Routing::Router
   def initialize(
     default_locale : String? = nil,
     strict_requirements : Bool? = true,
-    request_context : ART::RequestContext? = nil
+    request_context : ART::RequestContext? = nil,
   )
     super(
       ATH::Routing::AnnotationRouteLoader.route_collection,

--- a/src/components/framework/src/listeners/cors.cr
+++ b/src/components/framework/src/listeners/cors.cr
@@ -20,7 +20,7 @@ struct Athena::Framework::Listeners::CORS
       @allow_headers : Array(String) = [] of String,
       @allow_methods : Array(String) = Athena::Framework::Listeners::CORS::SAFELISTED_METHODS,
       @expose_headers : Array(String) = [] of String,
-      @max_age : Int32 = 0
+      @max_age : Int32 = 0,
     )
       @allow_origin = allow_origin.map &.as String | Regex
     end

--- a/src/components/framework/src/listeners/format.cr
+++ b/src/components/framework/src/listeners/format.cr
@@ -8,7 +8,7 @@ require "mime"
 # See the [Getting Started](/getting_started/routing#content-negotiation) docs for more information.
 struct Athena::Framework::Listeners::Format
   def initialize(
-    @format_negotiator : ATH::View::FormatNegotiator
+    @format_negotiator : ATH::View::FormatNegotiator,
   ); end
 
   @[AEDA::AsEventListener(priority: 34)]

--- a/src/components/framework/src/listeners/routing.cr
+++ b/src/components/framework/src/listeners/routing.cr
@@ -6,7 +6,7 @@ struct Athena::Framework::Listeners::Routing
   def initialize(
     @matcher : ART::Matcher::URLMatcherInterface | ART::Matcher::RequestMatcherInterface,
     @request_store : ATH::RequestStore,
-    request_context : ART::RequestContext? = nil
+    request_context : ART::RequestContext? = nil,
   )
     @request_context = request_context || @matcher.context
   end

--- a/src/components/framework/src/route_handler.cr
+++ b/src/components/framework/src/route_handler.cr
@@ -7,7 +7,7 @@ struct Athena::Framework::RouteHandler
     @event_dispatcher : AED::EventDispatcherInterface,
     @request_store : ATH::RequestStore,
     @argument_resolver : ATH::Controller::ArgumentResolverInterface,
-    @controller_resolver : ATH::ControllerResolverInterface
+    @controller_resolver : ATH::ControllerResolverInterface,
   )
   end
 

--- a/src/components/framework/src/spec/abstract_browser.cr
+++ b/src/components/framework/src/spec/abstract_browser.cr
@@ -31,7 +31,7 @@ abstract class Athena::Framework::Spec::AbstractBrowser
     method : String,
     path : String,
     headers : HTTP::Headers,
-    body : String | Bytes | IO | Nil
+    body : String | Bytes | IO | Nil,
   ) : HTTP::Server::Response
     # At the moment this just calls into `do_request`.
     # Kept this as way allow for future expansion.

--- a/src/components/framework/src/spec/expectations/request/attribute_equals.cr
+++ b/src/components/framework/src/spec/expectations/request/attribute_equals.cr
@@ -7,7 +7,7 @@ struct Athena::Framework::Spec::Expectations::Request::AttributeEquals(T)
   def initialize(
     @name : String,
     @value : T,
-    @description : String? = nil
+    @description : String? = nil,
   ); end
 
   def match(actual_value : ATH::Request) : Bool

--- a/src/components/framework/src/spec/expectations/response/cookie_value_equals.cr
+++ b/src/components/framework/src/spec/expectations/response/cookie_value_equals.cr
@@ -10,7 +10,7 @@ struct Athena::Framework::Spec::Expectations::Response::CookieValueEquals < Athe
     @value : String,
     @path : String? = nil,
     @domain : String? = nil,
-    description : String? = nil
+    description : String? = nil,
   )
     super description
   end

--- a/src/components/framework/src/spec/expectations/response/format_equals.cr
+++ b/src/components/framework/src/spec/expectations/response/format_equals.cr
@@ -6,7 +6,7 @@ struct Athena::Framework::Spec::Expectations::Response::FormatEquals < Athena::F
   def initialize(
     @request : ATH::Request,
     @format : String? = nil,
-    description : String? = nil
+    description : String? = nil,
   )
     super description
   end

--- a/src/components/framework/src/spec/expectations/response/has_cookie.cr
+++ b/src/components/framework/src/spec/expectations/response/has_cookie.cr
@@ -8,7 +8,7 @@ struct Athena::Framework::Spec::Expectations::Response::HasCookie < Athena::Fram
     @name : String,
     @path : String? = nil,
     @domain : String? = nil,
-    description : String? = nil
+    description : String? = nil,
   )
     super description
   end

--- a/src/components/framework/src/spec/expectations/response/has_header.cr
+++ b/src/components/framework/src/spec/expectations/response/has_header.cr
@@ -5,7 +5,7 @@ struct Athena::Framework::Spec::Expectations::Response::HasHeader < Athena::Fram
   def initialize(
     @name : String,
 
-    description : String? = nil
+    description : String? = nil,
   )
     super description
   end

--- a/src/components/framework/src/spec/expectations/response/has_status.cr
+++ b/src/components/framework/src/spec/expectations/response/has_status.cr
@@ -4,14 +4,14 @@ struct Athena::Framework::Spec::Expectations::Response::HasStatus < Athena::Fram
 
   def self.new(
     status_code : Int32,
-    description : String? = nil
+    description : String? = nil,
   )
     new ::HTTP::Status.from_value(status_code), description
   end
 
   def initialize(
     @status : ::HTTP::Status,
-    description : String? = nil
+    description : String? = nil,
   )
     super description
   end

--- a/src/components/framework/src/spec/expectations/response/header_equals.cr
+++ b/src/components/framework/src/spec/expectations/response/header_equals.cr
@@ -6,7 +6,7 @@ struct Athena::Framework::Spec::Expectations::Response::HeaderEquals < Athena::F
   def initialize(
     @name : String,
     @value : String,
-    description : String? = nil
+    description : String? = nil,
   )
     super description
   end

--- a/src/components/framework/src/view/format_negotiator.cr
+++ b/src/components/framework/src/view/format_negotiator.cr
@@ -13,7 +13,7 @@ class Athena::Framework::View::FormatNegotiator < ANG::Negotiator
 
   def initialize(
     @request_store : ATH::RequestStore,
-    @mime_types : Hash(String, Array(String)) = Hash(String, Array(String)).new
+    @mime_types : Hash(String, Array(String)) = Hash(String, Array(String)).new,
   )
   end
 

--- a/src/components/framework/src/view/view.cr
+++ b/src/components/framework/src/view/view.cr
@@ -70,7 +70,7 @@ class Athena::Framework::View(T)
   def self.create_redirect(
     url : String,
     status : HTTP::Status = HTTP::Status::FOUND,
-    headers : HTTP::Headers = HTTP::Headers.new
+    headers : HTTP::Headers = HTTP::Headers.new,
   ) : self
     view = ATH::View(Nil).new status: status, headers: headers
     view.location = url
@@ -85,7 +85,7 @@ class Athena::Framework::View(T)
     route : String,
     params : Hash(String, _) = Hash(String, String?).new,
     status : HTTP::Status = HTTP::Status::FOUND,
-    headers : HTTP::Headers = HTTP::Headers.new
+    headers : HTTP::Headers = HTTP::Headers.new,
   ) : self
     view = ATH::View(Nil).new status: status, headers: headers
     view.route = route

--- a/src/components/framework/src/view/view_handler.cr
+++ b/src/components/framework/src/view/view_handler.cr
@@ -25,7 +25,7 @@ class Athena::Framework::View::ViewHandler
     format_handlers : Array(Athena::Framework::View::FormatHandlerInterface),
     @failed_validation_status : HTTP::Status = HTTP::Status::UNPROCESSABLE_ENTITY,
     @empty_content_status : HTTP::Status = HTTP::Status::NO_CONTENT,
-    @emit_nil : Bool = false
+    @emit_nil : Bool = false,
   )
     format_handlers.each do |format_handler|
       self.register_handler format_handler.format, format_handler

--- a/src/components/mercure/spec/token_factory/jwt_spec.cr
+++ b/src/components/mercure/spec/token_factory/jwt_spec.cr
@@ -8,7 +8,7 @@ struct JWTTest < ASPEC::TestCase
     subscribe : Array(String)?,
     publish : Array(String)?,
     additional_claims : Hash?,
-    expected_jwt : String
+    expected_jwt : String,
   ) : Nil
     AMC::TokenFactory::JWT
       .new(secret, algorithm, jwt_lifetime: nil)

--- a/src/components/mercure/spec/token_provider/callable_spec.cr
+++ b/src/components/mercure/spec/token_provider/callable_spec.cr
@@ -10,6 +10,6 @@ describe AMC::TokenProvider::Callable do
   end
 
   it "proc overload" do
-    AMC::TokenProvider::Callable.new(->{ "BAR" }).jwt.should eq "BAR"
+    AMC::TokenProvider::Callable.new(-> { "BAR" }).jwt.should eq "BAR"
   end
 end

--- a/src/components/mercure/src/authorization.cr
+++ b/src/components/mercure/src/authorization.cr
@@ -4,7 +4,7 @@ class Athena::Mercure::Authorization
   def initialize(
     @hub_registry : AMC::Hub::Registry,
     @cookie_lifetime : Time::Span = 1.hour,
-    @cookie_samesite : HTTP::Cookie::SameSite = :strict
+    @cookie_samesite : HTTP::Cookie::SameSite = :strict,
   ); end
 
   def set_cookie(
@@ -13,7 +13,7 @@ class Athena::Mercure::Authorization
     subscribe : Array(String)? = [] of String,
     publish : Array(String)? = [] of String,
     additional_claims : Hash? = nil,
-    hub_name : String? = nil
+    hub_name : String? = nil,
   )
     self.update_cookies request, response, hub_name, self.create_cookie(request, subscribe, publish, additional_claims, hub_name)
   end
@@ -21,7 +21,7 @@ class Athena::Mercure::Authorization
   def clear_cookie(
     request : HTTP::Request,
     response : HTTP::Server::Response,
-    hub_name : String? = nil
+    hub_name : String? = nil,
   ) : Nil
     self.update_cookies request, response, hub_name, self.create_clear_cookie(request, hub_name)
   end
@@ -31,7 +31,7 @@ class Athena::Mercure::Authorization
     subscribe : Array(String)? = [] of String,
     publish : Array(String)? = [] of String,
     additional_claims : Hash? = nil,
-    hub_name : String? = nil
+    hub_name : String? = nil,
   ) : HTTP::Cookie
     hub = @hub_registry.hub hub_name
     unless token_factory = hub.token_factory
@@ -111,7 +111,7 @@ class Athena::Mercure::Authorization
     request : HTTP::Request,
     response : HTTP::Server::Response,
     hub_name : String?,
-    cookie : HTTP::Cookie
+    cookie : HTTP::Cookie,
   ) : Nil
     unless response.cookies[COOKIE_NAME]?.nil?
       raise AMC::Exception::Runtime.new "The 'mercureAuthorization' cookie for the '#{hub_name ? "#{hub_name} hub" : "default hub"}' has already been set. You cannot set it two times during the same request."

--- a/src/components/mercure/src/discovery.cr
+++ b/src/components/mercure/src/discovery.cr
@@ -1,6 +1,6 @@
 class Athena::Mercure::Discovery
   def initialize(
-    @hub_registry : AMC::Hub::Registry
+    @hub_registry : AMC::Hub::Registry,
   ); end
 
   def add_link(request : HTTP::Request, response : HTTP::Server::Response, hub_name : String? = nil) : Nil

--- a/src/components/mercure/src/hub/hub.cr
+++ b/src/components/mercure/src/hub/hub.cr
@@ -15,7 +15,7 @@ class Athena::Mercure::Hub
     @token_provider : AMC::TokenProvider::Interface,
     @public_url : String? = nil,
     @token_factory : AMC::TokenFactory::Interface? = nil,
-    http_client : HTTP::Client? = nil
+    http_client : HTTP::Client? = nil,
   )
     @uri = URI.parse url
     @http_client = http_client || HTTP::Client.new @uri

--- a/src/components/mercure/src/hub/registry.cr
+++ b/src/components/mercure/src/hub/registry.cr
@@ -3,7 +3,7 @@ class Athena::Mercure::Hub::Registry
 
   def initialize(
     @default_hub : AMC::Hub::Interface,
-    @hubs : Hash(String, AMC::Hub::Interface) = {} of String => AMC::Hub::Interface
+    @hubs : Hash(String, AMC::Hub::Interface) = {} of String => AMC::Hub::Interface,
   ); end
 
   def hub(name : String? = nil) : AMC::Hub::Interface

--- a/src/components/mercure/src/spec.cr
+++ b/src/components/mercure/src/spec.cr
@@ -35,7 +35,7 @@ module Athena::Mercure::Spec
       @token : String,
       @subscribe : Array(String)? = [] of String,
       @publish : Array(String)? = [] of String,
-      @additional_claims : Hash(String, String) = {} of String => String
+      @additional_claims : Hash(String, String) = {} of String => String,
     )
     end
 

--- a/src/components/mercure/src/token_factory/interface.cr
+++ b/src/components/mercure/src/token_factory/interface.cr
@@ -2,6 +2,6 @@ module Athena::Mercure::TokenFactory::Interface
   abstract def create(
     subscribe : Array(String)? = [] of String,
     publish : Array(String)? = [] of String,
-    additional_claims : Hash? = nil
+    additional_claims : Hash? = nil,
   ) : String
 end

--- a/src/components/mercure/src/token_factory/jwt.cr
+++ b/src/components/mercure/src/token_factory/jwt.cr
@@ -38,7 +38,7 @@ struct Athena::Mercure::TokenFactory::JWT
     @jwt_secret : String,
     @algorithm : ::JWT::Algorithm = :hs256,
     jwt_lifetime : Int32 | Time::Span | Nil = 3600,
-    @passphrase : String = ""
+    @passphrase : String = "",
   )
     @jwt_lifetime = jwt_lifetime.is_a?(Int32) ? jwt_lifetime.seconds : jwt_lifetime
   end
@@ -46,7 +46,7 @@ struct Athena::Mercure::TokenFactory::JWT
   def create(
     subscribe : Array(String)? = [] of String,
     publish : Array(String)? = [] of String,
-    additional_claims : Hash? = nil
+    additional_claims : Hash? = nil,
   ) : String
     ::JWT.encode(
       Payload.new(MercurePayload.new(subscribe, publish), @jwt_lifetime, additional_claims),

--- a/src/components/mercure/src/token_provider/factory.cr
+++ b/src/components/mercure/src/token_provider/factory.cr
@@ -6,7 +6,7 @@ struct Athena::Mercure::TokenProvider::Factory
   def initialize(
     @factory : AMC::TokenFactory::Interface,
     @subscribe : Array(String) = ["*"],
-    @publish : Array(String) = ["*"]
+    @publish : Array(String) = ["*"],
   ); end
 
   def jwt : String

--- a/src/components/mercure/src/update.cr
+++ b/src/components/mercure/src/update.cr
@@ -12,7 +12,7 @@ struct Athena::Mercure::Update
     @private : Bool = false,
     @id : String? = nil,
     @type : String? = nil,
-    @retry : Int32? = nil
+    @retry : Int32? = nil,
   )
     @topics = topics.is_a?(String) ? [topics] : topics
   end

--- a/src/components/routing/spec/route_compiler_spec.cr
+++ b/src/components/routing/spec/route_compiler_spec.cr
@@ -229,7 +229,7 @@ struct RouteCompilerTest < ASPEC::TestCase
     tokens : Array(ART::CompiledRoute::Token),
     host_regex : Regex,
     host_variables : Set(String),
-    host_tokens : Array(ART::CompiledRoute::Token)
+    host_tokens : Array(ART::CompiledRoute::Token),
   ) : Nil
     compiled_route = route.compile
     compiled_route.static_prefix.should eq prefix

--- a/src/components/routing/src/compiled_route.cr
+++ b/src/components/routing/src/compiled_route.cr
@@ -31,7 +31,7 @@ struct Athena::Routing::CompiledRoute
       @prefix : String,
       @regex : Regex? = nil,
       @var_name : String? = nil,
-      @important : Bool = false
+      @important : Bool = false,
     )
     end
 
@@ -71,7 +71,7 @@ struct Athena::Routing::CompiledRoute
     @host_regex : Regex? = nil,
     @host_tokens : Array(ART::CompiledRoute::Token) = Array(ART::CompiledRoute::Token).new,
     @host_variables : Set(String) = Set(String).new,
-    @variables : Set(String) = Set(String).new
+    @variables : Set(String) = Set(String).new,
   )
   end
 

--- a/src/components/routing/src/ext/regex.cr
+++ b/src/components/routing/src/ext/regex.cr
@@ -23,7 +23,7 @@ module Regex::PCRE2
       @pos : Int32,
       @ovector : LibC::SizeT*,
       @group_size : Int32,
-      @mark : String?
+      @mark : String?,
     )
     end
   end

--- a/src/components/routing/src/generator/url_generator.cr
+++ b/src/components/routing/src/generator/url_generator.cr
@@ -51,7 +51,7 @@ class Athena::Routing::Generator::URLGenerator
 
   def initialize(
     @context : ART::RequestContext,
-    @default_locale : String? = nil
+    @default_locale : String? = nil,
   )
   end
 
@@ -106,7 +106,7 @@ class Athena::Routing::Generator::URLGenerator
     name : String,
     reference_type : ART::Generator::ReferenceType,
     host_tokens : Array(ART::CompiledRoute::Token),
-    required_schemes : Set(String)?
+    required_schemes : Set(String)?,
   ) : String
     merged_params = Hash(String, String?).new
     merged_params.merge! defaults

--- a/src/components/routing/src/matcher/traceable_url_matcher.cr
+++ b/src/components/routing/src/matcher/traceable_url_matcher.cr
@@ -22,7 +22,7 @@ class Athena::Routing::Matcher::TraceableURLMatcher < Athena::Routing::Matcher::
 
   def initialize(
     @routes : ART::RouteCollection,
-    context : ART::RequestContext
+    context : ART::RequestContext,
   )
     super context
   end

--- a/src/components/routing/src/request_context.cr
+++ b/src/components/routing/src/request_context.cr
@@ -53,7 +53,7 @@ class Athena::Routing::RequestContext
     @http_port : Int32 = 80,
     @https_port : Int32 = 443,
     @path : String = "/",
-    @query_string : String = ""
+    @query_string : String = "",
   )
     self.method = @method
     self.host = @host

--- a/src/components/routing/src/route.cr
+++ b/src/components/routing/src/route.cr
@@ -215,7 +215,7 @@ class Athena::Routing::Route
     host : String | Regex | Nil = nil,
     methods : String | Enumerable(String) | Nil = nil,
     schemes : String | Enumerable(String) | Nil = nil,
-    @condition : ART::Route::Condition? = nil
+    @condition : ART::Route::Condition? = nil,
   )
     self.path = @path
     self.add_defaults defaults

--- a/src/components/routing/src/router.cr
+++ b/src/components/routing/src/router.cr
@@ -27,7 +27,7 @@ class Athena::Routing::Router
     @route_collection : ART::RouteCollection,
     @default_locale : String? = nil,
     @strict_requirements : Bool? = true,
-    context : ART::RequestContext? = nil
+    context : ART::RequestContext? = nil,
   )
     @context = context || ART::RequestContext.new
   end

--- a/src/components/routing/src/routing_handler.cr
+++ b/src/components/routing/src/routing_handler.cr
@@ -74,7 +74,7 @@ class Athena::Routing::RoutingHandler
   def initialize(
     matcher : ART::Matcher::URLMatcherInterface? = nil,
     @collection : ART::RouteCollection = ART::RouteCollection.new,
-    @bubble_exceptions : Bool = false
+    @bubble_exceptions : Bool = false,
   )
     @matcher = matcher || ART::Matcher::URLMatcher.new ART::RequestContext.new
   end

--- a/src/components/serializer/spec/spec_helper.cr
+++ b/src/components/serializer/spec/spec_helper.cr
@@ -138,7 +138,7 @@ def create_metadata(
   groups : Array(String) = ["default"],
   since_version : String? = nil,
   until_version : String? = nil,
-  annotation_configurations : ADI::AnnotationConfigurations = ADI::AnnotationConfigurations.new
+  annotation_configurations : ADI::AnnotationConfigurations = ADI::AnnotationConfigurations.new,
 ) : ASR::PropertyMetadata forall I
   context = ASR::PropertyMetadata(I, I, EmptyObject).new name, external_name, annotation_configurations, value, skip_when_empty, groups
 

--- a/src/components/serializer/src/navigators/deserialization_navigator.cr
+++ b/src/components/serializer/src/navigators/deserialization_navigator.cr
@@ -8,7 +8,7 @@ struct Athena::Serializer::Navigators::DeserializationNavigator
   def initialize(
     @visitor : ASR::Visitors::DeserializationVisitorInterface,
     @context : ASR::DeserializationContext,
-    @object_constructor : ASR::ObjectConstructorInterface
+    @object_constructor : ASR::ObjectConstructorInterface,
   ); end
 
   def accept(type : T.class, data : ASR::Any) forall T

--- a/src/components/serializer/src/property_metadata.cr
+++ b/src/components/serializer/src/property_metadata.cr
@@ -65,7 +65,7 @@ struct Athena::Serializer::PropertyMetadata(IvarType, ValueType, ClassType)
     @since_version : SemanticVersion? = nil,
     @until_version : SemanticVersion? = nil,
     @type : IvarType.class = IvarType,
-    @class : ClassType.class = ClassType
+    @class : ClassType.class = ClassType,
   )
     @groups = groups.to_set
   end

--- a/src/components/validator/spec/constraints/composite_spec.cr
+++ b/src/components/validator/spec/constraints/composite_spec.cr
@@ -2,7 +2,7 @@ private class ConcreteComposite < AVD::Constraints::Composite
   def initialize(
     constraints : Array(AVD::Constraint) | AVD::Constraint = [] of AVD::Constraint,
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super constraints, "", groups, payload
   end

--- a/src/components/validator/src/constraint.cr
+++ b/src/components/validator/src/constraint.cr
@@ -209,7 +209,7 @@
 #   def initialize(
 #     message : String = "This value should contain only alphanumeric characters.",
 #     groups : Array(String) | String | Nil = nil,
-#     payload : Hash(String, String)? = nil
+#     payload : Hash(String, String)? = nil,
 #   )
 #     super message, groups, payload
 #   end

--- a/src/components/validator/src/constraints/abstract_comparison.cr
+++ b/src/components/validator/src/constraints/abstract_comparison.cr
@@ -10,7 +10,7 @@ module Athena::Validator::Constraints::AbstractComparison(ValueType)
     @value : ValueType,
     message : String = default_error_message,
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/all.cr
+++ b/src/components/validator/src/constraints/all.cr
@@ -53,7 +53,7 @@ class Athena::Validator::Constraints::All < Athena::Validator::Constraints::Comp
   def initialize(
     constraints : AVD::Constraints::Composite::Type,
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super constraints, "", groups, payload
   end

--- a/src/components/validator/src/constraints/at_least_one_of.cr
+++ b/src/components/validator/src/constraints/at_least_one_of.cr
@@ -101,7 +101,7 @@ class Athena::Validator::Constraints::AtLeastOneOf < Athena::Validator::Constrai
     @message_collection : String = "Each element of this collection should satisfy its own set of constraints.",
     message : String = "This value should satisfy at least one of the following constraints:",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super constraints, message, groups, payload
   end

--- a/src/components/validator/src/constraints/blank.cr
+++ b/src/components/validator/src/constraints/blank.cr
@@ -39,7 +39,7 @@ class Athena::Validator::Constraints::Blank < Athena::Validator::Constraint
   def initialize(
     message : String = "This value should be blank.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/callback.cr
+++ b/src/components/validator/src/constraints/callback.cr
@@ -195,7 +195,7 @@ class Athena::Validator::Constraints::Callback < Athena::Validator::Constraint
     @callback : AVD::Constraints::Callback::CallbackProc? = nil,
     @callback_name : String? = nil,
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     raise AVD::Exception::Logic.new "either `callback` or `callback_name` must be provided." if @callback.nil? && @callback_name.nil?
 

--- a/src/components/validator/src/constraints/choice.cr
+++ b/src/components/validator/src/constraints/choice.cr
@@ -127,7 +127,7 @@ class Athena::Validator::Constraints::Choice < Athena::Validator::Constraint
     multiple : Bool = false,
     range : ::Range? = nil,
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     new choices.map(&.as(String | Number::Primitive | Symbol)), message, multiple_message, min_message, max_message, multiple, range.try(&.begin), range.try(&.end), groups, payload
   end
@@ -142,7 +142,7 @@ class Athena::Validator::Constraints::Choice < Athena::Validator::Constraint
     @min : Number::Primitive?,
     @max : Number::Primitive?,
     groups : Array(String) | String | Nil,
-    payload : Hash(String, String)?
+    payload : Hash(String, String)?,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/collection.cr
+++ b/src/components/validator/src/constraints/collection.cr
@@ -162,7 +162,7 @@ class Athena::Validator::Constraints::Collection < Athena::Validator::Constraint
     @extra_fields_message : String = "This field was not expected.",
     @missing_fields_message : String = "This field is missing.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     constraints = Hash(String, AVD::Constraint).new
 

--- a/src/components/validator/src/constraints/composite.cr
+++ b/src/components/validator/src/constraints/composite.cr
@@ -21,7 +21,7 @@ abstract class Athena::Validator::Constraints::Composite < Athena::Validator::Co
     constraints : AVD::Constraints::Composite::Type,
     message : String,
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
 

--- a/src/components/validator/src/constraints/compound.cr
+++ b/src/components/validator/src/constraints/compound.cr
@@ -59,7 +59,7 @@
 abstract class Athena::Validator::Constraints::Compound < Athena::Validator::Constraints::Composite
   def initialize(
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super self.constraints, "", groups, payload
   end

--- a/src/components/validator/src/constraints/email.cr
+++ b/src/components/validator/src/constraints/email.cr
@@ -72,7 +72,7 @@ class Athena::Validator::Constraints::Email < Athena::Validator::Constraint
     @mode : AVD::Constraints::Email::Mode = :html5,
     message : String = "This value is not a valid email address.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/existence.cr
+++ b/src/components/validator/src/constraints/existence.cr
@@ -3,7 +3,7 @@ abstract class Athena::Validator::Constraints::Existence < Athena::Validator::Co
   def initialize(
     constraints : Array(AVD::Constraint) | AVD::Constraint = [] of AVD::Constraint,
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super constraints, "", groups, payload
   end

--- a/src/components/validator/src/constraints/file.cr
+++ b/src/components/validator/src/constraints/file.cr
@@ -172,7 +172,7 @@ class Athena::Validator::Constraints::File < Athena::Validator::Constraint
     @max_size_message : String = "The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.",
     @mime_type_message : String = "The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super "", groups, payload
 

--- a/src/components/validator/src/constraints/image.cr
+++ b/src/components/validator/src/constraints/image.cr
@@ -350,7 +350,7 @@ class Athena::Validator::Constraints::Image < Athena::Validator::Constraints::Fi
     max_size_message : String = "The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.",
     mime_type_message : String = "This file is not a valid image.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super max_size, binary_format, mime_types, not_found_message, not_readable_message, empty_message, max_size_message, mime_type_message, groups, payload
 

--- a/src/components/validator/src/constraints/ip.cr
+++ b/src/components/validator/src/constraints/ip.cr
@@ -67,7 +67,7 @@ class Athena::Validator::Constraints::IP < Athena::Validator::Constraint
     @version : AVD::Constraints::IP::Version = :v4,
     message : String = "This value is not a valid IP address.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/is_false.cr
+++ b/src/components/validator/src/constraints/is_false.cr
@@ -39,7 +39,7 @@ class Athena::Validator::Constraints::IsFalse < Athena::Validator::Constraint
   def initialize(
     message : String = "This value should be false.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/is_nil.cr
+++ b/src/components/validator/src/constraints/is_nil.cr
@@ -39,7 +39,7 @@ class Athena::Validator::Constraints::IsNil < Athena::Validator::Constraint
   def initialize(
     message : String = "This value should be null.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/is_true.cr
+++ b/src/components/validator/src/constraints/is_true.cr
@@ -39,7 +39,7 @@ class Athena::Validator::Constraints::IsTrue < Athena::Validator::Constraint
   def initialize(
     message : String = "This value should be true.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/isbn.cr
+++ b/src/components/validator/src/constraints/isbn.cr
@@ -117,7 +117,7 @@ class Athena::Validator::Constraints::ISBN < Athena::Validator::Constraint
     @both_message : String = "This value is neither a valid ISBN-10 nor a valid ISBN-13.",
     message : String = "",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/isin.cr
+++ b/src/components/validator/src/constraints/isin.cr
@@ -50,7 +50,7 @@ class Athena::Validator::Constraints::ISIN < Athena::Validator::Constraint
   def initialize(
     message : String = "This value is not a valid International Securities Identification Number (ISIN).",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/issn.cr
+++ b/src/components/validator/src/constraints/issn.cr
@@ -72,7 +72,7 @@ class Athena::Validator::Constraints::ISSN < Athena::Validator::Constraint
     @require_hyphen : Bool = false,
     message : String = "This value is not a valid International Standard Serial Number (ISSN).",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/luhn.cr
+++ b/src/components/validator/src/constraints/luhn.cr
@@ -45,7 +45,7 @@ class Athena::Validator::Constraints::Luhn < Athena::Validator::Constraint
   def initialize(
     message : String = "This value is not a valid credit card number.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/negative.cr
+++ b/src/components/validator/src/constraints/negative.cr
@@ -36,7 +36,7 @@ class Athena::Validator::Constraints::Negative < Athena::Validator::Constraints:
   def initialize(
     message : String = "This value should be negative.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super Int32.zero, message, groups, payload
   end

--- a/src/components/validator/src/constraints/negative_or_zero.cr
+++ b/src/components/validator/src/constraints/negative_or_zero.cr
@@ -36,7 +36,7 @@ class Athena::Validator::Constraints::NegativeOrZero < Athena::Validator::Constr
   def initialize(
     message : String = "This value should be negative or zero.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super Int32.zero, message, groups, payload
   end

--- a/src/components/validator/src/constraints/not_blank.cr
+++ b/src/components/validator/src/constraints/not_blank.cr
@@ -48,7 +48,7 @@ class Athena::Validator::Constraints::NotBlank < Athena::Validator::Constraint
     @allow_nil : Bool = false,
     message : String = "This value should not be blank.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/not_nil.cr
+++ b/src/components/validator/src/constraints/not_nil.cr
@@ -42,7 +42,7 @@ class Athena::Validator::Constraints::NotNil < Athena::Validator::Constraint
   def initialize(
     message : String = "This value should not be null.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/positive.cr
+++ b/src/components/validator/src/constraints/positive.cr
@@ -36,7 +36,7 @@ class Athena::Validator::Constraints::Positive < Athena::Validator::Constraints:
   def initialize(
     message : String = "This value should be positive.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super Int32.zero, message, groups, payload
   end

--- a/src/components/validator/src/constraints/positive_or_zero.cr
+++ b/src/components/validator/src/constraints/positive_or_zero.cr
@@ -36,7 +36,7 @@ class Athena::Validator::Constraints::PositiveOrZero < Athena::Validator::Constr
   def initialize(
     message : String = "This value should be positive or zero.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super Int32.zero, message, groups, payload
   end

--- a/src/components/validator/src/constraints/range.cr
+++ b/src/components/validator/src/constraints/range.cr
@@ -91,7 +91,7 @@ class Athena::Validator::Constraints::Range < Athena::Validator::Constraint
     min_message : String = "This value should be {{ limit }} or more.",
     max_message : String = "This value should be {{ limit }} or less.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     range_end = range.end
 
@@ -109,7 +109,7 @@ class Athena::Validator::Constraints::Range < Athena::Validator::Constraint
     @min_message : String,
     @max_message : String,
     groups : Array(String) | String | Nil,
-    payload : Hash(String, String)?
+    payload : Hash(String, String)?,
   )
     super "", groups, payload
   end

--- a/src/components/validator/src/constraints/regex.cr
+++ b/src/components/validator/src/constraints/regex.cr
@@ -63,7 +63,7 @@ class Athena::Validator::Constraints::Regex < Athena::Validator::Constraint
     @match : Bool = true,
     message : String = "This value should match '{{ pattern }}'.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/sequentially.cr
+++ b/src/components/validator/src/constraints/sequentially.cr
@@ -67,7 +67,7 @@ class Athena::Validator::Constraints::Sequentially < Athena::Validator::Constrai
   def initialize(
     constraints : AVD::Constraints::Composite::Type,
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super constraints, "", groups, payload
   end

--- a/src/components/validator/src/constraints/size.cr
+++ b/src/components/validator/src/constraints/size.cr
@@ -94,7 +94,7 @@ class Athena::Validator::Constraints::Size < Athena::Validator::Constraint
     max_message : String = "This value is too long. It should have {{ limit }} {{ type }} or less.|This value is too long. It should have {{ limit }} {{ type }}s or less.",
     exact_message : String = "This value should have exactly {{ limit }} {{ type }}.|This value should have exactly {{ limit }} {{ type }}s.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     new range.begin, range.end, min_message, max_message, exact_message, groups, payload
   end
@@ -106,7 +106,7 @@ class Athena::Validator::Constraints::Size < Athena::Validator::Constraint
     @max_message : String = "This value is too long. It should have {{ limit }} {{ type }} or less.|This value is too long. It should have {{ limit }} {{ type }}s or less.",
     @exact_message : String = "This value should have exactly {{ limit }} {{ type }}.|This value should have exactly {{ limit }} {{ type }}s.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super "", groups, payload
   end

--- a/src/components/validator/src/constraints/unique.cr
+++ b/src/components/validator/src/constraints/unique.cr
@@ -39,7 +39,7 @@ class Athena::Validator::Constraints::Unique < Athena::Validator::Constraint
   def initialize(
     message : String = "This collection should contain only unique elements.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/url.cr
+++ b/src/components/validator/src/constraints/url.cr
@@ -60,7 +60,7 @@ class Athena::Validator::Constraints::URL < Athena::Validator::Constraint
     @relative_protocol : Bool = false,
     message : String = "This value is not a valid URL.",
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super message, groups, payload
   end

--- a/src/components/validator/src/constraints/valid.cr
+++ b/src/components/validator/src/constraints/valid.cr
@@ -56,7 +56,7 @@ class Athena::Validator::Constraints::Valid < Athena::Validator::Constraint
   def initialize(
     @traverse : Bool = true,
     groups : Array(String) | String | Nil = nil,
-    payload : Hash(String, String)? = nil
+    payload : Hash(String, String)? = nil,
   )
     super "", groups, payload
   end

--- a/src/components/validator/src/spec.cr
+++ b/src/components/validator/src/spec.cr
@@ -144,7 +144,7 @@ module Athena::Validator::Spec
     protected property! contextual_validator : AVD::Validator::ContextualValidatorInterface?
 
     def self.new(violations : AVD::Violation::ConstraintViolationListInterface = AVD::Violation::ConstraintViolationList.new) : self
-      new &->{ violations.as AVD::Violation::ConstraintViolationListInterface }
+      new &-> { violations.as AVD::Violation::ConstraintViolationListInterface }
     end
 
     def initialize(
@@ -205,7 +205,7 @@ module Athena::Validator::Spec
     def initialize(
       message : String = "Failed",
       groups : Array(String) | String | Nil = nil,
-      payload : Hash(String, String)? = nil
+      payload : Hash(String, String)? = nil,
     )
       super message, groups, payload
     end

--- a/src/components/validator/src/spec/constraint_validator_test_case.cr
+++ b/src/components/validator/src/spec/constraint_validator_test_case.cr
@@ -311,7 +311,7 @@ abstract struct Athena::Validator::Spec::ConstraintValidatorTestCase < ASPEC::Te
     property_path : String,
     value : _,
     constraints : Array(AVD::Constraint) | AVD::Constraint,
-    groups : Array(String) | String | AVD::Constraints::GroupSequence | Nil = nil
+    groups : Array(String) | String | AVD::Constraints::GroupSequence | Nil = nil,
   )
     raise "BUG: Null context" unless c = @context
 

--- a/src/components/validator/src/validator/recursive_contextual_validator.cr
+++ b/src/components/validator/src/validator/recursive_contextual_validator.cr
@@ -12,7 +12,7 @@ class Athena::Validator::Validator::RecursiveContextualValidator
   def initialize(
     @context : AVD::ExecutionContextInterface,
     @constraint_validator_factory : AVD::ConstraintValidatorFactoryInterface,
-    @metadata_factory : AVD::Metadata::MetadataFactoryInterface
+    @metadata_factory : AVD::Metadata::MetadataFactoryInterface,
   )
     @default_groups = [(g = @context.group) ? g : Constraint::DEFAULT_GROUP]
     @default_property_path = @context.property_path
@@ -170,7 +170,7 @@ class Athena::Validator::Validator::RecursiveContextualValidator
     collection : Iterable,
     property_path : String,
     groups : GroupsTypes,
-    context : AVD::ExecutionContextInterface
+    context : AVD::ExecutionContextInterface,
   )
     collection.each_with_index do |item, idx|
       case item
@@ -184,7 +184,7 @@ class Athena::Validator::Validator::RecursiveContextualValidator
     collection : Hash,
     property_path : String,
     groups : GroupsTypes,
-    context : AVD::ExecutionContextInterface
+    context : AVD::ExecutionContextInterface,
   )
     collection.each do |key, value|
       case value
@@ -201,7 +201,7 @@ class Athena::Validator::Validator::RecursiveContextualValidator
     property_path : String,
     groups : GroupsTypes,
     cascaded_groups : Array(String)?,
-    context : AVD::ExecutionContextInterface
+    context : AVD::ExecutionContextInterface,
   )
     context.set_node value, object, metadata, property_path
 
@@ -267,7 +267,7 @@ class Athena::Validator::Validator::RecursiveContextualValidator
     property_path : String,
     groups : GroupsTypes,
     cascaded_groups : Array(String)?,
-    context : AVD::ExecutionContextInterface
+    context : AVD::ExecutionContextInterface,
   ) : Nil
     context.set_node object, object, class_metadata, property_path
 
@@ -347,7 +347,7 @@ class Athena::Validator::Validator::RecursiveContextualValidator
     property_path : String,
     group_sequence : AVD::Constraints::GroupSequence,
     cascaded_groups : String?,
-    context : AVD::ExecutionContextInterface
+    context : AVD::ExecutionContextInterface,
   ) : Nil
     violation_count = context.violations.size
     cascaded_groups = cascaded_groups ? [cascaded_groups] : nil

--- a/src/components/validator/src/violation/constraint_violation.cr
+++ b/src/components/validator/src/violation/constraint_violation.cr
@@ -41,7 +41,7 @@ struct Athena::Validator::Violation::ConstraintViolation
     @plural : Int32? = nil,
     @code : String? = nil,
     @constraint : AVD::Constraint? = nil,
-    @cause : String? = nil
+    @cause : String? = nil,
   )
     @root_container = root.is_a?(AVD::Container) ? root : AVD::ValueContainer.new(root)
   end

--- a/src/components/validator/src/violation/constraint_violation_builder.cr
+++ b/src/components/validator/src/violation/constraint_violation_builder.cr
@@ -14,7 +14,7 @@ class Athena::Validator::Violation::ConstraintViolationBuilder
     @parameters : Hash(String, String),
     @root_container : AVD::Container,
     @property_path : String,
-    @invalid_value : AVD::Container
+    @invalid_value : AVD::Container,
   )
   end
 


### PR DESCRIPTION
## Context

https://github.com/crystal-lang/crystal/pull/14718 was recently merged which enables the new formatting rules in nightlies in preparation for Crystal 1.15. This PR applies these new formatting requirements, which are backwards compatible due to https://github.com/crystal-lang/crystal/pull/14726.

## Changelog

* Apply new formatting requirements in preparation for Crystal 1.15

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
