### PR TITLE
Allow having more than one compiled route collection

### DIFF
--- a/src/components/routing/spec/route_provider_spec.cr
+++ b/src/components/routing/spec/route_provider_spec.cr
@@ -36,6 +36,22 @@ struct RouteProviderTest < ASPEC::TestCase
     {% end %}
   {% end %}
 
+  def test_inspect : Nil
+    routes = ART::RouteCollection.new
+    routes.add "static", ART::Route.new "/static"
+    routes.add "dynamic", ART::Route.new "/user/{id}"
+
+    ART::RouteProvider.compile routes
+
+    data = ART::RouteProvider.inspect
+
+    data.should contain "Match Host:  false"
+    data.should contain "Static Routes:  {\"/static\" =>"
+    data.should contain "Regexes:  {0 =>"
+    data.should contain "Dynamic Routes:  {\"21\" =>"
+    data.should contain "Route Generation Data:  {\"static\" =>"
+  end
+
   def self.default_collection : ART::RouteCollection
     collection = ART::RouteCollection.new
 

--- a/src/components/routing/spec/routing_handler_spec.cr
+++ b/src/components/routing/spec/routing_handler_spec.cr
@@ -165,7 +165,9 @@ describe ART::RoutingHandler do
       handler = ART::RoutingHandler.new
       handler.add "a_route", ART::Route.new "/foo"
       handler.compile
-      ART::RouteProvider.static_routes.size.should eq 1
+      ART::RoutingHandler::RouteProvider.compiled?.should be_true
+      ART::RoutingHandler::RouteProvider.static_routes.size.should eq 1
+      ART::RouteProvider.compiled?.should be_false
     end
   end
 end

--- a/src/components/routing/src/athena-routing.cr
+++ b/src/components/routing/src/athena-routing.cr
@@ -7,10 +7,10 @@ require "./compiled_route"
 require "./request_context"
 require "./request_context_aware_interface"
 require "./route"
-require "./routing_handler"
 require "./route_collection"
 require "./route_compiler"
 require "./route_provider"
+require "./routing_handler"
 require "./router"
 
 require "./exception/*"
@@ -53,9 +53,9 @@ module Athena::Routing
   # This process compiles each route into its `ART::CompiledRoute` representation,
   # then merges them all together into a more efficient cacheable format.
   #
-  # The specifics of this process should be seen as an implementation detail.
-  # All you need to worry about is calling this method with your `ART::RouteCollection`.
-  def self.compile(routes : ART::RouteCollection) : Nil
-    ART::RouteProvider.compile routes
+  # A custom *route_provider* type may be provided to compile the routes into a different provider.
+  # By default, the default global `ART::RouteProvider` is used.
+  def self.compile(routes : ART::RouteCollection, *, route_provider : ART::RouteProvider.class = ART::RouteProvider) : Nil
+    route_provider.compile routes
   end
 end

--- a/src/components/routing/src/generator/url_generator.cr
+++ b/src/components/routing/src/generator/url_generator.cr
@@ -52,6 +52,7 @@ class Athena::Routing::Generator::URLGenerator
   def initialize(
     @context : ART::RequestContext,
     @default_locale : String? = nil,
+    @route_provider : ART::RouteProvider.class = ART::RouteProvider
   )
   end
 
@@ -62,12 +63,12 @@ class Athena::Routing::Generator::URLGenerator
   # :inherit:
   def generate(route : String, params : Hash(String, String?) = Hash(String, String?).new, reference_type : ART::Generator::ReferenceType = :absolute_path) : String
     if locale = params["_locale"]? || @context.parameters["_locale"]? || @default_locale
-      if (locale_route = ART::RouteProvider.route_generation_data["#{route}.#{locale}"]?) && (route == locale_route[1]["_canonical_route"]?)
+      if (locale_route = @route_provider.route_generation_data["#{route}.#{locale}"]?) && (route == locale_route[1]["_canonical_route"]?)
         route = "#{route}.#{locale}"
       end
     end
 
-    unless generation_data = ART::RouteProvider.route_generation_data[route]?
+    unless generation_data = @route_provider.route_generation_data[route]?
       raise ART::Exception::RouteNotFound.new "No route with the name '#{route}' exists."
     end
 

--- a/src/components/routing/src/generator/url_generator.cr
+++ b/src/components/routing/src/generator/url_generator.cr
@@ -52,7 +52,7 @@ class Athena::Routing::Generator::URLGenerator
   def initialize(
     @context : ART::RequestContext,
     @default_locale : String? = nil,
-    @route_provider : ART::RouteProvider.class = ART::RouteProvider
+    @route_provider : ART::RouteProvider.class = ART::RouteProvider,
   )
   end
 

--- a/src/components/routing/src/matcher/traceable_url_matcher.cr
+++ b/src/components/routing/src/matcher/traceable_url_matcher.cr
@@ -23,8 +23,9 @@ class Athena::Routing::Matcher::TraceableURLMatcher < Athena::Routing::Matcher::
   def initialize(
     @routes : ART::RouteCollection,
     context : ART::RequestContext,
+    route_provider : ART::RouteProvider.class = ART::RouteProvider
   )
-    super context
+    super context, route_provider
   end
 
   # Returns an array of `ART::Matcher::TraceableURLMatcher::Trace` representing the history of the matching logic when trying to match the provided *request*.

--- a/src/components/routing/src/matcher/traceable_url_matcher.cr
+++ b/src/components/routing/src/matcher/traceable_url_matcher.cr
@@ -23,7 +23,7 @@ class Athena::Routing::Matcher::TraceableURLMatcher < Athena::Routing::Matcher::
   def initialize(
     @routes : ART::RouteCollection,
     context : ART::RequestContext,
-    route_provider : ART::RouteProvider.class = ART::RouteProvider
+    route_provider : ART::RouteProvider.class = ART::RouteProvider,
   )
     super context, route_provider
   end

--- a/src/components/routing/src/matcher/url_matcher.cr
+++ b/src/components/routing/src/matcher/url_matcher.cr
@@ -9,7 +9,10 @@ class Athena::Routing::Matcher::URLMatcher
 
   @request : ART::Request? = nil
 
-  def initialize(@context : ART::RequestContext); end
+  def initialize(
+    @context : ART::RequestContext,
+    @route_provider : ART::RouteProvider.class = ART::RouteProvider
+  ); end
 
   # :inherit:
   def match(@request : ART::Request) : Hash(String, String?)
@@ -76,14 +79,14 @@ class Athena::Routing::Matcher::URLMatcher
     trimmed_path = path.rstrip('/').presence || "/"
     request_method = canonical_method = @context.method
 
-    host = @context.host.downcase if ART::RouteProvider.match_host?
+    host = @context.host.downcase if @route_provider.match_host?
 
     canonical_method = "GET" if "HEAD" == request_method
 
     supports_redirect = "GET" == canonical_method && self.is_a? ART::Matcher::RedirectableURLMatcherInterface
 
-    ART::RouteProvider.static_routes[trimmed_path]?.try &.each do |data, required_host, required_methods, required_schemes, has_trailing_slash, _, condition|
-      if condition && !(ART::RouteProvider.conditions[condition].call(@context, @request || self.build_request(path)))
+    @route_provider.static_routes[trimmed_path]?.try &.each do |data, required_host, required_methods, required_schemes, has_trailing_slash, _, condition|
+      if condition && !(@route_provider.conditions[condition].call(@context, @request || self.build_request(path)))
         next
       end
 
@@ -135,15 +138,15 @@ class Athena::Routing::Matcher::URLMatcher
       return data
     end
 
-    matched_path = ART::RouteProvider.match_host? ? "#{host}.#{path}" : path
+    matched_path = @route_provider.match_host? ? "#{host}.#{path}" : path
 
-    ART::RouteProvider.route_regexes.each do |offset, regex|
+    @route_provider.route_regexes.each do |offset, regex|
       while match = regex.match matched_path
-        ART::RouteProvider.dynamic_routes[matched_mark = match.mark.not_nil!]?.try &.each do |data, vars, required_methods, required_schemes, has_trailing_slash, has_trailing_var, condition|
+        @route_provider.dynamic_routes[matched_mark = match.mark.not_nil!]?.try &.each do |data, vars, required_methods, required_schemes, has_trailing_slash, has_trailing_var, condition|
           # Dup the data hash so we don't mutate the original.
           data = data.dup
 
-          if condition && !(ART::RouteProvider.conditions[condition].call(@context, @request || self.build_request(path)))
+          if condition && !(@route_provider.conditions[condition].call(@context, @request || self.build_request(path)))
             next
           end
 
@@ -151,7 +154,7 @@ class Athena::Routing::Matcher::URLMatcher
 
           if has_trailing_var &&
              (has_trailing_slash || (!vars || (n = match[vars.size]?).nil?) || ('/' != (n.try &.[-1]? || '/'))) &&
-             (sub_match = regex.match(ART::RouteProvider.match_host? ? "#{host}.#{trimmed_path}" : trimmed_path)) && (matched_mark == sub_match.mark.not_nil!)
+             (sub_match = regex.match(@route_provider.match_host? ? "#{host}.#{trimmed_path}" : trimmed_path)) && (matched_mark == sub_match.mark.not_nil!)
             if has_trailing_slash
               match = sub_match
             else

--- a/src/components/routing/src/matcher/url_matcher.cr
+++ b/src/components/routing/src/matcher/url_matcher.cr
@@ -11,7 +11,7 @@ class Athena::Routing::Matcher::URLMatcher
 
   def initialize(
     @context : ART::RequestContext,
-    @route_provider : ART::RouteProvider.class = ART::RouteProvider
+    @route_provider : ART::RouteProvider.class = ART::RouteProvider,
   ); end
 
   # :inherit:

--- a/src/components/routing/src/route_provider.cr
+++ b/src/components/routing/src/route_provider.cr
@@ -81,17 +81,17 @@ class Athena::Routing::RouteProvider
   # :nodoc:
   def self.inspect(io : IO) : Nil
     io << "Match Host:  "
-    self.match_host.inspect io
+    @@match_host.inspect io
     io << "\n\nStatic Routes:  "
-    self.static_routes.inspect io
+    @@static_routes.inspect io
     io << "\n\nRegexes:  "
-    self.route_regexes.inspect io
+    @@route_regexes.inspect io
     io << "\n\nDynamic Routes:  "
-    self.dynamic_routes.inspect io
+    @@dynamic_routes.inspect io
     io << "\n\nConditions:  "
-    self.conditions.inspect io
+    @@conditions.inspect io
     io << "\n\nRoute Generation Data:  "
-    self.route_generation_data.inspect io
+    @@route_generation_data.inspect io
     io << "\n\n"
   end
 

--- a/src/components/routing/src/route_provider.cr
+++ b/src/components/routing/src/route_provider.cr
@@ -1,22 +1,37 @@
 require "./static_prefix_collection"
 
-# :nodoc:
+# Stores the compiled route data on the class level for performance reasons.
 #
-# Exposes getters to static/dynamic routes as well as the full route regex.
-# Values are cached on the class level for performance resaons.
+# This type is default location, but can be extended to support multiple routers using different route collections without affecting one another.
+#
+# ```
+# class MyCustomProvider < ART::RouteProvider
+# end
+#
+# # ...
+#
+# # Compile the provided routes into MyCustomProvider, instead of the default provider.
+# ART.compile routes, route_provider: MyCustomProvider
+# ```
 class Athena::Routing::RouteProvider
   private alias Condition = Athena::Routing::Route::Condition
 
   # We store this as a tuple in order to get splatting/unpacking features.
   # defaults, variables, methods, schemas, trailing slash?, trailing var?, conditions
+  #
+  # :nodoc:
   alias DynamicRouteData = Tuple(Hash(String, String?), Set(String)?, Set(String)?, Set(String)?, Bool, Bool, Int32?)
 
   # We store this as a tuple in order to get splatting/unpacking features.
   # defaults, host, methods, schemas, trailing slash?, trailing var?, conditions
+  #
+  # :nodoc:
   alias StaticRouteData = Tuple(Hash(String, String?), String | Regex | Nil, Set(String)?, Set(String)?, Bool, Bool, Int32?)
 
   # We store this as a tuple in order to get splatting/unpacking features.
   # variables, defaults, requirements, tokens, host tokens, schemes
+  #
+  # :nodoc:
   alias RouteGenerationData = Tuple(Set(String), Hash(String, String?), Hash(String, Regex), Array(ART::CompiledRoute::Token), Array(ART::CompiledRoute::Token), Set(String)?)
 
   private record PreCompiledStaticRoute, route : ART::Route, has_trailing_slash : Bool
@@ -44,13 +59,14 @@ class Athena::Routing::RouteProvider
     end
   end
 
-  class_getter? match_host : Bool = false
-  class_getter static_routes : Hash(String, Array(StaticRouteData)) = Hash(String, Array(StaticRouteData)).new
-  class_getter route_regexes : Hash(Int32, Regex) = Hash(Int32, Regex).new
-  class_getter dynamic_routes : Hash(String, Array(DynamicRouteData)) = Hash(String, Array(DynamicRouteData)).new
-  class_getter conditions : Hash(Int32, Condition) = Hash(Int32, Condition).new
-  class_getter route_generation_data : Hash(String, RouteGenerationData) = Hash(String, RouteGenerationData).new
+  protected class_getter? match_host : Bool = false
+  protected class_getter static_routes : Hash(String, Array(StaticRouteData)) = Hash(String, Array(StaticRouteData)).new
+  protected class_getter route_regexes : Hash(Int32, Regex) = Hash(Int32, Regex).new
+  protected class_getter dynamic_routes : Hash(String, Array(DynamicRouteData)) = Hash(String, Array(DynamicRouteData)).new
+  protected class_getter conditions : Hash(Int32, Condition) = Hash(Int32, Condition).new
+  protected class_getter route_generation_data : Hash(String, RouteGenerationData) = Hash(String, RouteGenerationData).new
 
+  protected class_getter! routes : ART::RouteCollection
   protected class_getter? compiled : Bool = false
 
   def self.compile(routes : ART::RouteCollection) : Nil
@@ -61,6 +77,7 @@ class Athena::Routing::RouteProvider
     self.compile
   end
 
+  # :nodoc:
   def self.inspect(io : IO) : Nil
     io << "Match Host:  "
     self.match_host.inspect io
@@ -420,6 +437,8 @@ class Athena::Routing::RouteProvider
   end
 
   private def self.routes : ART::RouteCollection
-    @@routes || raise "Routes have not been compiled. Did you forget to call `ART.compile`?"
+    @@routes || raise "Routes have not been compiled. Did you forget to call `ART.compile` for #{self.class}?"
   end
+
+  private def initialize; end
 end

--- a/src/components/routing/src/route_provider.cr
+++ b/src/components/routing/src/route_provider.cr
@@ -66,8 +66,9 @@ class Athena::Routing::RouteProvider
   protected class_getter conditions : Hash(Int32, Condition) = Hash(Int32, Condition).new
   protected class_getter route_generation_data : Hash(String, RouteGenerationData) = Hash(String, RouteGenerationData).new
 
-  protected class_getter! routes : ART::RouteCollection
   protected class_getter? compiled : Bool = false
+
+  @@routes : ART::RouteCollection? = nil
 
   def self.compile(routes : ART::RouteCollection) : Nil
     return if @@compiled

--- a/src/components/routing/src/router.cr
+++ b/src/components/routing/src/router.cr
@@ -14,11 +14,11 @@ class Athena::Routing::Router
   # TODO: Should the matcher/generator types be customizable?
 
   getter matcher : ART::Matcher::URLMatcherInterface do
-    ART::Matcher::URLMatcher.new(@context)
+    ART::Matcher::URLMatcher.new(@context, @route_provider)
   end
 
   getter generator : ART::Generator::Interface do
-    generator = ART::Generator::URLGenerator.new @context, @default_locale
+    generator = ART::Generator::URLGenerator.new @context, @default_locale, @route_provider
     generator.strict_requirements = @strict_requirements
     generator
   end
@@ -28,6 +28,7 @@ class Athena::Routing::Router
     @default_locale : String? = nil,
     @strict_requirements : Bool? = true,
     context : ART::RequestContext? = nil,
+    @route_provider : ART::RouteProvider.class = ART::RouteProvider
   )
     @context = context || ART::RequestContext.new
   end

--- a/src/components/routing/src/router.cr
+++ b/src/components/routing/src/router.cr
@@ -28,7 +28,7 @@ class Athena::Routing::Router
     @default_locale : String? = nil,
     @strict_requirements : Bool? = true,
     context : ART::RequestContext? = nil,
-    @route_provider : ART::RouteProvider.class = ART::RouteProvider
+    @route_provider : ART::RouteProvider.class = ART::RouteProvider,
   )
     @context = context || ART::RequestContext.new
   end

--- a/src/components/routing/src/routing_handler.cr
+++ b/src/components/routing/src/routing_handler.cr
@@ -64,6 +64,10 @@
 class Athena::Routing::RoutingHandler
   include HTTP::Handler
 
+  # :nodoc:
+  class RouteProvider < ::Athena::Routing::RouteProvider
+  end
+
   @handlers : Hash(String, Proc(HTTP::Server::Context, Hash(String, String?), Nil)) = {} of String => HTTP::Server::Context, Hash(String, String?) -> Nil
 
   # :nodoc:
@@ -76,7 +80,7 @@ class Athena::Routing::RoutingHandler
     @collection : ART::RouteCollection = ART::RouteCollection.new,
     @bubble_exceptions : Bool = false,
   )
-    @matcher = matcher || ART::Matcher::URLMatcher.new ART::RequestContext.new
+    @matcher = matcher || ART::Matcher::URLMatcher.new ART::RequestContext.new, RouteProvider
   end
 
   # :inherit:
@@ -138,7 +142,7 @@ class Athena::Routing::RoutingHandler
   # ])
   # ```
   def compile : self
-    ART.compile @collection
+    ART.compile @collection, route_provider: RouteProvider
 
     self
   end


### PR DESCRIPTION
## Context

Exposes `ART::RouteProvider` and allows subclassing it to define scoped types to store compiled routes. This effectively allows more than one route collection to be compiled within an application. As such, each collection could have its own `ART::Router` to match/generate against without conflicting.

Is backwards compatible as the old `ART::RouteProvider` is used by default.

Resolves #467.

## Changelog

* Allow having more than one compiled route collection

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
