### PR TITLE
Make CI also use `Makefile` for building docs

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -34,9 +34,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: pip install -r requirements.txt
       - name: Build Docs
-        run: mkdocs build -d ./site
+        run: make build
       - name: Publish to Cloudflare Pages
         uses: cloudflare/pages-action@v1
         with:


### PR DESCRIPTION
## Context

Follow up to #471 to make the `sync.docs` CI job also use the `Makefile`.

## Changelog

* Make CI also use `Makefile` for building docs

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
