### PR TITLE
Properly tag some DI specs

### DIFF
--- a/src/components/dependency_injection/spec/compiler_passes/auto_wire_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/auto_wire_spec.cr
@@ -34,7 +34,7 @@ end
 record SameInstanceClient, a : SameInstancePrimary, b : SameInstanceAliasInterface
 
 describe ADI::ServiceContainer do
-  describe "compiler errors" do
+  describe "compiler errors", tags: "compiled" do
     it "does not resolve an un-aliased interface when there is only 1 implementation" do
       assert_error "Failed to resolve value for parameter 'a : SomeInterface' of service 'bar' (Bar).", <<-CR
         module SomeInterface; end

--- a/src/components/dependency_injection/spec/extension_spec.cr
+++ b/src/components/dependency_injection/spec/extension_spec.cr
@@ -16,7 +16,7 @@ private def assert_error(message : String, code : String, *, line : Int32 = __LI
   CR
 end
 
-describe ADI::Extension do
+describe ADI::Extension, tags: "compiled" do
   it "happy path" do
     assert_success <<-CR
       module Schema


### PR DESCRIPTION
## Context

This PR properly adds the `compiled` tag to some DI related specs. Noticed this in CI where unit tests for the DI component were taking >30s.

## Changelog

* Properly tag some DI specs

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
