### PR TITLE
Make class level `ARTA::Route` annotation consistent with method level

### DIFF
--- a/src/components/framework/spec/ext/routing/annotation_route_loader_spec.cr
+++ b/src/components/framework/spec/ext/routing/annotation_route_loader_spec.cr
@@ -92,6 +92,21 @@ class PrefixedController < ATH::Controller
   def slash_param(id : String) : Nil; end
 end
 
+@[ARTA::Route("pos-prefix")]
+class PositionalPrefixedController < ATH::Controller
+  @[ARTA::Post("")]
+  def empty : Nil; end
+
+  @[ARTA::Post("/")]
+  def slash : Nil; end
+
+  @[ARTA::Get("{id}")]
+  def empty_param(id : String) : Nil; end
+
+  @[ARTA::Get("/{id}")]
+  def slash_param(id : String) : Nil; end
+end
+
 @[ARTA::Route(
   schemes: ["BAR", "foo", "baz"],
   methods: ["foo", "baz", "bar"],
@@ -502,6 +517,46 @@ describe ATH::Routing::AnnotationRouteLoader do
           route,
           name: "prefixed_controller_slash_param",
           path: "/prefix/{id}",
+        )
+      end
+
+      it "normalizes positional prefixed route paths" do
+        routes = ATH::Routing::AnnotationRouteLoader.populate_collection(PositionalPrefixedController).routes.to_a
+
+        routes.size.should eq 4
+
+        route = routes[0]
+
+        assert_route(
+          route,
+          name: "positional_prefixed_controller_empty",
+          path: "/pos-prefix",
+          methods: Set{"POST"}
+        )
+
+        route = routes[1]
+
+        assert_route(
+          route,
+          name: "positional_prefixed_controller_slash",
+          path: "/pos-prefix/",
+          methods: Set{"POST"}
+        )
+
+        route = routes[2]
+
+        assert_route(
+          route,
+          name: "positional_prefixed_controller_empty_param",
+          path: "/pos-prefix/{id}",
+        )
+
+        route = routes[3]
+
+        assert_route(
+          route,
+          name: "positional_prefixed_controller_slash_param",
+          path: "/pos-prefix/{id}",
         )
       end
     end

--- a/src/components/framework/src/ext/routing/annotation_route_loader.cr
+++ b/src/components/framework/src/ext/routing/annotation_route_loader.cr
@@ -40,7 +40,7 @@ module Athena::Framework::Routing::AnnotationRouteLoader
           }
 
           if controller_ann = klass.annotation ARTA::Route
-            if (ann_path = controller_ann[:path]) && ann_path.is_a? HashLiteral
+            if (ann_path = (controller_ann[:path] || controller_ann[0])) && ann_path.is_a? HashLiteral
               globals[:localized_paths] = ann_path
             elsif ann_path != nil
               ann_path = ann_path.resolve if ann_path.is_a?(Path)


### PR DESCRIPTION
## Context

Fixes #481

When the routing component was integrated in #141, class level `ARTA::Route` annotations required the path to be provided explicitly via the `path` parameter, which is inconsistent with the method level implementation. This PR allows providing the path as the first positional argument in the class level, making them consistent.

## Changelog

* Make class level `ARTA::Route` annotation consistent with method level 

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
