### PR TITLE
Trusted hosts

### DIFF
--- a/src/components/framework/src/athena.cr
+++ b/src/components/framework/src/athena.cr
@@ -217,6 +217,10 @@ module Athena::Framework
 
     def start : Nil
       # TODO: Is there a better place to do this?
+      {% if (trusted_hosts = ADI::CONFIG["framework"]["trusted_hosts"]) && !trusted_hosts.empty? %}
+        ATH::Request.set_trusted_hosts({{trusted_hosts}})
+      {% end %}
+
       {% if (trusted_proxies = ADI::CONFIG["framework"]["trusted_proxies"]) && (trusted_headers = ADI::CONFIG["framework"]["trusted_headers"]) %}
         ATH::Request.set_trusted_proxies({{trusted_proxies}}, {{trusted_headers}})
       {% end %}

--- a/src/components/framework/src/bundle.cr
+++ b/src/components/framework/src/bundle.cr
@@ -29,6 +29,8 @@ struct Athena::Framework::Bundle < Athena::Framework::AbstractBundle
     # See the [external documentation](/guides/proxies) for more information.
     property trusted_headers : Athena::Framework::Request::ProxyHeader = Athena::Framework::Request::ProxyHeader[:forwarded_for, :forwarded_port, :forwarded_proto]
 
+    property trusted_hosts : Array(Regex) = [] of Regex
+
     # Allows overriding the header name to use for a given `ATH::Request::ProxyHeader`.
     #
     # See the [external documentation](/guides/proxies/#custom-headers) for more information.

--- a/src/components/framework/src/bundle.cr
+++ b/src/components/framework/src/bundle.cr
@@ -29,6 +29,11 @@ struct Athena::Framework::Bundle < Athena::Framework::AbstractBundle
     # See the [external documentation](/guides/proxies) for more information.
     property trusted_headers : Athena::Framework::Request::ProxyHeader = Athena::Framework::Request::ProxyHeader[:forwarded_for, :forwarded_port, :forwarded_proto]
 
+    # By default the application can handle requests from any host.
+    # This property allows configuring regular expression patterns to control what hostnames the application is allowed to serve.
+    # This effectively prevents [host header attacks](https://www.skeletonscribe.net/2013/05/practical-http-host-header-attacks.html).
+    #
+    # If there is at least one pattern defined, requests whose hostname does _NOT_ match any of the patterns, will receive a 400 response.
     property trusted_hosts : Array(Regex) = [] of Regex
 
     # Allows overriding the header name to use for a given `ATH::Request::ProxyHeader`.

--- a/src/components/framework/src/request.cr
+++ b/src/components/framework/src/request.cr
@@ -83,12 +83,16 @@ class Athena::Framework::Request
   # Returns the list of trusted proxy IP addresses as set via `.set_trusted_proxies`.
   class_getter trusted_proxies : Array(String) = [] of String
 
-  # Returns the list of trusted host patterns.
+  # Returns the list of trusted host patterns set via `.set_trusted_hosts`.
   class_getter trusted_host_patterns : Array(Regex) = [] of Regex
 
   protected class_getter trusted_header_overrides : Hash(ATH::Request::ProxyHeader, String) = {} of ATH::Request::ProxyHeader => String
   protected class_getter trusted_hosts : Array(String) = [] of String
 
+  # Allows setting a list of *host_patterns* used to whitelist the allowed hostnames of requests.
+  # If there is at least one pattern defined, requests whose hostname does _NOT_ match any of the patterns, will receive a 400 response.
+  #
+  # See [ATH::Bundle:Schema#trusted_hosts](/Framework/Bundle/Schema/#Athena::Framework::Bundle::Schema#trusted_hosts) for more information.
   def self.set_trusted_hosts(host_patterns : Array(Regex)) : Nil
     @@trusted_host_patterns = host_patterns.map! { |pattern| /#{pattern}/i }
     @@trusted_hosts.clear

--- a/src/components/framework/src/request.cr
+++ b/src/components/framework/src/request.cr
@@ -83,7 +83,16 @@ class Athena::Framework::Request
   # Returns the list of trusted proxy IP addresses as set via `.set_trusted_proxies`.
   class_getter trusted_proxies : Array(String) = [] of String
 
+  # Returns the list of trusted host patterns.
+  class_getter trusted_host_patterns : Array(Regex) = [] of Regex
+
   protected class_getter trusted_header_overrides : Hash(ATH::Request::ProxyHeader, String) = {} of ATH::Request::ProxyHeader => String
+  protected class_getter trusted_hosts : Array(String) = [] of String
+
+  def self.set_trusted_hosts(host_patterns : Array(Regex)) : Nil
+    @@trusted_host_patterns = host_patterns.map! { |pattern| /#{pattern}/i }
+    @@trusted_hosts.clear
+  end
 
   # Allows setting a list of *trusted_proxies*, and which `ATH::Request::ProxyHeader` should be whitelisted.
   # The provided proxies are expected to be either IPv4 and/or IPv6 addresses.
@@ -210,7 +219,21 @@ class Athena::Framework::Request
       raise ATH::Exception::SuspiciousOperation.new "Invalid Host: '#{host}'."
     end
 
-    # TODO: Trusted hosts
+    unless @@trusted_host_patterns.empty?
+      return host if @@trusted_hosts.includes? host
+
+      @@trusted_host_patterns.each do |pattern|
+        if host.matches? pattern
+          @@trusted_hosts << host
+          return host
+        end
+      end
+
+      return unless @is_host_valid
+      @is_host_valid = false
+
+      raise ATH::Exception::SuspiciousOperation.new "Untrusted Host: '#{host}'."
+    end
 
     host
   end


### PR DESCRIPTION
## Context

Many different kinds of attacks have been discovered relying on inconsistencies in handling the `Host` header by various software. This PR provides a simple way to guard against these types of attacks by allowing users to whitelist the hostnames they wish to handle requests from.

When configured, any request with a hostname that doesn't match at least one of the provided regexes, will return a 400 response.

## Changelog

* Add a new `trusted_hosts` bundle schema property to allow setting trusted hosts

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
