### PR TITLE
Log unhandled `ART::RoutingHandler` exceptions

### DIFF
--- a/src/components/routing/spec/spec_helper.cr
+++ b/src/components/routing/spec/spec_helper.cr
@@ -2,11 +2,15 @@ require "spec"
 require "athena-spec"
 require "../src/athena-routing"
 
+require "log/spec"
+
 ASPEC.run_all
 
 Spec.before_each do
   ART::RouteProvider.reset
 end
+
+Log.setup :none
 
 # FIXME: Refactor these specs to not depend on calling a protected method.
 include Athena::Routing

--- a/src/components/routing/src/routing_handler.cr
+++ b/src/components/routing/src/routing_handler.cr
@@ -1,3 +1,5 @@
+require "log"
+
 # Provides basic routing functionality to an [HTTP::Server](https://crystal-lang.org/api/HTTP/Server.html).
 #
 # This type works as both a [HTTP::Handler](https://crystal-lang.org/api/HTTP/Handler.html) and
@@ -64,6 +66,8 @@
 class Athena::Routing::RoutingHandler
   include HTTP::Handler
 
+  private LOG = Log.for "athena.routing"
+
   # :nodoc:
   class RouteProvider < ::Athena::Routing::RouteProvider
   end
@@ -113,6 +117,7 @@ class Athena::Routing::RoutingHandler
       @handlers[parameters["_route"]].call context, parameters
     rescue ex : ::Exception
       raise ex if @bubble_exceptions
+      LOG.error(exception: ex) { "Unhandled exception" }
       context.response.respond_with_status(:internal_server_error)
     end
   end


### PR DESCRIPTION
## Context

If an exception is raised within an `ART::RoutingHandler` action, it is by default gracefully handled by returning a 500 response. However this does not make it clear that an exception occurred at all, thus leading to some possibly hard to debug code.

This PR logs all unhandled user-land exceptions when not bubbling the exceptions. This is to prevent duplicate log messages if the user's custom error handling logic also logs the exception.

## Changelog

* Log unhandled `ART::RoutingHandler` exceptions

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
