### PR TITLE
Bump min ameba version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -44,7 +44,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.6.1
+    version: ~> 1.6.3
   athena-spec:
     github: athena-framework/spec
     version: ~> 0.3.2

--- a/src/components/dotenv/src/athena-dotenv.cr
+++ b/src/components/dotenv/src/athena-dotenv.cr
@@ -223,7 +223,6 @@ class Athena::Dotenv
       self.load override_existing_vars, {dist_path}
     end
 
-    # ameba:disable Lint/UselessAssign
     unless env = ENV[env_key]?
       self.populate({env_key => env = default_environment}, override_existing_vars)
     end


### PR DESCRIPTION
## Context

https://github.com/crystal-ameba/ameba/issues/468 was resolved and released, which is now causing failing CI due to not needing the disable pragma anymore.

## Changelog

* Bump min ameba version and fix error

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
