### PR TITLE
Add usages for the constraints.

### DIFF
--- a/src/components/validator/src/constraints/blank.cr
+++ b/src/components/validator/src/constraints/blank.cr
@@ -1,6 +1,6 @@
 # Validates that a value is blank; meaning equal to an empty string or `nil`.
 #
-# ```crystal
+# ```
 # class Profile
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/blank.cr
+++ b/src/components/validator/src/constraints/blank.cr
@@ -1,5 +1,16 @@
 # Validates that a value is blank; meaning equal to an empty string or `nil`.
 #
+# ```crystal
+# class Profile
+#   include AVD::Validatable
+#
+#   def initialize(@username : String); end
+#
+#   @[Assert::NotBlank]
+#   property username : String
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/choice.cr
+++ b/src/components/validator/src/constraints/choice.cr
@@ -1,6 +1,17 @@
 # Validates that a value is one of a given set of valid choices;
 # can also be used to validate that each item in a collection is one of those valid values.
 #
+# ```crystal
+# class User
+#   include AVD::Validatable
+#
+#   def initialize(@role : String); end
+#
+#   @[Assert::Choice(["member", "moderator", "admin"])]
+#   property role : String
+# end
+# ```
+#
 # # Configuration
 #
 # ## Required Arguments

--- a/src/components/validator/src/constraints/choice.cr
+++ b/src/components/validator/src/constraints/choice.cr
@@ -1,7 +1,7 @@
 # Validates that a value is one of a given set of valid choices;
 # can also be used to validate that each item in a collection is one of those valid values.
 #
-# ```crystal
+# ```
 # class User
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/email.cr
+++ b/src/components/validator/src/constraints/email.cr
@@ -4,6 +4,17 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
+# ```crystal
+# class User
+#   include AVD::Validatable
+#
+#   def initialize(@email : String); end
+#
+#   @[Assert::Email]
+#   property email : String
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/email.cr
+++ b/src/components/validator/src/constraints/email.cr
@@ -4,7 +4,7 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ```crystal
+# ```
 # class User
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/equal_to.cr
+++ b/src/components/validator/src/constraints/equal_to.cr
@@ -1,5 +1,16 @@
 # Validates that a value is equal to another.
 #
+# ```crystal
+# class Project
+#   include AVD::Validatable
+#
+#   def initialize(@name : String); end
+#
+#   @[Assert::EqualTo("Athena")]
+#   property name : String
+# end
+# ```
+#
 # # Configuration
 #
 # ## Required Arguments

--- a/src/components/validator/src/constraints/equal_to.cr
+++ b/src/components/validator/src/constraints/equal_to.cr
@@ -1,6 +1,6 @@
 # Validates that a value is equal to another.
 #
-# ```crystal
+# ```
 # class Project
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/file.cr
+++ b/src/components/validator/src/constraints/file.cr
@@ -7,6 +7,17 @@ require "mime"
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
+# ```crystal
+# class Profile
+#   include AVD::Validatable
+#
+#   def initialize(@resume : ::File); end
+#
+#   @[Assert::File]
+#   property resume : ::File
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/file.cr
+++ b/src/components/validator/src/constraints/file.cr
@@ -7,7 +7,7 @@ require "mime"
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ```crystal
+# ```
 # class Profile
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/greater_than.cr
+++ b/src/components/validator/src/constraints/greater_than.cr
@@ -1,5 +1,16 @@
 # Validates that a value is greater than another.
 #
+# ```crystal
+# class Person
+#   include AVD::Validatable
+#
+#   def initialize(@age : Int64); end
+#
+#   @[Assert::GreaterThan(18)]
+#   property age : Int64
+# end
+# ```
+#
 # # Configuration
 #
 # ## Required Arguments

--- a/src/components/validator/src/constraints/greater_than.cr
+++ b/src/components/validator/src/constraints/greater_than.cr
@@ -1,6 +1,6 @@
 # Validates that a value is greater than another.
 #
-# ```crystal
+# ```
 # class Person
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/greater_than_or_equal.cr
+++ b/src/components/validator/src/constraints/greater_than_or_equal.cr
@@ -1,5 +1,16 @@
 # Validates that a value is greater than or equal to another.
 #
+# ```crystal
+# class Person
+#   include AVD::Validatable
+#
+#   def initialize(@age : Int64); end
+#
+#   @[Assert::GreaterThanOrEqual(18)]
+#   property age : Int64
+# end
+# ```
+#
 # # Configuration
 #
 # ## Required Arguments

--- a/src/components/validator/src/constraints/greater_than_or_equal.cr
+++ b/src/components/validator/src/constraints/greater_than_or_equal.cr
@@ -1,6 +1,6 @@
 # Validates that a value is greater than or equal to another.
 #
-# ```crystal
+# ```
 # class Person
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/image.cr
+++ b/src/components/validator/src/constraints/image.cr
@@ -5,7 +5,7 @@ require "athena-image_size"
 #
 # See `AVD::Constraints::File` for common documentation.
 #
-# ```crystal
+# ```
 # class Profile
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/image.cr
+++ b/src/components/validator/src/constraints/image.cr
@@ -5,6 +5,17 @@ require "athena-image_size"
 #
 # See `AVD::Constraints::File` for common documentation.
 #
+# ```crystal
+# class Profile
+#   include AVD::Validatable
+#
+#   def initialize(@avatar : ::File); end
+#
+#   @[Assert::Image]
+#   property avatar : ::File
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/ip.cr
+++ b/src/components/validator/src/constraints/ip.cr
@@ -7,6 +7,17 @@ require "socket"
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
+# ```crystal
+# class Machine
+#   include AVD::Validatable
+#
+#   def initialize(@ip_address : String); end
+#
+#   @[Assert::IP]
+#   property ip_address : String
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/ip.cr
+++ b/src/components/validator/src/constraints/ip.cr
@@ -7,7 +7,7 @@ require "socket"
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ```crystal
+# ```
 # class Machine
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/is_false.cr
+++ b/src/components/validator/src/constraints/is_false.cr
@@ -1,6 +1,6 @@
 # Validates that a value is `false`.
 #
-# ```crystal
+# ```
 # class Post
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/is_false.cr
+++ b/src/components/validator/src/constraints/is_false.cr
@@ -1,5 +1,16 @@
 # Validates that a value is `false`.
 #
+# ```crystal
+# class Post
+#   include AVD::Validatable
+#
+#   def initialize(@is_published : Bool); end
+#
+#   @[Assert::IsFalse]
+#   property is_published : Bool
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/is_nil.cr
+++ b/src/components/validator/src/constraints/is_nil.cr
@@ -1,6 +1,6 @@
 # Validates that a value is `nil`.
 #
-# ```crystal
+# ```
 # class Post
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/is_nil.cr
+++ b/src/components/validator/src/constraints/is_nil.cr
@@ -1,5 +1,16 @@
 # Validates that a value is `nil`.
 #
+# ```crystal
+# class Post
+#   include AVD::Validatable
+#
+#   def initialize(@updated_at : Time?); end
+#
+#   @[Assert::IsNil]
+#   property updated_at : Time?
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/is_true.cr
+++ b/src/components/validator/src/constraints/is_true.cr
@@ -1,6 +1,6 @@
 # Validates that a value is `true`.
 #
-# ```crystal
+# ```
 # class Post
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/is_true.cr
+++ b/src/components/validator/src/constraints/is_true.cr
@@ -1,5 +1,16 @@
 # Validates that a value is `true`.
 #
+# ```crystal
+# class Post
+#   include AVD::Validatable
+#
+#   def initialize(@is_published : Bool); end
+#
+#   @[Assert::IsTrue]
+#   property is_published : Bool
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/isbn.cr
+++ b/src/components/validator/src/constraints/isbn.cr
@@ -4,7 +4,7 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ```crystal
+# ```
 # class Book
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/isbn.cr
+++ b/src/components/validator/src/constraints/isbn.cr
@@ -4,6 +4,17 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
+# ```crystal
+# class Book
+#   include AVD::Validatable
+#
+#   def initialize(@isbn : String); end
+#
+#   @[Assert::ISBN]
+#   property isbn : String
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/isin.cr
+++ b/src/components/validator/src/constraints/isin.cr
@@ -4,6 +4,16 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
+# ```crystal
+# class UnitAccount
+#   include AVD::Validatable
+#
+#   def initialize(@isin : String); end
+#
+#   @[Assert::ISIN]
+#   property isin : String
+# end
+# ```
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/isin.cr
+++ b/src/components/validator/src/constraints/isin.cr
@@ -4,7 +4,7 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ```crystal
+# ```
 # class UnitAccount
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/issn.cr
+++ b/src/components/validator/src/constraints/issn.cr
@@ -4,6 +4,17 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
+# ```crystal
+# class Journal
+#   include AVD::Validatable
+#
+#   def initialize(@isin : String); end
+#
+#   @[Assert::ISSN]
+#   property issn : String
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/issn.cr
+++ b/src/components/validator/src/constraints/issn.cr
@@ -4,7 +4,7 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ```crystal
+# ```
 # class Journal
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/less_than.cr
+++ b/src/components/validator/src/constraints/less_than.cr
@@ -1,5 +1,16 @@
 # Validates that a value is less than another.
 #
+# ```crystal
+# class Employee
+#   include AVD::Validatable
+#
+#   def initialize(@age : Number); end
+#
+#   @[Assert::LessThan(60)]
+#   property age : Number
+# end
+# ```
+#
 # # Configuration
 #
 # ## Required Arguments

--- a/src/components/validator/src/constraints/less_than.cr
+++ b/src/components/validator/src/constraints/less_than.cr
@@ -1,6 +1,6 @@
 # Validates that a value is less than another.
 #
-# ```crystal
+# ```
 # class Employee
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/less_than_or_equal.cr
+++ b/src/components/validator/src/constraints/less_than_or_equal.cr
@@ -1,5 +1,16 @@
 # Validates that a value is less than or equal to another.
 #
+# ```crystal
+# class Employee
+#   include AVD::Validatable
+#
+#   def initialize(@age : Number); end
+#
+#   @[Assert::LessThanOrEqual(60)]
+#   property age : Number
+# end
+# ```
+#
 # # Configuration
 #
 # ## Required Arguments

--- a/src/components/validator/src/constraints/less_than_or_equal.cr
+++ b/src/components/validator/src/constraints/less_than_or_equal.cr
@@ -1,6 +1,6 @@
 # Validates that a value is less than or equal to another.
 #
-# ```crystal
+# ```
 # class Employee
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/luhn.cr
+++ b/src/components/validator/src/constraints/luhn.cr
@@ -4,7 +4,7 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ```crystal
+# ```
 # class Transaction
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/luhn.cr
+++ b/src/components/validator/src/constraints/luhn.cr
@@ -4,6 +4,17 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
+# ```crystal
+# class Transaction
+#   include AVD::Validatable
+#
+#   def initialize(@card_number : String); end
+#
+#   @[Assert::Luhn]
+#   property card_number : String
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/negative.cr
+++ b/src/components/validator/src/constraints/negative.cr
@@ -1,7 +1,7 @@
 # Validates that a value is a negative number.
 # Use `AVD::Constraints::NegativeOrZero` if you wish to also allow `0`.
 #
-# ```crystal
+# ```
 # class Mall
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/negative.cr
+++ b/src/components/validator/src/constraints/negative.cr
@@ -1,6 +1,17 @@
 # Validates that a value is a negative number.
 # Use `AVD::Constraints::NegativeOrZero` if you wish to also allow `0`.
 #
+# ```crystal
+# class Mall
+#   include AVD::Validatable
+#
+#   def initialize(@lowest_floor : Number); end
+#
+#   @[Assert::Negative]
+#   property lowest_floor : Number
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/negative_or_zero.cr
+++ b/src/components/validator/src/constraints/negative_or_zero.cr
@@ -1,6 +1,17 @@
 # Validates that a value is a negative number, or `0`.
 # Use `AVD::Constraints::Negative` if you don't want to allow `0`.
 #
+# ```crystal
+# class Mall
+#   include AVD::Validatable
+#
+#   def initialize(@lowest_floor : Number); end
+#
+#   @[Assert::NegativeOrZero]
+#   property lowest_floor : Number
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/negative_or_zero.cr
+++ b/src/components/validator/src/constraints/negative_or_zero.cr
@@ -1,7 +1,7 @@
 # Validates that a value is a negative number, or `0`.
 # Use `AVD::Constraints::Negative` if you don't want to allow `0`.
 #
-# ```crystal
+# ```
 # class Mall
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/not_blank.cr
+++ b/src/components/validator/src/constraints/not_blank.cr
@@ -1,6 +1,6 @@
 # Validates that a value is not blank; meaning not equal to a blank string, an empty `Iterable`, `false`, or optionally `nil`.
 #
-# ```crystal
+# ```
 # class User
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/not_blank.cr
+++ b/src/components/validator/src/constraints/not_blank.cr
@@ -1,5 +1,16 @@
 # Validates that a value is not blank; meaning not equal to a blank string, an empty `Iterable`, `false`, or optionally `nil`.
 #
+# ```crystal
+# class User
+#   include AVD::Validatable
+#
+#   def initialize(@name : String); end
+#
+#   @[Assert::NotBlank]
+#   property name : String
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/not_equal_to.cr
+++ b/src/components/validator/src/constraints/not_equal_to.cr
@@ -1,6 +1,6 @@
 # Validates that a value is not equal to another.
 #
-# ```crystal
+# ```
 # class User
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/not_equal_to.cr
+++ b/src/components/validator/src/constraints/not_equal_to.cr
@@ -1,5 +1,16 @@
 # Validates that a value is not equal to another.
 #
+# ```crystal
+# class User
+#   include AVD::Validatable
+#
+#   def initialize(@name : String); end
+#
+#   @[Assert::NotEqualTo("John Doe")]
+#   property name : String
+# end
+# ```
+#
 # # Configuration
 #
 # ## Required Arguments

--- a/src/components/validator/src/constraints/not_nil.cr
+++ b/src/components/validator/src/constraints/not_nil.cr
@@ -3,7 +3,7 @@
 # NOTE: Due to Crystal's static typing, when validating objects the property's type must be nilable,
 # otherwise `nil` is inherently not allowed due to the compiler's type checking.
 #
-# ```crystal
+# ```
 # class Post
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/not_nil.cr
+++ b/src/components/validator/src/constraints/not_nil.cr
@@ -3,6 +3,20 @@
 # NOTE: Due to Crystal's static typing, when validating objects the property's type must be nilable,
 # otherwise `nil` is inherently not allowed due to the compiler's type checking.
 #
+# ```crystal
+# class Post
+#   include AVD::Validatable
+#
+#   def initialize(@title : String?, @description : String?); end
+#
+#   @[Assert::NotNil]
+#   property title : String?
+#
+#   @[Assert::NotNil]
+#   property description : String?
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/optional.cr
+++ b/src/components/validator/src/constraints/optional.cr
@@ -1,5 +1,16 @@
 # Allows wrapping `AVD::Constraint`(s) to denote it as being optional within an `AVD::Constraints::Collection`.
 # See [this][Athena::Validator::Constraints::Collection--required-and-optional-constraints] for more information.
+#
+# ```crystal
+# class Post
+#   include AVD::Validatable
+#
+#   def initialize(@content : String); end
+#
+#   @[Assert::Optional]
+#   property content : String
+# end
+# ```
 class Athena::Validator::Constraints::Optional < Athena::Validator::Constraints::Existence
   # :inherit:
   def validated_by : NoReturn

--- a/src/components/validator/src/constraints/optional.cr
+++ b/src/components/validator/src/constraints/optional.cr
@@ -1,7 +1,7 @@
 # Allows wrapping `AVD::Constraint`(s) to denote it as being optional within an `AVD::Constraints::Collection`.
 # See [this][Athena::Validator::Constraints::Collection--required-and-optional-constraints] for more information.
 #
-# ```crystal
+# ```
 # class Post
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/optional.cr
+++ b/src/components/validator/src/constraints/optional.cr
@@ -1,16 +1,5 @@
 # Allows wrapping `AVD::Constraint`(s) to denote it as being optional within an `AVD::Constraints::Collection`.
 # See [this][Athena::Validator::Constraints::Collection--required-and-optional-constraints] for more information.
-#
-# ```
-# class Post
-#   include AVD::Validatable
-#
-#   def initialize(@content : String); end
-#
-#   @[Assert::Optional]
-#   property content : String
-# end
-# ```
 class Athena::Validator::Constraints::Optional < Athena::Validator::Constraints::Existence
   # :inherit:
   def validated_by : NoReturn

--- a/src/components/validator/src/constraints/positive.cr
+++ b/src/components/validator/src/constraints/positive.cr
@@ -1,6 +1,17 @@
 # Validates that a value is a positive number.
 # Use `AVD::Constraints::PositiveOrZero` if you wish to also allow `0`.
 #
+# ```crystal
+# class Account
+#   include AVD::Validatable
+#
+#   def initialize(@balance : Number); end
+#
+#   @[Assert::Positive]
+#   property balance : Number
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/positive.cr
+++ b/src/components/validator/src/constraints/positive.cr
@@ -1,7 +1,7 @@
 # Validates that a value is a positive number.
 # Use `AVD::Constraints::PositiveOrZero` if you wish to also allow `0`.
 #
-# ```crystal
+# ```
 # class Account
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/positive_or_zero.cr
+++ b/src/components/validator/src/constraints/positive_or_zero.cr
@@ -1,7 +1,7 @@
 # Validates that a value is a positive number, or `0`.
 # Use `AVD::Constraints::Positive` if you don't want to allow `0`.
 #
-# ```crystal
+# ```
 # class Account
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/positive_or_zero.cr
+++ b/src/components/validator/src/constraints/positive_or_zero.cr
@@ -1,6 +1,17 @@
 # Validates that a value is a positive number, or `0`.
 # Use `AVD::Constraints::Positive` if you don't want to allow `0`.
 #
+# ```crystal
+# class Account
+#   include AVD::Validatable
+#
+#   def initialize(@balance : Number); end
+#
+#   @[Assert::PositiveOrZero]
+#   property balance : Number
+# end
+# ```
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/range.cr
+++ b/src/components/validator/src/constraints/range.cr
@@ -1,5 +1,16 @@
 # Validates that a `Number` or `Time` value is between some minimum and maximum.
 #
+# ```crystal
+# class House
+#   include AVD::Validatable
+#
+#   def initialize(@area : Number); end
+#
+#   @[Assert::Range(15..100)]
+#   property area : Number
+# end
+# ```
+#
 # # Configuration
 #
 # ## Required Arguments

--- a/src/components/validator/src/constraints/range.cr
+++ b/src/components/validator/src/constraints/range.cr
@@ -1,6 +1,6 @@
 # Validates that a `Number` or `Time` value is between some minimum and maximum.
 #
-# ```crystal
+# ```
 # class House
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/regex.cr
+++ b/src/components/validator/src/constraints/regex.cr
@@ -4,6 +4,19 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
+# ```crystal
+# class User
+#   include AVD::Validatable
+#
+#   def initialize(@username : String); end
+#
+#   # this regex verifies that username contains alphanumeric chars
+#   # and some special characters (underscore, space and dash).
+#   @[Assert::Regex(/^[a-zA-Z0-9]+([_ -]?[a-zA-Z0-9])*$/)]
+#   property username : String
+# end
+# ```
+#
 # # Configuration
 #
 # ## Required Arguments

--- a/src/components/validator/src/constraints/regex.cr
+++ b/src/components/validator/src/constraints/regex.cr
@@ -4,7 +4,7 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ```crystal
+# ```
 # class User
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/required.cr
+++ b/src/components/validator/src/constraints/required.cr
@@ -1,5 +1,19 @@
 # Allows wrapping `AVD::Constraint`(s) to denote it as being required within an `AVD::Constraints::Collection`.
 # See [this][Athena::Validator::Constraints::Collection--required-and-optional-constraints] for more information.
+#
+# ```crystal
+# class Post
+#   include AVD::Validatable
+#
+#   def initialize(@title : String, @description : String); end
+#
+#   @[Assert::Required]
+#   property title : String
+#
+#   @[Assert::Required]
+#   property description : String
+# end
+# ```
 class Athena::Validator::Constraints::Required < Athena::Validator::Constraints::Existence
   # :inherit:
   def validated_by : NoReturn

--- a/src/components/validator/src/constraints/required.cr
+++ b/src/components/validator/src/constraints/required.cr
@@ -1,19 +1,5 @@
 # Allows wrapping `AVD::Constraint`(s) to denote it as being required within an `AVD::Constraints::Collection`.
 # See [this][Athena::Validator::Constraints::Collection--required-and-optional-constraints] for more information.
-#
-# ```
-# class Post
-#   include AVD::Validatable
-#
-#   def initialize(@title : String, @description : String); end
-#
-#   @[Assert::Required]
-#   property title : String
-#
-#   @[Assert::Required]
-#   property description : String
-# end
-# ```
 class Athena::Validator::Constraints::Required < Athena::Validator::Constraints::Existence
   # :inherit:
   def validated_by : NoReturn

--- a/src/components/validator/src/constraints/required.cr
+++ b/src/components/validator/src/constraints/required.cr
@@ -1,7 +1,7 @@
 # Allows wrapping `AVD::Constraint`(s) to denote it as being required within an `AVD::Constraints::Collection`.
 # See [this][Athena::Validator::Constraints::Collection--required-and-optional-constraints] for more information.
 #
-# ```crystal
+# ```
 # class Post
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/size.cr
+++ b/src/components/validator/src/constraints/size.cr
@@ -1,6 +1,6 @@
 # Validates that the `#size` of a `String` or `Indexable` value is between some minimum and maximum.
 #
-# ```crystal
+# ```
 # class User
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/size.cr
+++ b/src/components/validator/src/constraints/size.cr
@@ -1,5 +1,15 @@
 # Validates that the `#size` of a `String` or `Indexable` value is between some minimum and maximum.
 #
+# ```crystal
+# class User
+#   include AVD::Validatable
+#
+#   def initialize(@username : String); end
+#
+#   @[Assert::Size(3..30)]
+#   property username : String
+# end
+#
 # # Configuration
 #
 # ## Required Arguments

--- a/src/components/validator/src/constraints/unique.cr
+++ b/src/components/validator/src/constraints/unique.cr
@@ -1,6 +1,6 @@
 # Validates that all elements of an `Indexable` are unique.
 #
-# ```crystal
+# ```
 # class School
 #   include AVD::Validatable
 #

--- a/src/components/validator/src/constraints/unique.cr
+++ b/src/components/validator/src/constraints/unique.cr
@@ -1,5 +1,15 @@
 # Validates that all elements of an `Indexable` are unique.
 #
+# ```crystal
+# class School
+#   include AVD::Validatable
+#
+#   def initialize(@rooms : Array(String)); end
+#
+#   @[Assert::Unique]
+#   property rooms : Array(String)
+# end
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/url.cr
+++ b/src/components/validator/src/constraints/url.cr
@@ -4,6 +4,16 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
+# ```crystal
+# class Profile
+#   include AVD::Validatable
+#
+#   def initialize(@avatar_url : String); end
+#
+#   @[Assert::URL]
+#   property avatar_url : String
+# end
+#
 # # Configuration
 #
 # ## Optional Arguments

--- a/src/components/validator/src/constraints/url.cr
+++ b/src/components/validator/src/constraints/url.cr
@@ -4,7 +4,7 @@
 # NOTE: As with most other constraints, `nil` and empty strings are considered valid values, in order to allow the value to be optional.
 # If the value is required, consider combining this constraint with `AVD::Constraints::NotBlank`.
 #
-# ```crystal
+# ```
 # class Profile
 #   include AVD::Validatable
 #


### PR DESCRIPTION
## Context

Reference to issue #201

This pull request consists to add usages that provide a better understanding of their representations, so, developers can easily use the constraints.

## Changelog

- Add example usages to `AVD::Constraints` docs

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
