### PR TITLE
Additional `RequestBody` annotation properties

### DIFF
--- a/src/components/framework/spec/controller/value_resolvers/request_body_spec.cr
+++ b/src/components/framework/spec/controller/value_resolvers/request_body_spec.cr
@@ -22,7 +22,6 @@ private record MockJSONAndURISerializableEntity, id : Int32, name : String do
   include URI::Params::Serializable
 end
 
-@[ASPEC::TestCase::Focus]
 struct RequestBodyResolverTest < ASPEC::TestCase
   @target : ATHR::RequestBody
 

--- a/src/components/framework/spec/controller/value_resolvers/request_body_spec.cr
+++ b/src/components/framework/spec/controller/value_resolvers/request_body_spec.cr
@@ -22,6 +22,7 @@ private record MockJSONAndURISerializableEntity, id : Int32, name : String do
   include URI::Params::Serializable
 end
 
+@[ASPEC::TestCase::Focus]
 struct RequestBodyResolverTest < ASPEC::TestCase
   @target : ATHR::RequestBody
 
@@ -118,6 +119,15 @@ struct RequestBodyResolverTest < ASPEC::TestCase
 
     object.id.should eq 10
     object.name.should eq "Fred"
+  end
+
+  def test_it_supports_specifiying_accepted_formats : Nil
+    expect_raises ATH::Exception::UnsupportedMediaType, %(Unsupported format, expects one of: 'json, xml', but got 'form'.) do
+      @target.resolve(
+        new_request(body: "id=10&name=Fred", format: "form"),
+        self.get_config(MockURISerializableEntity, configuration: ATHA::MapRequestBodyConfiguration.new(["json", "xml"]))
+      )
+    end
   end
 
   def test_it_supports_query_string_serializable : Nil

--- a/src/components/framework/spec/controller/value_resolvers/request_body_spec.cr
+++ b/src/components/framework/spec/controller/value_resolvers/request_body_spec.cr
@@ -120,7 +120,7 @@ struct RequestBodyResolverTest < ASPEC::TestCase
     object.name.should eq "Fred"
   end
 
-  def test_it_supports_specifiying_accepted_formats : Nil
+  def test_it_supports_specifying_accepted_formats : Nil
     expect_raises ATH::Exception::UnsupportedMediaType, %(Unsupported format, expects one of: 'json, xml', but got 'form'.) do
       @target.resolve(
         new_request(body: "id=10&name=Fred", format: "form"),

--- a/src/components/framework/src/athena.cr
+++ b/src/components/framework/src/athena.cr
@@ -82,7 +82,7 @@ module Athena::Framework
   #
   # 1. `ATHR::UUID` (105) - Attempts to resolve a value from the request attributes into a `::UUID` instance.
   #
-  # 1. `ATHR::RequestBody` (105) - If enabled, attempts to deserialize the request body into the type of the related parameter, running any validations, if any.
+  # 1. `ATHR::RequestBody` (105) - If enabled, attempts to deserialize the request body/query string into the type of the related parameter, running any defined validations if applicable.
   #
   # 1. `ATHR::RequestAttribute` (100) - Provides a value stored in `ATH::Request#attributes` if one with the same name as the action parameter exists.
   #

--- a/src/components/framework/src/controller/value_resolvers/interface.cr
+++ b/src/components/framework/src/controller/value_resolvers/interface.cr
@@ -223,7 +223,7 @@
 #
 # In all of the examples so far, the resolvers could be applied to any parameter of any type and all of the logic to resolve a value would happen at runtime.
 # In some cases a specific resolver may only support a single, or small subset of types.
-# Such as how the `ATHR::RequestBody` resolver only allows `ASR::Serializable` or `JSON::Serializable` types.
+# Such as how the `ATHR::RequestBody` resolver only allows `ASR::Serializable`, `JSON::Serializable`, or `URI::Params::Serializable` types.
 # In this case, the `ATHR::Interface::Typed` module may be used to define the allowed parameter types.
 #
 # WARNING: Strict typing is _ONLY_ supported when a configuration annotation is used to enable the resolver.

--- a/src/components/framework/src/controller/value_resolvers/request_body.cr
+++ b/src/components/framework/src/controller/value_resolvers/request_body.cr
@@ -116,7 +116,7 @@ struct Athena::Framework::Controller::ValueResolvers::RequestBody
   #
   # ## Optional Arguments
   #
-  # ### accept_format
+  # ### accept_formats
   #
   # **Type:** `Array(String)?` **Default:** `nil`
   #
@@ -129,7 +129,7 @@ struct Athena::Framework::Controller::ValueResolvers::RequestBody
   #
   # The [validation groups](/Validator/Constraint/#Athena::Validator::Constraint--validation-groups) that should be used when validating the resolved object.
   configuration ::Athena::Framework::Annotations::MapRequestBody,
-    accept_format : Array(String)? = nil,
+    accept_formats : Array(String)? = nil,
     validation_groups : Array(String) | AVD::Constraints::GroupSequence | Nil = nil
 
   # Enables the `ATHR::RequestBody` resolver for the parameter this annotation is applied to based on the request's query string.
@@ -202,8 +202,8 @@ struct Athena::Framework::Controller::ValueResolvers::RequestBody
 
     format = request.content_type_format
 
-    if (accept_format = configuration.accept_format) && !accept_format.includes? format
-      raise ATH::Exception::UnsupportedMediaType.new "Unsupported format, expects one of: '#{accept_format.join(", ")}', but got '#{format}'."
+    if (accept_formats = configuration.accept_formats) && !accept_formats.includes? format
+      raise ATH::Exception::UnsupportedMediaType.new "Unsupported format, expects one of: '#{accept_formats.join(", ")}', but got '#{format}'."
     end
 
     # We have to use separate deserialization methods with the case such that a type that includes multiple modules is handled as expected.

--- a/src/components/framework/src/controller/value_resolvers/request_body.cr
+++ b/src/components/framework/src/controller/value_resolvers/request_body.cr
@@ -99,11 +99,79 @@ struct Athena::Framework::Controller::ValueResolvers::RequestBody
 
   # Enables the `ATHR::RequestBody` resolver for the parameter this annotation is applied to based on the request's body.
   # See the related resolver documentation for more information.
-  configuration ::Athena::Framework::Annotations::MapRequestBody
+  #
+  # ```
+  # class UserController < ATH::Controller
+  #   @[ARTA::Post("/user")]
+  #   def new_user(
+  #     @[ATHA::MapRequestBody]
+  #     user_create : UserCreateDTO,
+  #   ) : UserCreateDTO
+  #     user_create
+  #   end
+  # end
+  # ```
+  #
+  # # Configuration
+  #
+  # ## Optional Arguments
+  #
+  # ### accept_format
+  #
+  # **Type:** `Array(String)?` **Default:** `nil`
+  #
+  # Allows whitelisting the allowed [request format(s)][ATH::Request::FORMATS].
+  # If the `ATH::Request#content_type_format` is not included in this list, a `ATH::Exception::UnsupportedMediaType` error will be raised.
+  #
+  # ### validation_groups
+  #
+  # **Type:** `Array(String) | AVD::Constraints::GroupSequence | Nil` **Default:** `nil`
+  #
+  # The [validation groups](/Validator/Constraint/#Athena::Validator::Constraint--validation-groups) that should be used when validating the resolved object.
+  #
+  # ### validation_failed_status
+  #
+  # **Type:** `HTTP::Status` **Default:** `:unprocessable_entity`
+  #
+  # The `HTTP::Status` to use for the error response if the resolved object fails validation.
+  configuration ::Athena::Framework::Annotations::MapRequestBody,
+    accept_format : Array(String)? = nil,
+    validation_groups : Array(String) | AVD::Constraints::GroupSequence | Nil = nil,
+    validation_failed_status : HTTP::Status = :unprocessable_entity
 
   # Enables the `ATHR::RequestBody` resolver for the parameter this annotation is applied to based on the request's query string.
   # See the related resolver documentation for more information.
-  configuration ::Athena::Framework::Annotations::MapQueryString
+  #
+  # ```
+  # class ArticleController < ATH::Controller
+  #   @[ARTA::Get("/articles")]
+  #   def articles(
+  #     @[ATHA::MapQueryString]
+  #     pagination_context : PaginationContext,
+  #   ) : Array(Article)
+  #     # ...
+  #   end
+  # end
+  # ```
+  #
+  # # Configuration
+  #
+  # ## Optional Arguments
+  #
+  # ### validation_groups
+  #
+  # **Type:** `Array(String) | AVD::Constraints::GroupSequence | Nil` **Default:** `nil`
+  #
+  # The [validation groups](/Validator/Constraint/#Athena::Validator::Constraint--validation-groups) that should be used when validating the resolved object.
+  #
+  # ### validation_failed_status
+  #
+  # **Type:** `HTTP::Status` **Default:** `:not_found`
+  #
+  # The `HTTP::Status` to use for the error response if the resolved object fails validation.
+  configuration ::Athena::Framework::Annotations::MapQueryString,
+    validation_groups : Array(String) | AVD::Constraints::GroupSequence | Nil = nil,
+    validation_failed_status : HTTP::Status = :not_found
 
   def initialize(
     @serializer : ASR::SerializerInterface,

--- a/src/components/framework/src/controller/value_resolvers/uuid.cr
+++ b/src/components/framework/src/controller/value_resolvers/uuid.cr
@@ -18,7 +18,7 @@ require "uuid"
 # # GET /uuid/b115c7a5-0a13-47b4-b4ac-55b3e2686946 # => "Version: V4 - Variant: RFC4122"
 # ```
 #
-# TIP: Checkout `ART::Requirement` for an easy way to restrict/validate the version of the UUID that is allowed.
+# TIP: Checkout [ART::Requirement](/Routing/Requirement/) for an easy way to restrict/validate the version of the UUID that is allowed.
 struct Athena::Framework::Controller::ValueResolvers::UUID
   include Athena::Framework::Controller::ValueResolvers::Interface
 

--- a/src/components/framework/src/ext/routing.cr
+++ b/src/components/framework/src/ext/routing.cr
@@ -1,3 +1,6 @@
 require "athena-routing"
 
+# :nodoc:
+module Athena::Framework::Routing; end
+
 require "./routing/*"


### PR DESCRIPTION
## Context

Enhances the `RequestBody` resolver by allowing some data to flow thru to the underlying implementation via the annotation. This should ultimately make them a bit more flexible.

## Changelog

* Add `#validation_groups` to `ATHA::MapRequestBody` and `ATHA::MapQueryString`
* Add `#accept_formats` to `ATHA::MapRequestBody`
* Improve docs to call out the resolver can handle form data and query strings
* Hide `ATH::Routing` namespace from docs

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
