### PR TITLE
Reduce usages of `codegen: true` in specs

### DIFF
--- a/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
@@ -12,7 +12,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
   describe "compiler errors" do
     describe "root level" do
       it "errors if a required configuration value has not been provided" do
-        assert_error "Required configuration property 'test.id : Int32' must be provided.", <<-CR
+        assert_error "Required configuration property 'test.id : Int32' must be provided.", <<-'CR'
           module Schema
             include ADI::Extension::Schema
 
@@ -31,7 +31,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
       end
 
       it "errors if there is a collection type mismatch" do
-        assert_error "Expected configuration value 'test.foo' to be a 'Array(Int32)', but got 'Array(String)'.", <<-CR
+        assert_error "Expected configuration value 'test.foo' to be a 'Array(Int32)', but got 'Array(String)'.", <<-'CR'
           module Schema
             include ADI::Extension::Schema
 
@@ -49,7 +49,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
       end
 
       it "errors if there is a type mismatch within an array" do
-        assert_error "Expected configuration value 'test.foo[0]' to be a 'Int32', but got 'UInt64'.", <<-CR
+        assert_error "Expected configuration value 'test.foo[0]' to be a 'Int32', but got 'UInt64'.", <<-'CR'
           module Schema
             include ADI::Extension::Schema
 
@@ -67,7 +67,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
       end
 
       it "errors if a configuration value not found in the schema is encountered" do
-        assert_error "Encountered unexpected property 'test.name' with value '\"Fred\"'.", <<-CR
+        assert_error "Encountered unexpected property 'test.name' with value '\"Fred\"'.", <<-'CR'
           module Schema
             include ADI::Extension::Schema
 
@@ -88,7 +88,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
 
     describe "nested level" do
       it "errors if a configuration value has the incorrect type" do
-        assert_error "Required configuration property 'test.sub_config.defaults.id : Int32' must be provided.", <<-CR
+        assert_error "Required configuration property 'test.sub_config.defaults.id : Int32' must be provided.", <<-'CR'
           module Schema
             include ADI::Extension::Schema
 
@@ -119,7 +119,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
       end
 
       it "errors if there is a collection type mismatch" do
-        assert_error "Expected configuration value 'test.sub_config.defaults.foo' to be a 'Array(Int32)', but got 'Array(String)'.", <<-CR
+        assert_error "Expected configuration value 'test.sub_config.defaults.foo' to be a 'Array(Int32)', but got 'Array(String)'.", <<-'CR'
           module Schema
             include ADI::Extension::Schema
 
@@ -149,7 +149,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
       end
 
       it "errors if there is a type mismatch within an array" do
-        assert_error "Expected configuration value 'test.sub_config.defaults.foo[1]' to be a 'Int32', but got 'UInt64'.", <<-CR
+        assert_error "Expected configuration value 'test.sub_config.defaults.foo[1]' to be a 'Int32', but got 'UInt64'.", <<-'CR'
           module Schema
             include ADI::Extension::Schema
 
@@ -179,7 +179,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
       end
 
       it "errors if there is a type mismatch within an array without type hint" do
-        assert_error "Expected configuration value 'test.sub_config.defaults.foo[1]' to be a 'Int32', but got 'UInt64'.", <<-CR
+        assert_error "Expected configuration value 'test.sub_config.defaults.foo[1]' to be a 'Int32', but got 'UInt64'.", <<-'CR'
           module Schema
             include ADI::Extension::Schema
 
@@ -209,7 +209,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
       end
 
       it "errors if there is a type mismatch within an array using NoReturn schema default" do
-        assert_error "Expected configuration value 'test.sub_config.defaults.foo[1]' to be a 'Int32', but got 'UInt64'.", <<-CR
+        assert_error "Expected configuration value 'test.sub_config.defaults.foo[1]' to be a 'Int32', but got 'UInt64'.", <<-'CR'
           module Schema
             include ADI::Extension::Schema
 
@@ -239,7 +239,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
       end
 
       it "errors if a configuration value not found in the schema is encountered" do
-        assert_error "Encountered unexpected property 'test.sub_config.defaults.name' with value '\"Fred\"'.", <<-CR
+        assert_error "Encountered unexpected property 'test.sub_config.defaults.name' with value '\"Fred\"'.", <<-'CR'
           module Schema
             include ADI::Extension::Schema
 
@@ -271,7 +271,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
     end
 
     it "errors if a configuration value has the incorrect type" do
-      assert_error "Extension 'foo' is configured, but no extension with that name has been registered.", <<-CR
+      assert_error "Extension 'foo' is configured, but no extension with that name has been registered.", <<-'CR'
         ADI.configure({
           foo: {
             id: 1
@@ -281,7 +281,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
     end
 
     it "errors if nothing is configured, but a property is required" do
-      assert_error "Required configuration property 'test.id : Int32' must be provided.", <<-CR
+      assert_error "Required configuration property 'test.id : Int32' must be provided.", <<-'CR'
         require "../spec_helper"
 
         module Schema
@@ -296,7 +296,7 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
   end
 
   it "extension configuration value resolution" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper"
 
       enum Color
@@ -335,22 +335,26 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::CONFIG["blah"]["id"]}}.should eq 123 }
-          it { \\{{ADI::CONFIG["blah"]["name"]}}.should eq "fred" }
-          it { \\{{ADI::CONFIG["blah"]["float"]}}.should eq 10 }
-          it { \\{{ADI::CONFIG["blah"]["nilable"]}}.should be_nil }
-          it { \\{{ADI::CONFIG["blah"]["color_type"]}}.should eq Color::Red }
-          it { \\{{ADI::CONFIG["blah"]["color_sym"]}}.should eq Color::Blue }
-          it { \\{{ADI::CONFIG["blah"]["color_default"]}}.should eq Color::Green }
-          it { \\{{ADI::CONFIG["blah"]["value"]}}.should eq({"id" => "10", "name" => "fred"}) }
-          it { \\{{ADI::CONFIG["blah"]["regex"]}}.should eq /foo/ }
+          \{%
+            config = ADI::CONFIG["blah"]
+
+            raise "#{config}" unless config["id"] == 123
+            raise "#{config}" unless config["name"] == "fred"
+            raise "#{config}" unless config["float"] == 10.0
+            raise "#{config}" unless config["nilable"].nil?
+            raise "#{config}" unless config["color_type"].stringify == "Color.new(0)"
+            raise "#{config}" unless config["color_sym"].stringify == "Color.new(:blue)"
+            raise "#{config}" unless config["color_default"].stringify == "Color.new(:green)"
+            raise "#{config}" unless config["value"] == {"id" => "10", "name" => "fred"}
+            raise "#{config}" unless config["regex"] == /foo/
+          %}
         end
       end
     CR
   end
 
   it "does not error if nothing is configured, but all properties have defaults or are nilable" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper"
 
       module Schema
@@ -363,14 +367,18 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::CONFIG["blah"]["id"]}}.should eq 123 }
+          \{%
+            config = ADI::CONFIG["blah"]
+
+            raise "#{config}" unless config["id"] == 123
+          %}
         end
       end
     CR
   end
 
   it "inherits type of arrays from property if not explicitly set" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper"
 
       module Schema
@@ -389,14 +397,18 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::CONFIG["test"]["foo"]}}.should eq [1, 2] }
+          \{%
+            config = ADI::CONFIG["test"]
+
+            raise "#{config}" unless config["foo"] == [1, 2]
+          %}
         end
       end
     CR
   end
 
   it "allows using NoReturn to type empty arrays in schema" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper"
 
       module Schema
@@ -409,15 +421,18 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
 
       macro finished
         macro finished
-          it { (\\{{ADI::CONFIG["test"]["foo"]}}).should be_empty }
-          it { \\{{ADI::CONFIG["test"]["foo"].stringify}}.should eq "Array(Int32 | String).new" }
+          \{%
+            config = ADI::CONFIG["test"]
+
+            raise "#{config}" unless config["foo"].stringify == "Array(Int32 | String).new"
+          %}
         end
       end
     CR
   end
 
   it "allows customizing values when using NoReturn to type empty arrays defaults in schema" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper"
 
       module Schema
@@ -436,14 +451,18 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::CONFIG["test"]["foo"]}}.should eq [1, 2] }
+          \{%
+            config = ADI::CONFIG["test"]
+
+            raise "#{config}" unless config["foo"] == [1, 2]
+          %}
         end
       end
     CR
   end
 
   it "expands schema to include expected structure/defaults if not configuration is provided" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper"
 
       module Schema
@@ -466,15 +485,19 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::CONFIG["test"]["one"]["enabled"]}}.should be_false }
-          it { \\{{ADI::CONFIG["test"]["two"]["enabled"]}}.should be_false }
+          \{%
+            config = ADI::CONFIG["test"]
+
+            raise "#{config}" unless config["one"]["enabled"] == false
+            raise "#{config}" unless config["two"]["enabled"] == false
+          %}
         end
       end
     CR
   end
 
   it "expands schema to include expected structure/defaults if not explicitly provided" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper"
 
       module Schema
@@ -512,17 +535,22 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::CONFIG["test"]["one"]["enabled"]}}.should be_false }
-          it { \\{{ADI::CONFIG["test"]["one"]["id"]}}.should eq 10 }
-          it { \\{{ADI::CONFIG["test"]["two"]["enabled"]}}.should be_false }
-          it { \\{{ADI::CONFIG["test"]["two"]["three"]["enabled"]}}.should be_false }
+          \{%
+            config = ADI::CONFIG["test"]
+
+            raise "#{config}" unless config["one"]["enabled"] == false
+            raise "#{config}" unless config["one"]["id"] == 10
+
+            raise "#{config}" unless config["two"]["enabled"] == false
+            raise "#{config}" unless config["two"]["three"]["enabled"] == false
+          %}
         end
       end
     CR
   end
 
   it "merges missing array_of defaults" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper"
 
       module Schema
@@ -542,15 +570,19 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::CONFIG["test"]["rules"][0]["id"]}}.should eq 10 }
-          it { \\{{ADI::CONFIG["test"]["rules"][0]["stop"]}}.should be_false }
+          \{%
+            config = ADI::CONFIG["test"]
+
+            raise "#{config}" unless config["rules"][0]["id"] == 10
+            raise "#{config}" unless config["rules"][0]["stop"] == false
+          %}
         end
       end
     CR
   end
 
   it "merges missing array_of defaults in time for other compiler passes" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper"
 
       module Schema
@@ -583,14 +615,18 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::CONFIG["parameters"]["stop"]}}.should be_false }
+          \{%
+            parameters = ADI::CONFIG["parameters"]
+
+            raise "#{parameters}" unless parameters["stop"] == false
+          %}
         end
       end
     CR
   end
 
   it "fills in missing nilable keys with `nil`" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper"
 
       module Schema
@@ -609,16 +645,20 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::CONFIG["blah"]["config"].keys.stringify}}.should eq %([__nil, id, name]) }
-          it { \\{{ADI::CONFIG["blah"]["config"]["id"]}}.should eq 10 }
-          it { \\{{ADI::CONFIG["blah"]["config"]["name"]}}.should be_nil }
+          \{%
+            config = ADI::CONFIG["blah"]
+
+            raise "#{config}" unless config["config"].keys.stringify == %([__nil, id, name])
+            raise "#{config}" unless config["config"]["id"] == 10
+            raise "#{config}" unless config["config"]["name"].nil?
+          %}
         end
       end
     CR
   end
 
   it "fills in missing nilable keys with `nil` when missing from default value" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper"
 
       module Schema
@@ -631,9 +671,13 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::CONFIG["blah"]["config"].keys.stringify}}.should eq %([id, name]) }
-          it { \\{{ADI::CONFIG["blah"]["config"]["id"]}}.should eq 123 }
-          it { \\{{ADI::CONFIG["blah"]["config"]["name"]}}.should be_nil }
+          \{%
+            config = ADI::CONFIG["blah"]
+
+            raise "#{config}" unless config["config"].keys.stringify == %([id, name])
+            raise "#{config}" unless config["config"]["id"] == 123
+            raise "#{config}" unless config["config"]["name"].nil?
+          %}
         end
       end
     CR

--- a/src/components/dependency_injection/spec/compiler_passes/normalize_definitions_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/normalize_definitions_spec.cr
@@ -32,7 +32,7 @@ end
 describe ADI::ServiceContainer::NormalizeDefinitions, tags: "compiled" do
   describe "compiler errors" do
     it "`class` is not provided" do
-      assert_error "Service 'some_service' is missing required 'class' property.", <<-CR
+      assert_error "Service 'some_service' is missing required 'class' property.", <<-'CR'
         SERVICE_HASH["some_service"] = {
           public: false,
         }
@@ -41,7 +41,7 @@ describe ADI::ServiceContainer::NormalizeDefinitions, tags: "compiled" do
   end
 
   it "applies defaults to missing properties" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper.cr"
       module MySchema
         include ADI::Extension::Schema
@@ -71,13 +71,17 @@ describe ADI::ServiceContainer::NormalizeDefinitions, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["class"].stringify}}.should eq "SomeService" }
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["public"]}}.should be_false }
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["calls"].stringify}}.should eq "[]" }
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["tags"].stringify}}.should eq "{}" }
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["generics"].stringify}}.should eq "[]" }
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"].stringify}}.should eq "{}" }
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["shared"]}}.should be_true }
+          \{%
+            some_service = ADI::ServiceContainer::SERVICE_HASH["some_service"]
+
+            raise "#{some_service}" unless some_service["class"] == SomeService
+            raise "#{some_service}" unless some_service["public"] == false
+            raise "#{some_service}" unless some_service["calls"].size == 0
+            raise "#{some_service}" unless some_service["tags"].size == 0
+            raise "#{some_service}" unless some_service["generics"].size == 0
+            raise "#{some_service}" unless some_service["parameters"].size == 0
+            raise "#{some_service}" unless some_service["shared"] == true
+          %}
         end
       end
     CR

--- a/src/components/dependency_injection/spec/compiler_passes/process_aliases_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/process_aliases_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
 private def assert_success(code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_success <<-CR, codegen: true, line: line
+  ASPEC::Methods.assert_success <<-CR, line: line
     require "../spec_helper.cr"
     #{code}
     ADI::ServiceContainer.new
@@ -18,7 +18,7 @@ end
 
 describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
   it "errors if unable to determine the alias name" do
-    assert_error "Alias cannot be automatically determined for 'foo' (Foo). If the type includes multiple interfaces, provide the interface to alias as the first positional argument to `@[ADI::AsAlias]`.", <<-CR
+    assert_error "Alias cannot be automatically determined for 'foo' (Foo). If the type includes multiple interfaces, provide the interface to alias as the first positional argument to `@[ADI::AsAlias]`.", <<-'CR'
       module SomeInterface; end
       module OtherInterface; end
 
@@ -28,35 +28,29 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
         include SomeInterface
         include OtherInterface
       end
-
-      macro finished
-        macro finished
-          it { \\{{ADI::ServiceContainer::ALIASES.keys}}.should eq [SomeInterface] }
-          it { \\{{ADI::ServiceContainer::ALIASES[SomeInterface]["id"].stringify}}.should eq %("foo") }
-          it { \\{{ADI::ServiceContainer::ALIASES[SomeInterface]["public"]}}.should be_false }
-        end
-      end
     CR
   end
 
   it "allows explicit string alias name" do
-    assert_success <<-CR
+    assert_success <<-'CR'
       @[ADI::Register]
       @[ADI::AsAlias("bar")]
       class Foo; end
 
       macro finished
         macro finished
-          it { \\{{ADI::ServiceContainer::ALIASES.keys}}.should eq ["bar"] }
-          it { \\{{ADI::ServiceContainer::ALIASES["bar"]["id"].stringify}}.should eq %("foo") }
-          it { \\{{ADI::ServiceContainer::ALIASES["bar"]["public"]}}.should be_false }
+          \{%
+            raise "" unless ADI::ServiceContainer::ALIASES.keys == ["bar"]
+            raise "" unless ADI::ServiceContainer::ALIASES["bar"]["id"] == "foo"
+            raise "" unless ADI::ServiceContainer::ALIASES["bar"]["public"] == false
+          %}
         end
       end
     CR
   end
 
   it "allows explicit const alias name" do
-    assert_success <<-CR
+    assert_success <<-'CR'
       BAR = "bar"
 
       @[ADI::Register]
@@ -65,16 +59,18 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::ServiceContainer::ALIASES.keys}}.should eq ["bar"] }
-          it { \\{{ADI::ServiceContainer::ALIASES["bar"]["id"].stringify}}.should eq %("foo") }
-          it { \\{{ADI::ServiceContainer::ALIASES["bar"]["public"]}}.should be_false }
+          \{%
+            raise "" unless ADI::ServiceContainer::ALIASES.keys == ["bar"]
+            raise "" unless ADI::ServiceContainer::ALIASES["bar"]["id"] == "foo"
+            raise "" unless ADI::ServiceContainer::ALIASES["bar"]["public"] == false
+          %}
         end
       end
     CR
   end
 
   it "allows explicit TypeNode alias name" do
-    assert_success <<-CR
+    assert_success <<-'CR'
       module SomeInterface; end
 
       @[ADI::Register]
@@ -85,16 +81,18 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::ServiceContainer::ALIASES.keys}}.should eq [SomeInterface] }
-          it { \\{{ADI::ServiceContainer::ALIASES[SomeInterface]["id"].stringify}}.should eq %("foo") }
-          it { \\{{ADI::ServiceContainer::ALIASES[SomeInterface]["public"]}}.should be_true }
+          \{%
+            raise "" unless ADI::ServiceContainer::ALIASES.keys == [SomeInterface]
+            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface]["id"] == "foo"
+            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface]["public"] == true
+          %}
         end
       end
     CR
   end
 
   it "uses included interface type as alias name if there is only 1" do
-    assert_success <<-CR
+    assert_success <<-'CR'
       module SomeInterface; end
 
       @[ADI::Register]
@@ -105,16 +103,18 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::ServiceContainer::ALIASES.keys}}.should eq [SomeInterface] }
-          it { \\{{ADI::ServiceContainer::ALIASES[SomeInterface]["id"].stringify}}.should eq %("foo") }
-          it { \\{{ADI::ServiceContainer::ALIASES[SomeInterface]["public"]}}.should be_false }
+          \{%
+            raise "" unless ADI::ServiceContainer::ALIASES.keys == [SomeInterface]
+            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface]["id"] == "foo"
+            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface]["public"] == false
+          %}
         end
       end
     CR
   end
 
   it "allows aliasing more than one interface" do
-    assert_success <<-CR
+    assert_success <<-'CR'
       module SomeInterface; end
       module OtherInterface; end
 
@@ -128,7 +128,9 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::ServiceContainer::ALIASES.keys}}.should eq [SomeInterface, OtherInterface] }
+          \{%
+            raise "" unless ADI::ServiceContainer::ALIASES.keys == [SomeInterface, OtherInterface]
+          %}
         end
       end
     CR

--- a/src/components/dependency_injection/spec/compiler_passes/process_parameters_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/process_parameters_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 describe ADI::ServiceContainer::ProcessParameters, tags: "compiled" do
   it "populates parameter information of registered services" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper.cr"
 
       @[ADI::Register(_id: 123)]
@@ -14,22 +14,27 @@ describe ADI::ServiceContainer::ProcessParameters, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"].size}}.should eq 1 }
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["declaration"].stringify}}.should eq "id : Int32" }
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["name"].stringify}}.should eq %("id") }
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["internal_name"].stringify}}.should eq %("id") }
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["idx"]}}.should eq 0 }
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["restriction"].stringify}}.should eq "Int32" }
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["resolved_restriction"].stringify}}.should eq "Int32" }
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["default_value"]}}.should be_nil }
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["value"].stringify}}.should eq "123" }
+          \{%
+            parameters = ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]
+            raise "#{parameters}" unless parameters.size == 1
+
+            id = parameters["id"]
+            raise "#{id}" unless id["declaration"].stringify == "id : Int32"
+            raise "#{id}" unless id["name"] == "id"
+            raise "#{id}" unless id["internal_name"] == "id"
+            raise "#{id}" unless id["idx"] == 0
+            raise "#{id}" unless id["restriction"].stringify == "Int32"
+            raise "#{id}" unless id["resolved_restriction"].stringify == "Int32"
+            raise "#{id}" unless id["default_value"].nil?
+            raise "#{id}" unless id["value"] == 123
+            %}
         end
       end
     CR
   end
 
   it "does not override value of manually wired up parameters" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper.cr"
 
       class SomeService
@@ -58,14 +63,14 @@ describe ADI::ServiceContainer::ProcessParameters, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["value"].stringify}}.should eq "999" }
+          \{% raise "" unless ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["value"] == 999 %}
         end
       end
     CR
   end
 
   it "does not override value of manually wired up parameters with default value" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper.cr"
 
       class SomeService
@@ -94,7 +99,7 @@ describe ADI::ServiceContainer::ProcessParameters, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["value"].stringify}}.should eq "999" }
+          \{% raise "" unless ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["value"] == 999 %}
         end
       end
     CR

--- a/src/components/dependency_injection/spec/compiler_passes/validate_arguments_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/validate_arguments_spec.cr
@@ -11,7 +11,7 @@ end
 describe ADI::ServiceContainer::ValidateArguments, tags: "compiled" do
   describe "compiler errors" do
     it "errors if a expects a string value parameter but it is not of that type" do
-      assert_error "Parameter 'value : String' of service 'foo' (Foo) expects a String but got '123'.", <<-CR
+      assert_error "Parameter 'value : String' of service 'foo' (Foo) expects a String but got '123'.", <<-'CR'
         @[ADI::Register(_value: "%value%")]
         record Foo, value : String
 
@@ -24,7 +24,7 @@ describe ADI::ServiceContainer::ValidateArguments, tags: "compiled" do
     end
 
     it "errors if a parameter resolves to a service of the incorrect type" do
-      assert_error "Parameter 'value : Int32' of service 'foo' (Foo) expects 'Int32' but the resolved service 'bar' is of type 'Bar'.", <<-CR
+      assert_error "Parameter 'value : Int32' of service 'foo' (Foo) expects 'Int32' but the resolved service 'bar' is of type 'Bar'.", <<-'CR'
         @[ADI::Register]
         record Bar
 
@@ -35,7 +35,7 @@ describe ADI::ServiceContainer::ValidateArguments, tags: "compiled" do
 
     describe NamedTuple do
       it "errors if configuration is missing a non-nilable property" do
-        assert_error "Configuration value 'test.connection' is missing required value for 'port' of type 'Int32'.", <<-CR
+        assert_error "Configuration value 'test.connection' is missing required value for 'port' of type 'Int32'.", <<-'CR'
           module Schema
             include ADI::Extension::Schema
 
@@ -57,7 +57,7 @@ describe ADI::ServiceContainer::ValidateArguments, tags: "compiled" do
       end
 
       it "errors if there is a type mismatch" do
-        assert_error "Expected configuration value 'test.connection.hostname' to be a 'String', but got 'Int32'.", <<-CR
+        assert_error "Expected configuration value 'test.connection.hostname' to be a 'String', but got 'Int32'.", <<-'CR'
           module Schema
             include ADI::Extension::Schema
             property connection : NamedTuple(hostname: String)
@@ -74,7 +74,7 @@ describe ADI::ServiceContainer::ValidateArguments, tags: "compiled" do
       end
 
       it "errors if there is a type mismatch within an array type" do
-        assert_error "Expected configuration value 'test.connection.ports[1]' to be a 'Int32', but got 'String'.", <<-CR
+        assert_error "Expected configuration value 'test.connection.ports[1]' to be a 'Int32', but got 'String'.", <<-'CR'
           module Schema
             include ADI::Extension::Schema
             property connection : NamedTuple(ports: Array(Int32))
@@ -94,7 +94,7 @@ describe ADI::ServiceContainer::ValidateArguments, tags: "compiled" do
       end
 
       it "errors if there is a type mismatch within a nilable array type" do
-        assert_error "Expected configuration value 'test.connection.ports[1]' to be a 'Int32', but got 'String'.", <<-CR
+        assert_error "Expected configuration value 'test.connection.ports[1]' to be a 'Int32', but got 'String'.", <<-'CR'
           module Schema
             include ADI::Extension::Schema
             property connection : NamedTuple(ports: Array(Int32)?)
@@ -116,7 +116,7 @@ describe ADI::ServiceContainer::ValidateArguments, tags: "compiled" do
 
     describe "array_of" do
       it "errors on type mismatch in array within array_of object" do
-        assert_error "Expected configuration value 'test.rules[0].priorities[2]' to be a 'String', but got 'Int32'.", <<-CR
+        assert_error "Expected configuration value 'test.rules[0].priorities[2]' to be a 'String', but got 'Int32'.", <<-'CR'
           require "../spec_helper"
 
           module Schema
@@ -141,7 +141,7 @@ describe ADI::ServiceContainer::ValidateArguments, tags: "compiled" do
 
     describe "object_of" do
       it "errors on type mismatch in array within object_of object" do
-        assert_error "Expected configuration value 'test.rule.priorities[2]' to be a 'String', but got 'Int32'.", <<-CR
+        assert_error "Expected configuration value 'test.rule.priorities[2]' to be a 'String', but got 'Int32'.", <<-'CR'
           require "../spec_helper"
 
           module Schema
@@ -163,7 +163,7 @@ describe ADI::ServiceContainer::ValidateArguments, tags: "compiled" do
   end
 
   it "sets missing NT keys to `nil` if the type is nilable" do
-    ASPEC::Methods.assert_success <<-CR, codegen: true
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper"
 
       module Schema
@@ -186,14 +186,14 @@ describe ADI::ServiceContainer::ValidateArguments, tags: "compiled" do
 
       macro finished
         macro finished
-          it { \\{{ADI::CONFIG["test"]["connection"]["port"]}}.should be_nil }
+          \{% raise "" unless ADI::CONFIG["test"]["connection"]["port"].nil? %}
         end
       end
     CR
   end
 
   it "properly checks type within array of array_of object" do
-    ASPEC::Methods.assert_success <<-CR
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper"
 
       module Schema
@@ -216,7 +216,7 @@ describe ADI::ServiceContainer::ValidateArguments, tags: "compiled" do
   end
 
   it "properly checks type within array of object_of object" do
-    ASPEC::Methods.assert_success <<-CR
+    ASPEC::Methods.assert_success <<-'CR'
       require "../spec_helper"
 
       module Schema

--- a/src/components/dependency_injection/spec/extension_spec.cr
+++ b/src/components/dependency_injection/spec/extension_spec.cr
@@ -1,10 +1,9 @@
 require "./spec_helper"
 
 private def assert_success(code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_success <<-CR, codegen: true, line: line
+  ASPEC::Methods.assert_success <<-CR, line: line
     require "./spec_helper.cr"
     #{code}
-    Schema.validate
   CR
 end
 
@@ -18,74 +17,77 @@ end
 
 describe ADI::Extension, tags: "compiled" do
   it "happy path" do
-    assert_success <<-CR
+    assert_success <<-'CR'
       module Schema
         include ADI::Extension::Schema
         property id : Int32
         property name : String = "Fred"
-        def self.validate
-          it do
-            {{OPTIONS.size}}.should eq 2
-            {{OPTIONS[0]["name"].stringify}}.should eq "id"
-            {{OPTIONS[0]["type"].stringify}}.should eq "Int32"
-            {{OPTIONS[0]["default"].stringify}}.should be_empty
-            {{OPTIONS[1]["name"].stringify}}.should eq "name"
-            {{OPTIONS[1]["type"].stringify}}.should eq "String"
-            {{OPTIONS[1]["default"].stringify}}.should eq %("Fred")
-
-            {{CONFIG_DOCS.stringify}}.should eq <<-JSON
-            [{"name":"id","type":"`Int32`","default":"``"}, {"name":"name","type":"`String`","default":"`Fred`"}] of Nil
-            JSON
-          end
-        end
       end
+
       ADI.register_extension "test", Schema
       ADI.configure({
         test: {
           id: 10,
         },
       })
+
+      macro finished
+        macro finished
+          \{%
+             options = Schema::OPTIONS
+
+             raise "#{options}" unless options.size == 2
+
+             raise "#{options}" unless options[0]["name"] == "id"
+             raise "#{options}" unless options[0]["type"] == Int32
+             raise "#{options}" unless options[0]["default"].nil?
+
+             raise "#{options}" unless options[1]["name"] == "name"
+             raise "#{options}" unless options[1]["type"] == String
+             raise "#{options}" unless options[1]["default"] == "Fred"
+
+             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"id","type":"`Int32`","default":"``"}, {"name":"name","type":"`String`","default":"`Fred`"}] of Nil)
+          %}
+        end
+      end
     CR
   end
 
   it "allows using NoReturn array default to inherit type of the array" do
-    assert_success <<-CR
+    assert_success <<-'CR'
       module Schema
         include ADI::Extension::Schema
         property values : Array(Int32 | String) = [] of NoReturn
-        def self.validate
-          it do
-            {{OPTIONS.size}}.should eq 1
-            {{OPTIONS[0]["name"].stringify}}.should eq "values"
-            {{OPTIONS[0]["type"].stringify}}.should eq "Array(Int32 | String)"
-            {{OPTIONS[0]["default"].stringify}}.should eq "Array(Int32 | String).new"
+      end
 
-            {{CONFIG_DOCS.stringify}}.should eq <<-JSON
-            [{"name":"values","type":"`Array(Int32 | String)`","default":"`Array(Int32 | String).new`"}] of Nil
-            JSON
-          end
+      ADI.register_extension "test", Schema
+
+      macro finished
+        macro finished
+          \{%
+             options = Schema::OPTIONS
+
+             raise "#{options}" unless options.size == 1
+
+             raise "#{options}" unless options[0]["name"] == "values"
+             raise "#{options}" unless options[0]["type"] == Array(Int32 | String)
+             raise "#{options}" unless options[0]["default"].stringify == "Array(Int32 | String).new"
+
+             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"values","type":"`Array(Int32 | String)`","default":"`Array(Int32 | String).new`"}] of Nil)
+          %}
         end
       end
-      ADI.register_extension "test", Schema
     CR
   end
 
   describe "object_of / object_of?" do
     it "is able to resolve parameters from the object value" do
-      assert_success <<-CR
+      assert_success <<-'CR'
         module Schema
           include ADI::Extension::Schema
           object_of connection, username : String, password : String, port : Int32 = 1234
-          macro finished
-            macro finished
-              def self.validate
-                it { \\{{ADI::CONFIG["test"]["connection"]["username"]}}.should eq "addminn" }
-                it { \\{{ADI::CONFIG["test"]["connection"]["password"]}}.should eq "abc123" }
-                it { \\{{ADI::CONFIG["test"]["connection"]["port"]}}.should eq 1234 }
-              end
-            end
-          end
         end
+
         ADI.register_extension "test", Schema
 
         ADI.configure({
@@ -99,11 +101,23 @@ describe ADI::Extension, tags: "compiled" do
             "app.username": "addminn",
           },
         })
+
+        macro finished
+          macro finished
+            \{%
+               config = ADI::CONFIG["test"]
+
+               raise "#{config}" unless config["connection"]["username"] == "addminn"
+               raise "#{config}" unless config["connection"]["password"] == "abc123"
+               raise "#{config}" unless config["connection"]["port"] == 1234
+            %}
+          end
+        end
       CR
     end
 
     it "errors if a required configuration value has not been provided" do
-      assert_error "Configuration value 'test.connection' is missing required value for 'port' of type 'Int32'.", <<-CR
+      assert_error "Configuration value 'test.connection' is missing required value for 'port' of type 'Int32'.", <<-'CR'
         module Schema
           include ADI::Extension::Schema
 
@@ -124,7 +138,7 @@ describe ADI::Extension, tags: "compiled" do
     end
 
     it "errors if a configuration value has been provided a value of the wrong type" do
-      assert_error "Expected configuration value 'test.connection.port' to be a 'Int32', but got 'Bool'.", <<-CR
+      assert_error "Expected configuration value 'test.connection.port' to be a 'Int32', but got 'Bool'.", <<-'CR'
         module Schema
           include ADI::Extension::Schema
 
@@ -146,29 +160,14 @@ describe ADI::Extension, tags: "compiled" do
     end
 
     it "object_of" do
-      assert_success <<-CR
+      assert_success <<-'CR'
         module Schema
           include ADI::Extension::Schema
           object_of rule, id : Int32, stop : Bool = false
-          def self.validate
-            it do
-              {{OPTIONS.size}}.should eq 1
-              {{OPTIONS[0]["name"].stringify}}.should eq "rule"
-              {{OPTIONS[0]["type"].stringify}}.should eq "NamedTuple(T)"
-              {{OPTIONS[0]["default"].stringify}}.should eq ""
-              {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
-              {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
-              {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
-              {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
-              {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
-
-              {{CONFIG_DOCS.stringify}}.should eq <<-JSON
-              [{"name":"rule","type":"`NamedTuple(T)`","default":"``","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil
-              JSON
-            end
-          end
         end
+
         ADI.register_extension "test", Schema
+
         ADI.configure({
           test: {
             rule: {
@@ -176,166 +175,240 @@ describe ADI::Extension, tags: "compiled" do
             },
           },
         })
+
+        macro finished
+          macro finished
+            \{%
+             options = Schema::OPTIONS
+
+             raise "#{options}" unless options.size == 1
+
+             raise "#{options}" unless options[0]["name"] == "rule"
+             raise "#{options}" unless options[0]["type"].stringify == "NamedTuple(T)"
+             raise "#{options}" unless options[0]["default"].nil?
+
+             members = options[0]["members"]
+             raise "#{members}" unless members.size == 3 # Account for __nil
+
+             raise "#{members}" unless members["id"].type.stringify == "Int32"
+             raise "#{members}" unless members["id"].value.nil?
+             raise "#{members}" unless members["stop"].type.stringify == "Bool"
+             raise "#{members}" unless members["stop"].value == false
+
+             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`NamedTuple(T)`","default":"``","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+            %}
+          end
+        end
       CR
     end
 
     it "object_of with assign" do
-      assert_success <<-CR
+      assert_success <<-'CR'
         module Schema
           include ADI::Extension::Schema
           object_of rule = {id: 999}, id : Int32, stop : Bool = false
-          def self.validate
-            it do
-              {{OPTIONS.size}}.should eq 1
-              {{OPTIONS[0]["name"].stringify}}.should eq "rule"
-              {{OPTIONS[0]["type"].stringify}}.should eq "NamedTuple(T)"
-              {{OPTIONS[0]["default"].stringify}}.should eq "{id: 999, stop: false}"
-              {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
-              {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
-              {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
-              {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
-              {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
+        end
 
-              {{CONFIG_DOCS.stringify}}.should eq <<-JSON
-              [{"name":"rule","type":"`NamedTuple(T)`","default":"`{id: 999}`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil
-              JSON
-            end
+        ADI.register_extension "test", Schema
+
+        macro finished
+          macro finished
+            \{%
+             options = Schema::OPTIONS
+
+             raise "#{options}" unless options.size == 1
+
+             raise "#{options}" unless options[0]["name"] == "rule"
+             raise "#{options}" unless options[0]["type"].stringify == "NamedTuple(T)"
+             raise "#{options}" unless options[0]["default"] == {id: 999, stop: false}
+
+             members = options[0]["members"]
+             raise "#{members}" unless members.size == 3 # Account for __nil
+
+             raise "#{members}" unless members["id"].type.stringify == "Int32"
+             raise "#{members}" unless members["id"].value.nil?
+             raise "#{members}" unless members["stop"].type.stringify == "Bool"
+             raise "#{members}" unless members["stop"].value == false
+
+             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`NamedTuple(T)`","default":"`{id: 999}`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+            %}
           end
         end
-        ADI.register_extension "test", Schema
       CR
     end
 
     it "object_of?" do
-      assert_success <<-CR
+      assert_success <<-'CR'
         module Schema
           include ADI::Extension::Schema
           object_of? rule, id : Int32, stop : Bool = false
-          def self.validate
-            it do
-              {{OPTIONS.size}}.should eq 1
-              {{OPTIONS[0]["name"].stringify}}.should eq "rule"
-              {{OPTIONS[0]["type"].stringify}}.should eq "(NamedTuple(T) | Nil)"
-              {{OPTIONS[0]["default"].stringify}}.should eq "nil"
-              {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
-              {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
-              {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
-              {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
-              {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
+        end
 
-              {{CONFIG_DOCS.stringify}}.should eq <<-JSON
-              [{"name":"rule","type":"`(NamedTuple(T) | Nil)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil
-              JSON
-            end
+        ADI.register_extension "test", Schema
+
+        macro finished
+          macro finished
+            \{%
+             options = Schema::OPTIONS
+
+             raise "#{options}" unless options.size == 1
+
+             raise "#{options}" unless options[0]["name"] == "rule"
+             raise "#{options}" unless options[0]["type"].stringify == "(NamedTuple(T) | Nil)"
+             raise "#{options}" unless options[0]["default"].nil?
+
+             members = options[0]["members"]
+             raise "#{members}" unless members.size == 3 # Account for __nil
+
+             raise "#{members}" unless members["id"].type.stringify == "Int32"
+             raise "#{members}" unless members["id"].value.nil?
+             raise "#{members}" unless members["stop"].type.stringify == "Bool"
+             raise "#{members}" unless members["stop"].value == false
+
+             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`(NamedTuple(T) | Nil)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+            %}
           end
         end
-        ADI.register_extension "test", Schema
       CR
     end
 
     it "object_of? with assign" do
-      assert_success <<-CR
+      assert_success <<-'CR'
         module Schema
           include ADI::Extension::Schema
           object_of? rule = {id: 999}, id : Int32, stop : Bool = false
-          def self.validate
-            it do
-              {{OPTIONS.size}}.should eq 1
-              {{OPTIONS[0]["name"].stringify}}.should eq "rule"
-              {{OPTIONS[0]["type"].stringify}}.should eq "(NamedTuple(T) | Nil)"
-              {{OPTIONS[0]["default"].stringify}}.should eq "nil"
-              {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
-              {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
-              {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
-              {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
-              {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
+        end
 
-              {{CONFIG_DOCS.stringify}}.should eq <<-JSON
-              [{"name":"rule","type":"`(NamedTuple(T) | Nil)`","default":"`{id: 999}`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil
-              JSON
-            end
+        ADI.register_extension "test", Schema
+
+        macro finished
+          macro finished
+            \{%
+             options = Schema::OPTIONS
+
+             raise "#{options}" unless options.size == 1
+
+             raise "#{options}" unless options[0]["name"] == "rule"
+             raise "#{options}" unless options[0]["type"].stringify == "(NamedTuple(T) | Nil)"
+             raise "#{options}" unless options[0]["default"].nil?
+
+             members = options[0]["members"]
+             raise "#{members}" unless members.size == 3 # Account for __nil
+
+             raise "#{members}" unless members["id"].type.stringify == "Int32"
+             raise "#{members}" unless members["id"].value.nil?
+             raise "#{members}" unless members["stop"].type.stringify == "Bool"
+             raise "#{members}" unless members["stop"].value == false
+
+             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`(NamedTuple(T) | Nil)`","default":"`{id: 999}`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+            %}
           end
         end
-        ADI.register_extension "test", Schema
       CR
     end
   end
 
   describe "array_of / array_of?" do
     it "array_of" do
-      assert_success <<-CR
+      assert_success <<-'CR'
         module Schema
           include ADI::Extension::Schema
           array_of rules, id : Int32, stop : Bool = false
-          def self.validate
-            it do
-              {{OPTIONS.size}}.should eq 1
-              {{OPTIONS[0]["name"].stringify}}.should eq "rules"
-              {{OPTIONS[0]["type"].stringify}}.should eq "Array(T)"
-              {{OPTIONS[0]["default"].stringify}}.should eq "[]"
-              {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
-              {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
-              {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
-              {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
-              {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
-            end
+        end
+
+        ADI.register_extension "test", Schema
+
+        macro finished
+          macro finished
+            \{%
+             options = Schema::OPTIONS
+
+             raise "#{options}" unless options.size == 1
+
+             raise "#{options}" unless options[0]["name"] == "rules"
+             raise "#{options}" unless options[0]["type"].stringify == "Array(T)"
+             raise "#{options}" unless options[0]["default"].stringify == "[]"
+
+             members = options[0]["members"]
+             raise "#{members}" unless members.size == 3 # Account for __nil
+
+             raise "#{members}" unless members["id"].type.stringify == "Int32"
+             raise "#{members}" unless members["id"].value.nil?
+             raise "#{members}" unless members["stop"].type.stringify == "Bool"
+             raise "#{members}" unless members["stop"].value == false
+            %}
           end
         end
-        ADI.register_extension "test", Schema
       CR
     end
 
     it "array_of with assign" do
-      assert_success <<-CR
+      assert_success <<-'CR'
         module Schema
           include ADI::Extension::Schema
           array_of rules = [{id: 10}], id : Int32, stop : Bool = false
-          def self.validate
-            it do
-              {{OPTIONS.size}}.should eq 1
-              {{OPTIONS[0]["name"].stringify}}.should eq "rules"
-              {{OPTIONS[0]["type"].stringify}}.should eq "Array(T)"
-              {{OPTIONS[0]["default"].stringify}}.should eq "[{id: 10, stop: false}]"
-              {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
-              {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
-              {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
-              {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
-              {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
+        end
 
-              {{CONFIG_DOCS.stringify}}.should eq <<-JSON
-              [{"name":"rules","type":"`Array(T)`","default":"`[{id: 10}]`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil
-              JSON
-            end
+        ADI.register_extension "test", Schema
+
+        macro finished
+          macro finished
+            \{%
+             options = Schema::OPTIONS
+
+             raise "#{options}" unless options.size == 1
+
+             raise "#{options}" unless options[0]["name"] == "rules"
+             raise "#{options}" unless options[0]["type"].stringify == "Array(T)"
+             raise "#{options}" unless options[0]["default"] == [{id: 10, stop: false}]
+
+             members = options[0]["members"]
+             raise "#{members}" unless members.size == 3 # Account for __nil
+
+             raise "#{members}" unless members["id"].type.stringify == "Int32"
+             raise "#{members}" unless members["id"].value.nil?
+             raise "#{members}" unless members["stop"].type.stringify == "Bool"
+             raise "#{members}" unless members["stop"].value == false
+
+             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"rules","type":"`Array(T)`","default":"`[{id: 10}]`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+            %}
           end
         end
-        ADI.register_extension "test", Schema
       CR
     end
 
     it "array_of?" do
-      assert_success <<-CR
+      assert_success <<-'CR'
         module Schema
           include ADI::Extension::Schema
           array_of? rules, id : Int32, stop : Bool = false
-          def self.validate
-            it do
-              {{OPTIONS.size}}.should eq 1
-              {{OPTIONS[0]["name"].stringify}}.should eq "rules"
-              {{OPTIONS[0]["type"].stringify}}.should eq "(Array(T) | Nil)"
-              {{OPTIONS[0]["default"].stringify}}.should eq "nil"
-              {{OPTIONS[0]["members"].size}}.should eq 3 # Account for __nil
-              {{OPTIONS[0]["members"]["id"].type.stringify}}.should eq "Int32"
-              {{OPTIONS[0]["members"]["id"].value.stringify}}.should eq ""
-              {{OPTIONS[0]["members"]["stop"].type.stringify}}.should eq "Bool"
-              {{OPTIONS[0]["members"]["stop"].value.stringify}}.should eq "false"
+        end
 
-              {{CONFIG_DOCS.stringify}}.should eq <<-JSON
-              [{"name":"rules","type":"`(Array(T) | Nil)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil
-              JSON
-            end
+        ADI.register_extension "test", Schema
+
+        macro finished
+          macro finished
+            \{%
+             options = Schema::OPTIONS
+
+             raise "#{options}" unless options.size == 1
+
+             raise "#{options}" unless options[0]["name"] == "rules"
+             raise "#{options}" unless options[0]["type"].stringify == "(Array(T) | Nil)"
+             raise "#{options}" unless options[0]["default"].nil?
+
+             members = options[0]["members"]
+             raise "#{members}" unless members.size == 3 # Account for __nil
+
+             raise "#{members}" unless members["id"].type.stringify == "Int32"
+             raise "#{members}" unless members["id"].value.nil?
+             raise "#{members}" unless members["stop"].type.stringify == "Bool"
+             raise "#{members}" unless members["stop"].value == false
+
+             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"rules","type":"`(Array(T) | Nil)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+            %}
           end
         end
-        ADI.register_extension "test", Schema
       CR
     end
   end


### PR DESCRIPTION
## Context

As I realized in https://github.com/crystal-lang/crystal/issues/14880#issuecomment-2411714073, using codegen to test macro logic has a large impact on spec duration. This PR refactors _most_ specs to avoid needing to use it. Either going back to not doing codegen, or moving the specs out of `Process.run` entirely.

This'll also make it easier to handle macro code coverage reports.

## Changelog

* Reduce usages of `codegen: true` in specs
* Use single quote heredocs to enable syntax highlighting 
  * Is prob just a bug in the sublime text plugin but :shrug:

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
