### PR TITLE
Fix conflicting `image_size` test case method names

### DIFF
--- a/src/components/image_size/spec/athena-image_size_spec.cr
+++ b/src/components/image_size/spec/athena-image_size_spec.cr
@@ -64,7 +64,7 @@ struct ImageTest < ASPEC::TestCase
     tempfile.delete
   end
 
-  def test_from_io_parse_failure_nil : Nil
+  def test_from_io_parse_failure_raises : Nil
     tempfile = File.tempfile
     tempfile.write_byte 0x00
     tempfile.write_byte 0x00
@@ -127,18 +127,6 @@ struct ImageTest < ASPEC::TestCase
     tempfile.delete
   end
 
-  def test_from_file_path_unsupported_raises : Nil
-    tempfile = File.tempfile
-    tempfile.write Bytes.new 50, 0
-    tempfile.rewind
-
-    expect_raises Exception, "Unsupported image format." do
-      AIS::Image.from_file_path tempfile.path
-    end
-
-    tempfile.delete
-  end
-
   def test_from_file_path_parse_failure_nil : Nil
     tempfile = File.tempfile
     tempfile.write_byte 0x00
@@ -157,7 +145,7 @@ struct ImageTest < ASPEC::TestCase
     tempfile.delete
   end
 
-  def test_from_file_path_parse_failure_nil : Nil
+  def test_from_file_path_parse_failure_raises : Nil
     tempfile = File.tempfile
     tempfile.write_byte 0x00
     tempfile.write_byte 0x00


### PR DESCRIPTION
## Context

Noticed via https://app.codecov.io/gh/athena-framework/athena/pull/458/blob/src/components/image_size/spec/athena-image_size_spec.cr that some `image_size` spec test cases were conflicting, thus leading to some tests that were not running. This PR resolves that.

## Changelog

* Fix conflicting `image_size` test case method names

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
