### PR TITLE
Fix redirection with non-standard ports

### DIFF
--- a/src/components/framework/spec/controller/redirect_spec.cr
+++ b/src/components/framework/spec/controller/redirect_spec.cr
@@ -32,22 +32,6 @@ struct RedirectControllerTest < ASPEC::TestCase
     response.status.found?.should be_true
   end
 
-  def test_non_standard_port : Nil
-    request = ATH::Request.new "GET", "/", headers: HTTP::Headers{"host" => "example.com"}
-    controller = ATH::Controller::Redirect.new
-
-    self.assert_redirect_url controller.redirect_url(request, "/foo", scheme: "http", http_port: 90), "http://example.com:90/foo"
-    self.assert_redirect_url controller.redirect_url(request, "/foo", scheme: "https", https_port: 90), "https://example.com:90/foo"
-  end
-
-  def test_falls_back_on_controller_ports : Nil
-    request = ATH::Request.new "GET", "/", headers: HTTP::Headers{"host" => "example.com"}
-    controller = ATH::Controller::Redirect.new 100, 200
-
-    self.assert_redirect_url controller.redirect_url(request, "/foo", scheme: "http"), "http://example.com:100/foo"
-    self.assert_redirect_url controller.redirect_url(request, "/foo", scheme: "https"), "https://example.com:200/foo"
-  end
-
   def test_full_url_with_method_keep : Nil
     request = ATH::Request.new "GET", "/"
     controller = ATH::Controller::Redirect.new
@@ -57,11 +41,84 @@ struct RedirectControllerTest < ASPEC::TestCase
     response.status.temporary_redirect?.should be_true
   end
 
-  # def test_url_redirect_default_ports : Nil
-  # end
+  def test_protocol_relative : Nil
+    request = ATH::Request.new "GET", "/"
+    controller = ATH::Controller::Redirect.new
 
-  # def test_url_redirect : Nil
-  # end
+    response = controller.redirect_url request, "//foo.bar/"
+    self.assert_redirect_url response, "http://foo.bar/"
+    response.status.found?.should be_true
+  end
+
+  def test_url_redirect_default_ports : Nil
+    host = "www.example.com"
+    path = "/redirect-path"
+    http_port = 1080
+    https_port = 1443
+
+    expected_url = "https://#{host}:#{https_port}#{path}"
+    request = ATH::Request.new "GET", "/", headers: HTTP::Headers{"host" => "#{host}:#{http_port}"}
+    controller = ATH::Controller::Redirect.new https_port: https_port
+    response = controller.redirect_url request, path, scheme: "https"
+    self.assert_redirect_url response, expected_url
+
+    expected_url = "http://#{host}:#{http_port}#{path}"
+    request = ATH::Request.new "GET", "/", headers: HTTP::Headers{"host" => "#{host}:#{http_port}"}
+    controller = ATH::Controller::Redirect.new http_port
+    response = controller.redirect_url request, path, scheme: "http"
+    self.assert_redirect_url response, expected_url
+  end
+
+  @[DataProvider("url_redirect_provider")]
+  def test_url_redirect(
+    scheme : String,
+    http_port : Int32?,
+    https_port : Int32?,
+    request_scheme : String,
+    request_port : Int32,
+    expected_port : String,
+  ) : Nil
+    host = "www.example.com"
+    path = "/redirect-path"
+    expected_url = "#{scheme}://#{host}#{expected_port}#{path}"
+
+    request = ATH::Request.new "GET", "/", headers: HTTP::Headers{"host" => "#{host}:#{request_port}"}
+    request.scheme = request_scheme
+    controller = ATH::Controller::Redirect.new
+
+    response = controller.redirect_url request, path, scheme: scheme, http_port: http_port, https_port: https_port
+    self.assert_redirect_url response, expected_url
+  end
+
+  def url_redirect_provider : Tuple
+    {
+      # Standard ports
+      {"http", nil, nil, "http", 80, ""},
+      {"http", 80, nil, "http", 80, ""},
+      {"https", nil, nil, "http", 80, ""},
+      {"https", 80, nil, "http", 80, ""},
+
+      {"http", nil, nil, "https", 443, ""},
+      {"http", nil, 443, "https", 443, ""},
+      {"https", nil, nil, "https", 443, ""},
+      {"https", nil, 443, "https", 443, ""},
+
+      # Non-standard ports
+      {"http", nil, nil, "http", 8080, ":8080"},
+      {"http", 4080, nil, "http", 8080, ":4080"},
+      {"http", 80, nil, "http", 8080, ""},
+      {"https", nil, nil, "http", 8080, ""},
+      {"https", nil, 8443, "http", 8080, ":8443"},
+      {"https", nil, 443, "http", 8080, ""},
+
+      {"https", nil, nil, "https", 8443, ":8443"},
+      {"https", nil, 4443, "https", 8443, ":4443"},
+      {"https", nil, 443, "https", 8443, ""},
+      {"http", nil, nil, "https", 8443, ""},
+      {"http", 8080, 4443, "https", 8443, ":8080"},
+      {"http", 80, 4443, "https", 8443, ""},
+    }
+  end
 
   @[TestWith(
     {"http://www.example.com/redirect-path", "/redirect-path", ""},
@@ -83,6 +140,14 @@ struct RedirectControllerTest < ASPEC::TestCase
 
     self.assert_redirect_url controller.redirect_url(request, path, scheme: scheme, http_port: port), expected
   end
+
+  # TODO: For when we have a way to redirect to a route vs just a path
+
+  # def test_redirect_with_query : Nil
+  # end
+
+  # def test_redirect_with_query_with_route_params_overriding : Nil
+  # end
 
   private def assert_redirect_url(response : ATH::Response, expected : String) : Nil
     response.redirect?(expected).should be_true, failure_message: "Expected: '#{expected}'\n Got: '#{response.headers["location"]}'."

--- a/src/components/framework/spec/routing_spec.cr
+++ b/src/components/framework/spec/routing_spec.cr
@@ -219,27 +219,27 @@ struct RoutingTest < ATH::Spec::APITestCase
   end
 
   def test_redirects_get_request_to_route_without_trailing_slash : Nil
-    self.get "/macro/get-nil/"
+    self.get "/macro/get-nil/", headers: HTTP::Headers{"host" => "localhost"}
 
-    self.assert_response_redirects "/macro/get-nil"
+    self.assert_response_redirects "http://localhost/macro/get-nil"
   end
 
   def test_redirects_head_request_to_route_without_trailing_slash : Nil
-    self.head "/head/"
+    self.head "/head/", headers: HTTP::Headers{"host" => "localhost"}
 
-    self.assert_response_redirects "/head"
+    self.assert_response_redirects "http://localhost/head"
   end
 
   def test_redirects_get_request_to_route_with_trailing_slash : Nil
-    self.get "/head-get"
+    self.get "/head-get", headers: HTTP::Headers{"host" => "localhost"}
 
-    self.assert_response_redirects "/head-get/"
+    self.assert_response_redirects "http://localhost/head-get/"
   end
 
   def test_redirects_head_request_to_route_with_trailing_slash : Nil
-    self.head "/head-get"
+    self.head "/head-get", headers: HTTP::Headers{"host" => "localhost"}
 
-    self.assert_response_redirects "/head-get/"
+    self.assert_response_redirects "http://localhost/head-get/"
   end
 
   def test_does_not_redirect_post_requests : Nil

--- a/src/components/framework/spec/spec_helper.cr
+++ b/src/components/framework/spec/spec_helper.cr
@@ -23,6 +23,11 @@ end
 
 ASPEC.run_all
 
+# TODO: Is there a better way to handle customizing the scheme of a request w/o monkey patching it?
+class ATH::Request
+  property scheme : String = "http"
+end
+
 class TestController < ATH::Controller
   get "test" do
     "TEST"


### PR DESCRIPTION
## Context

This PR leverages the extra `ATH::Request` methods added in #440 within `ATH::Controller::Redirect` to implement more robust redirection logic

## Changelog

* Fix automatic redirection with non-standard ports
* Automatic redirection should overall be more robust now

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
