### PR TITLE
Update docs based on new query parameter implementation

### DIFF
--- a/docs/getting_started/middleware.md
+++ b/docs/getting_started/middleware.md
@@ -36,9 +36,6 @@ The next event to be dispatched is the [ATH::Events::Action](/Framework/Events/A
 This event is dispatched after the related controller/action pair is determined, but before it is executed.
 This event is intended to be used when a listener requires information from the related [ATH::Action](/Framework/Action/); such as reading [custom annotations](./configuration.md#custom-annotations).
 
-!!! example "Action event in the Athena Framework"
-    This is the event that the [ATH::Listeners::ParamFetcher](/Framework/Listeners/ParamFetcher) listens on to resolve request parameters such as [ATHA::QueryParam](/Framework/Events/Annotations/QueryParam).
-
 ### 3. Invoke the Controller Action
 
 This next step is not an event, but a important concept within the Athena Framework nonetheless; executing the controller action related to the current request.

--- a/docs/getting_started/routing.md
+++ b/docs/getting_started/routing.md
@@ -88,7 +88,6 @@ end
 ATH.run
 
 # GET /add/2/3    # => 5
-# GET /add/5/5    # => -10
 # GET /add/foo/12 # => {"code":400,"message":"Required parameter 'value1' with value 'foo' could not be converted into a valid 'Int32'"}
 ```
 
@@ -112,7 +111,7 @@ ATH.run
 
 # GET /          # => {"code":404,"message":"Missing query parameter: 'page'."}
 # GET /?page=10  # => 10
-# GET /?page=bar # => {"code":400,"message":"Invalid query parameter: 'page'."}
+# GET /?page=bar # => {"code":404,"message":"Invalid query parameter: 'page'."}
 ```
 
 This works well enough for one-off parameters.

--- a/docs/getting_started/routing.md
+++ b/docs/getting_started/routing.md
@@ -80,44 +80,44 @@ require "athena"
 
 class ExampleController < ATH::Controller
   @[ARTA::Get("/add/{value1}/{value2}")]
-  @[ATHA::QueryParam("negative")]
-  def add(value1 : Int32, value2 : Int32, negative : Bool = false) : Int32
-    sum = value1 + value2
-    negative ? -sum : sum
+  def add(value1 : Int32, value2 : Int32) : Int32
+    value1 + value2
   end
 end
 
 ATH.run
 
-# GET /add/2/3               # => 5
-# GET /add/5/5?negative=true # => -10
-# GET /add/foo/12            # => {"code":400,"message":"Required parameter 'value1' with value 'foo' could not be converted into a valid 'Int32'"}
+# GET /add/2/3    # => 5
+# GET /add/5/5    # => -10
+# GET /add/foo/12 # => {"code":400,"message":"Required parameter 'value1' with value 'foo' could not be converted into a valid 'Int32'"}
 ```
 
 TIP: For more complex conversions, consider creating a [Value Resolver](/Framework/Controller/ValueResolvers/Interface) to encapsulate the logic.
 
-#### Query Params
+#### Query Parameters
 
-[ATHA::QueryParam](/Framework/Annotations/QueryParam) and [ATHA::RequestParam](/Framework/Annotations/RequestParam)s are defined via annotations and map directly to the method's arguments.
+[ATHA::MapQueryParameter](/Framework/Annotations/MapQueryParameter) can be used to map a query parameter directly to a controller action parameter.
 
 ```crystal
 require "athena"
 
 class ExampleController < ATH::Controller
   @[ARTA::Get("/")]
-  @[ATHA::QueryParam("page", requirements: /\d{2}/)]
-  def index(page : Int32) : Int32
+  def index(@[ATHA::MapQueryParameter] page : Int32) : Int32
     page
   end
 end
 
 ATH.run
 
-# GET /          # => {"code":422,"message":"Parameter 'page' of value '' violated a constraint: 'This value should not be null.'\n"}
+# GET /          # => {"code":404,"message":"Missing query parameter: 'page'."}
 # GET /?page=10  # => 10
-# GET /?page=bar # => {"code":400,"message":"Required parameter 'page' with value 'bar' could not be converted into a valid 'Int32'."}
-# GET /?page=5   # => {"code":422,"message":"Parameter 'page' of value '5' violated a constraint: 'Parameter 'page' value does not match requirements: (?-imsx:^(?-imsx:\\d{2})$)'\n"}
+# GET /?page=bar # => {"code":400,"message":"Invalid query parameter: 'page'."}
 ```
+
+This works well enough for one-off parameters.
+However [ATHA::MapQueryString](/Framework/Annotations/MapQueryString) can be used to the request's query string into a DTO type, much like how `JSON::Serializable` works for example.
+In addition to making it easier to reuse, it also allows for enhanced validation of the query parameters via the [`Athena::Validator`](/Validator/#validating-objects) component.
 
 ### Raw Request
 
@@ -143,7 +143,6 @@ ATH.run
 
 # POST /data body: {"id":1,"name":"Jim"} # => Jim
 ```
-
 
 ### Streaming Response
 

--- a/docs/getting_started/testing.md
+++ b/docs/getting_started/testing.md
@@ -47,9 +47,8 @@ require "athena"
 require "athena/spec"
 
 class ExampleController < ATH::Controller
-  @[ATHA::QueryParam("negative")]
   @[ARTA::Get("/add/{value1}/{value2}")]
-  def add(value1 : Int32, value2 : Int32, negative : Bool = false) : Int32
+  def add(value1 : Int32, value2 : Int32, @[ATHA::MapQueryParameter] negative : Bool = false) : Int32
     sum = value1 + value2
     negative ? -sum : sum
   end

--- a/src/components/framework/src/athena.cr
+++ b/src/components/framework/src/athena.cr
@@ -118,11 +118,6 @@ module Athena::Framework
   # See each listener and the [Getting Started](/getting_started/middleware) docs for more information.
   module Listeners; end
 
-  # Namespace for types related to request parameter processing.
-  #
-  # See `ATHA::QueryParam` and `ATHA::RequestParam`.
-  module Params; end
-
   # :nodoc:
   module CompilerPasses; end
 

--- a/src/components/framework/src/controller.cr
+++ b/src/components/framework/src/controller.cr
@@ -1,7 +1,7 @@
 # The core of any framework is routing; how a route is tied to an action.
 # Athena takes an annotation based approach; an annotation, such as `ARTA::Get` is applied to an instance method of a controller class, which will be executed when that endpoint receives a request.
 #
-# Additional annotation also exist for defining a query parameter. See `ATHA::QueryParam` for more information.
+# Additional annotations also exist for defining [query parameters](/getting_started/routing/#query-parameters).
 #
 # Child controllers must inherit from `ATH::Controller` (or an abstract child of it). Each request gets its own instance of the controller to better allow for DI via `Athena::DependencyInjection`.
 #
@@ -38,7 +38,7 @@
 #     end
 #   end
 #
-#   # A GET endpoint with no params returning a `String`.
+#   # A GET endpoint with no parameters returning a `String`.
 #   #
 #   # Action return type restrictions are required.
 #   @[ARTA::Get("/me")]
@@ -46,7 +46,7 @@
 #     "Jim"
 #   end
 #
-#   # A GET endpoint with no params returning `Nil`.
+#   # A GET endpoint with no parameters returning `Nil`.
 #   # `Nil` return types are returned with a status
 #   # of 204 no content
 #   @[ARTA::Get("/no_content")]
@@ -54,7 +54,7 @@
 #     # Do stuff
 #   end
 #
-#   # A GET endpoint with two `Int32` params returning an `Int32`.
+#   # A GET endpoint with two `Int32` parameters returning an `Int32`.
 #   #
 #   # The parameters of a route _MUST_ match the parameters of the action.
 #   # Type restrictions on action parameters are required.
@@ -63,8 +63,8 @@
 #     val1 + val2
 #   end
 #
-#   # A GET endpoint with a required trailing slash, a `String` route param,
-#   # and a required string query param that must match the given pattern; returning a `String`.
+#   # A GET endpoint with a required trailing slash, a `String` route parameter,
+#   # and a required string query parameter; returning a `String`.
 #   #
 #   # Athena treats non `GET`/`HEAD` routes with a trailing slash as unique
 #   # E.g. `POST /foo/bar/` versus `POST /foo/bar`.
@@ -73,20 +73,18 @@
 #   # A non-nilable type denotes it as required. If the parameter is not supplied,
 #   # and no default value is assigned, an `ATH::Exception::BadRequest` exception is raised.
 #   @[ARTA::Get("/event/{event_name}/")]
-#   @[ATHA::QueryParam("time", requirements: /\d:\d:\d/)]
-#   def event_time(event_name : String, time : String) : String
+#   def event_time(event_name : String, @[ATHA::MapQueryParameter] time : String) : String
 #     "#{event_name} occurred at #{time}"
 #   end
 #
-#   # A GET endpoint with an optional query parameter and optional path param
+#   # A GET endpoint with an optional query parameter and optional path parameter
 #   # with a default value; returning a `NamedTuple(user_id : Int32?, page : Int32)`.
 #   #
 #   # A nilable type denotes it as optional.
 #   # If the parameter is not supplied (or could not be converted),
 #   # and no default value is assigned, it is `nil`.
-#   @[ATHA::QueryParam("user_id")]
 #   @[ARTA::Get("/events/{page}")]
-#   def events(user_id : Int32?, page : Int32 = 1) : NamedTuple(user_id: Int32?, page: Int32)
+#   def events(@[ATHA::MapQueryParameter] user_id : Int32?, page : Int32 = 1) : NamedTuple(user_id: Int32?, page: Int32)
 #     {user_id: user_id, page: page}
 #   end
 #
@@ -100,9 +98,9 @@
 #     time
 #   end
 #
-#   # A POST endpoint with a route param and accessing the request body; returning a `Bool`.
+#   # A POST endpoint with a route parameter and accessing the request body; returning a `Bool`.
 #   #
-#   # It is recommended to use param converters to pass an actual object representing the data (assuming the body is JSON)
+#   # It is recommended to use `ATHR::RequestBody` to allow passing an actual object representing the data
 #   # to the route's action; however the raw request body can be accessed by typing an action argument as `ATH::Request`.
 #   @[ARTA::Post("/test/{expected}")]
 #   def post_body(expected : String, request : ATH::Request) : Bool

--- a/src/components/framework/src/spec/api_test_case.cr
+++ b/src/components/framework/src/spec/api_test_case.cr
@@ -9,9 +9,8 @@ require "./web_test_case"
 #
 # ```
 # class ExampleController < ATH::Controller
-#   @[ATHA::QueryParam("negative")]
 #   @[ARTA::Get("/add/{value1}/{value2}")]
-#   def add(value1 : Int32, value2 : Int32, negative : Bool = false) : Int32
+#   def add(value1 : Int32, value2 : Int32, @[ATHA::MapQueryParameter] negative : Bool = false) : Int32
 #     sum = value1 + value2
 #     negative ? -sum : sum
 #   end


### PR DESCRIPTION
## Context

Follow up to #426 and #477 to update the docs to reference the new implementation.

## Changelog

* Update documentation to reference the new `ATHA::MapQueryParameter` and `ATHA::MapQueryString` annotations
* Remove now defunct `Athena::Framework::Params` namespace

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
