### PR TITLE
Migrate `pages-action` to `wrangler-action`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: pip install -r requirements.txt
       - name: Build Docs
-        run: mkdocs build -d ./site
+        run: make build
       - name: Publish to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: athenaframework
-          directory: site
-          branch: master
+          command: pages deploy ./site --project-name=athenaframework --branch=master

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -37,10 +37,8 @@ jobs:
       - name: Build Docs
         run: make build
       - name: Publish to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: athenaframework
-          directory: site
-          branch: dev
+          command: pages deploy ./site --project-name=athenaframework --branch=dev


### PR DESCRIPTION
## Context

Resolves #457. Also follows up to #472 to use the `Makefile` in the `release` doc flow as well.

## Changelog

* Migrate `pages-action` to `wrangler-action`

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
