### PR TITLE
Generate missed lines via `unreachable` tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install kcov
-        if: matrix.crystal == 'latest'
+        if: matrix.crystal == 'nightly'
         run: |
           sudo apt-get update &&
           sudo apt-get install binutils-dev libssl-dev libcurl4-openssl-dev libelf-dev libstdc++-12-dev zlib1g-dev libdw-dev libiberty-dev
@@ -82,19 +82,21 @@ jobs:
         run: ./scripts/test.sh all compiled
         shell: bash
       - uses: codecov/codecov-action@v4
-        if: matrix.crystal == 'latest' && github.event_name == 'pull_request' # Only want to upload coverage report once in the matrix
+        if: matrix.crystal == 'nightly' && github.event_name == 'pull_request' # Only want to upload coverage report once in the matrix
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          files: ./coverage/**/cov.xml
+          directory: coverage
+          files: '**/cov.xml' # There is no `unreachable.codecov.json` file when running _only_ compiled specs
           flags: compiled
           verbose: true
       - uses: codecov/test-results-action@v1
-        if: matrix.crystal == 'latest' && github.event_name == 'pull_request' # Only want to upload coverage report once in the matrix
+        if: matrix.crystal == 'nightly' && github.event_name == 'pull_request' # Only want to upload coverage report once in the matrix
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          files: ./coverage/**/junit.xml
+          directory: coverage
+          files: '**/junit.xml'
           flags: compiled
           verbose: true
   test_unit:
@@ -117,7 +119,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install kcov
-        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'nightly'
         run: |
           sudo apt-get update &&
           sudo apt-get install binutils-dev libssl-dev libcurl4-openssl-dev libelf-dev libstdc++-12-dev zlib1g-dev libdw-dev libiberty-dev
@@ -142,18 +144,20 @@ jobs:
         run: ./scripts/test.sh all unit
         shell: bash
       - uses: codecov/codecov-action@v4
-        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest' && github.event_name == 'pull_request' # Only want to upload coverage report once in the matrix
+        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'nightly' && github.event_name == 'pull_request' # Only want to upload coverage report once in the matrix
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          files: ./coverage/**/cov.xml
+          directory: coverage
+          files: '**/cov.xml,**/unreachable.codecov.json'
           flags: unit
           verbose: true
       - uses: codecov/test-results-action@v1
-        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest' && github.event_name == 'pull_request' # Only want to upload coverage report once in the matrix
+        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'nightly' && github.event_name == 'pull_request' # Only want to upload coverage report once in the matrix
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          files: ./coverage/**/junit.xml
+          directory: coverage
+          files: '**/junit.xml'
           flags: unit
           verbose: true

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -13,8 +13,15 @@ function runSpecsWithCoverage()
 {
   mkdir -p coverage/bin
   echo "require \"../../src/components/$1/spec/**\"" > "./coverage/bin/$1.cr" && \
-  crystal build "${DEFAULT_BUILD_OPTIONS[@]}" "./coverage/bin/$1.cr" -o "./coverage/bin/$1" && \
+  $CRYSTAL build "${DEFAULT_BUILD_OPTIONS[@]}" "./coverage/bin/$1.cr" -o "./coverage/bin/$1" && \
   kcov $(if $IS_CI != "true"; then echo "--cobertura-only"; fi) --clean --include-path="./src/components/$1/src" "./coverage/$1" "./coverage/bin/$1" --junit_output="./coverage/$1/junit.xml" "${DEFAULT_OPTIONS[@]}" || EXIT_CODE=1
+
+  # We're using nightly Crystal to have access to this for now.
+  # When Crystal 1.15 releases, make this no longer scoped to $IS_CI as local `crystal` will also have it.
+  if [ $IS_CI = "true" ] && [ $TYPE != "compiled" ]
+  then
+    $CRYSTAL tool unreachable --format=codecov "./coverage/bin/$1.cr" > "./coverage/$1/unreachable.codecov.json"
+  fi
 }
 
 DEFAULT_BUILD_OPTIONS=(-Dstrict_multi_assign -Dpreview_overload_order --error-on-warnings)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,7 +14,7 @@ function runSpecsWithCoverage()
   mkdir -p coverage/bin
   echo "require \"../../src/components/$1/spec/**\"" > "./coverage/bin/$1.cr" && \
   $CRYSTAL build "${DEFAULT_BUILD_OPTIONS[@]}" "./coverage/bin/$1.cr" -o "./coverage/bin/$1" && \
-  kcov $(if $IS_CI != "true"; then echo "--cobertura-only"; fi) --clean --include-path="./src/components/$1/src" "./coverage/$1" "./coverage/bin/$1" --junit_output="./coverage/$1/junit.xml" "${DEFAULT_OPTIONS[@]}" || EXIT_CODE=1
+  kcov $(if $IS_CI != "true"; then echo "--cobertura-only"; fi) --clean --include-path="./src/components/$1/src" "./coverage/$1" "./coverage/bin/$1" --junit_output="./coverage/$1/junit.xml" "${DEFAULT_OPTIONS[@]}"
 
   # We're using nightly Crystal to have access to this for now.
   # When Crystal 1.15 releases, make this no longer scoped to $IS_CI as local `crystal` will also have it.
@@ -57,9 +57,9 @@ if [ $COMPONENT != "all" ]
 then
   if [ $HAS_KCOV = "true" ]
   then
-    runSpecsWithCoverage $COMPONENT
+    runSpecsWithCoverage $COMPONENT || EXIT_CODE=1
   else
-    runSpecs $COMPONENT
+    runSpecs $COMPONENT || EXIT_CODE=1
   fi
   exit $?
 fi
@@ -71,7 +71,7 @@ for component in $(find src/components/ -maxdepth 2 -type f -name shard.yml | xa
   then
     runSpecsWithCoverage $component || EXIT_CODE=1
   else
-    runSpecs $component
+    runSpecs $component || EXIT_CODE=1
   fi
 
   echo "::endgroup::"


### PR DESCRIPTION
## Context

With https://github.com/crystal-lang/crystal/pull/15059 now merged, let's try and take advantage of it by running/generating coverage reports via Crystal nightlies. This PR generated a new `unreachable.codecov.json` file as part of `./scripts/test.sh`. This should properly flag missed lines that otherwise would have went un-reported since they would not be in the binary at all.

This PR will result in a net decline to total coverage. This is expected as before it was artificially high due to not including dead code. Will probably want to use this data to create some follow up PRs to improve coverage where possible/it makes sense.

## Changelog

* Generate report of missed lines via `unreachable` tool
* Generate coverage reports via Crystal nightlies

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
