### PR TITLE
Only return exit code 1, if that's what the spec run did

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -74,7 +74,7 @@ for component in $(find src/components/ -maxdepth 2 -type f -name shard.yml | xa
     runSpecs $component
   fi
 
-  if [ $? -ne 0 ]; then
+  if [ $? -eq 1 ]; then
     EXIT_CODE=1
   fi
 


### PR DESCRIPTION
## Context

It seems that `kcov` can return `127` sometimes, likely due to a bug. This was causing an issue making the CI job fail due to non-zero exit code. This PR makes it a bit more strict by only failing the script if it failed with exit code 1.

## Changelog

* Fix unexpected non zero exit codes in `scripts/test.sh`

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
