### PR TITLE
Add `ACON::Output::Verbosity::SILENT` verbosity level

### DIFF
--- a/src/components/console/spec/application_spec.cr
+++ b/src/components/console/spec/application_spec.cr
@@ -580,11 +580,14 @@ struct ApplicationTest < ASPEC::TestCase
     ENV["COLUMNS"] = "120"
     tester = ACON::Spec::ApplicationTester.new app
 
-    tester.run command: "foo", decorated: false, capture_stderr_separately: true
+    tester.run command: "foo", decorated: false, verbosity: :quiet, capture_stderr_separately: true
     self.assert_file_equals_string "text/application_renderexception1.txt", tester.error_output true
 
-    tester.run command: "foo", decorated: false, capture_stderr_separately: true, verbosity: :verbose
+    tester.run command: "foo", decorated: false, verbosity: :verbose, capture_stderr_separately: true
     tester.error_output.should contain "Exception trace"
+
+    tester.run command: "foo", decorated: false, verbosity: :silent, capture_stderr_separately: true
+    tester.error_output(true).should be_empty
 
     tester.run command: "list", "--foo": true, decorated: false, capture_stderr_separately: true
     self.assert_file_equals_string "text/application_renderexception2.txt", tester.error_output true

--- a/src/components/console/spec/commands/complete_spec.cr
+++ b/src/components/console/spec/commands/complete_spec.cr
@@ -116,9 +116,9 @@ struct CompleteCommandTest < ASPEC::TestCase
 
   def provide_input_definition_inputs : Hash
     {
-      "definition"         => {["hello", "-"], ["--help", "--quiet", "--verbose", "--version", "--ansi", "--no-ansi", "--no-interaction"]},
+      "definition"         => {["hello", "-"], ["--help", "--silent", "--quiet", "--verbose", "--version", "--ansi", "--no-ansi", "--no-interaction"]},
       "custom"             => {["hello"], ["Athena", "Crystal", "Ruby"]},
-      "aliased definition" => {["ahoy", "-"], ["--help", "--quiet", "--verbose", "--version", "--ansi", "--no-ansi", "--no-interaction"]},
+      "aliased definition" => {["ahoy", "-"], ["--help", "--silent", "--quiet", "--verbose", "--version", "--ansi", "--no-ansi", "--no-interaction"]},
       "aliased custom"     => {["ahoy"], ["Athena", "Crystal", "Ruby"]},
     }
   end

--- a/src/components/console/spec/commands/list_spec.cr
+++ b/src/components/console/spec/commands/list_spec.cr
@@ -46,7 +46,8 @@ struct ListCommandTest < ASPEC::TestCase
 
       Options:
         -h, --help            Display help for the given command. When no command is given display help for the list command
-        -q, --quiet           Do not output any message
+            --silent          Do not output any message
+        -q, --quiet           Only errors are displayed. All other output is suppressed
         -V, --version         Display this application version
             --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
         -n, --no-interaction  Do not ask any interactive question

--- a/src/components/console/spec/fixtures/text/application_1.txt
+++ b/src/components/console/spec/fixtures/text/application_1.txt
@@ -5,7 +5,8 @@ foo <info>UNKNOWN</info>
 
 <comment>Options:</comment>
   <info>-h, --help</info>            Display help for the given command. When no command is given display help for the <info>list</info> command
-  <info>-q, --quiet</info>           Do not output any message
+  <info>    --silent</info>          Do not output any message
+  <info>-q, --quiet</info>           Only errors are displayed. All other output is suppressed
   <info>-V, --version</info>         Display this application version
   <info>    --ansi|--no-ansi</info>  Force (or disable --no-ansi) ANSI output
   <info>-n, --no-interaction</info>  Do not ask any interactive question

--- a/src/components/console/spec/fixtures/text/application_2.txt
+++ b/src/components/console/spec/fixtures/text/application_2.txt
@@ -5,7 +5,8 @@ My Athena application <info>1.0.0</info>
 
 <comment>Options:</comment>
   <info>-h, --help</info>            Display help for the given command. When no command is given display help for the <info>list</info> command
-  <info>-q, --quiet</info>           Do not output any message
+  <info>    --silent</info>          Do not output any message
+  <info>-q, --quiet</info>           Only errors are displayed. All other output is suppressed
   <info>-V, --version</info>         Display this application version
   <info>    --ansi|--no-ansi</info>  Force (or disable --no-ansi) ANSI output
   <info>-n, --no-interaction</info>  Do not ask any interactive question

--- a/src/components/console/spec/fixtures/text/application_filtered_namespace.txt
+++ b/src/components/console/spec/fixtures/text/application_filtered_namespace.txt
@@ -5,7 +5,8 @@ My Athena application <info>1.0.0</info>
 
 <comment>Options:</comment>
   <info>-h, --help</info>            Display help for the given command. When no command is given display help for the <info>list</info> command
-  <info>-q, --quiet</info>           Do not output any message
+  <info>    --silent</info>          Do not output any message
+  <info>-q, --quiet</info>           Only errors are displayed. All other output is suppressed
   <info>-V, --version</info>         Display this application version
   <info>    --ansi|--no-ansi</info>  Force (or disable --no-ansi) ANSI output
   <info>-n, --no-interaction</info>  Do not ask any interactive question

--- a/src/components/console/spec/fixtures/text/application_run1.txt
+++ b/src/components/console/spec/fixtures/text/application_run1.txt
@@ -5,7 +5,8 @@ Usage:
 
 Options:
   -h, --help            Display help for the given command\. When no command is given display help for the list command
-  -q, --quiet           Do not output any message
+      --silent          Do not output any message
+  -q, --quiet           Only errors are displayed. All other output is suppressed
   -V, --version         Display this application version
       --ansi\|--no-ansi  Force \(or disable --no-ansi\) ANSI output
   -n, --no-interaction  Do not ask any interactive question

--- a/src/components/console/spec/fixtures/text/application_run2.txt
+++ b/src/components/console/spec/fixtures/text/application_run2.txt
@@ -12,7 +12,8 @@ Options:
       --format=FORMAT   The output format \(txt\) \[default: "txt"\]
       --short           To skip describing command's arguments
   -h, --help            Display help for the given command. When no command is given display help for the list command
-  -q, --quiet           Do not output any message
+      --silent          Do not output any message
+  -q, --quiet           Only errors are displayed. All other output is suppressed
   -V, --version         Display this application version
       --ansi\|--no-ansi  Force \(or disable --no-ansi\) ANSI output
   -n, --no-interaction  Do not ask any interactive question

--- a/src/components/console/spec/fixtures/text/application_run3.txt
+++ b/src/components/console/spec/fixtures/text/application_run3.txt
@@ -12,7 +12,8 @@ Options:
       --format=FORMAT   The output format \(txt\) \[default: "txt"\]
       --short           To skip describing command's arguments
   -h, --help            Display help for the given command\. When no command is given display help for the list command
-  -q, --quiet           Do not output any message
+      --silent          Do not output any message
+  -q, --quiet           Only errors are displayed. All other output is suppressed
   -V, --version         Display this application version
       --ansi\|--no-ansi  Force \(or disable --no-ansi\) ANSI output
   -n, --no-interaction  Do not ask any interactive question

--- a/src/components/console/spec/fixtures/text/application_run5.txt
+++ b/src/components/console/spec/fixtures/text/application_run5.txt
@@ -11,7 +11,8 @@ Options:
       --format=FORMAT   The output format \(txt\) \[default: "txt"\]
       --raw             To output raw command help
   -h, --help            Display help for the given command\. When no command is given display help for the list command
-  -q, --quiet           Do not output any message
+      --silent          Do not output any message
+  -q, --quiet           Only errors are displayed. All other output is suppressed
   -V, --version         Display this application version
       --ansi\|--no-ansi  Force \(or disable --no-ansi\) ANSI output
   -n, --no-interaction  Do not ask any interactive question

--- a/src/components/console/spec/output/null_spec.cr
+++ b/src/components/console/spec/output/null_spec.cr
@@ -1,0 +1,11 @@
+require "../spec_helper"
+
+struct NullSpec < ASPEC::TestCase
+  def test_verbosity : Nil
+    ACON::Output::Null.new.verbosity.silent?.should be_true
+  end
+
+  def test_formatter : Nil
+    ACON::Output::Null.new.formatter.should be_a ACON::Formatter::Null
+  end
+end

--- a/src/components/console/spec/output/output_spec.cr
+++ b/src/components/console/spec/output/output_spec.cr
@@ -79,6 +79,7 @@ struct OutputTest < ASPEC::TestCase
 
   def verbosity_provider : Tuple
     {
+      {ACON::Output::Verbosity::SILENT, ""},
       {ACON::Output::Verbosity::QUIET, "2"},
       {ACON::Output::Verbosity::NORMAL, "123"},
       {ACON::Output::Verbosity::VERBOSE, "1234"},

--- a/src/components/console/src/application.cr
+++ b/src/components/console/src/application.cr
@@ -533,16 +533,20 @@ class Athena::Console::Application
       input.interactive = false
     end
 
-    case shell_verbosity = ENV["SHELL_VERBOSITY"]?.try &.to_i
+    shell_verbosity = ENV["SHELL_VERBOSITY"]?.try(&.to_i) || 0
+
+    case shell_verbosity
+    when -2 then output.verbosity = :silent
     when -1 then output.verbosity = :quiet
     when  1 then output.verbosity = :verbose
     when  2 then output.verbosity = :very_verbose
     when  3 then output.verbosity = :debug
-    else
-      shell_verbosity = 0
     end
 
-    if input.has_parameter? "--quiet", "-q", only_params: true
+    if input.has_parameter? "--silent", only_params: true
+      output.verbosity = :silent
+      shell_verbosity = -2
+    elsif input.has_parameter? "--quiet", "-q", only_params: true
       output.verbosity = :quiet
       shell_verbosity = -1
     else
@@ -558,7 +562,7 @@ class Athena::Console::Application
       end
     end
 
-    if -1 == shell_verbosity
+    if 0 > shell_verbosity
       input.interactive = false
     end
 
@@ -667,7 +671,8 @@ class Athena::Console::Application
     ACON::Input::Definition.new(
       ACON::Input::Argument.new("command", :required, "The command to execute"),
       ACON::Input::Option.new("help", "h", description: "Display help for the given command. When no command is given display help for the <info>#{@default_command}</info> command"),
-      ACON::Input::Option.new("quiet", "q", description: "Do not output any message"),
+      ACON::Input::Option.new("silent", description: "Do not output any message"),
+      ACON::Input::Option.new("quiet", "q", description: "Only errors are displayed. All other output is suppressed"),
       ACON::Input::Option.new("verbose", "v|vv|vvv", description: "Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug"),
       ACON::Input::Option.new("version", "V", description: "Display this application version"),
       ACON::Input::Option.new("ansi", value_mode: :negatable, description: "Force (or disable --no-ansi) ANSI output", default: false),

--- a/src/components/console/src/output/null.cr
+++ b/src/components/console/src/output/null.cr
@@ -22,7 +22,7 @@ class Athena::Console::Output::Null
 
   # :inherit:
   def verbosity : ACON::Output::Verbosity
-    ACON::Output::Verbosity::QUIET
+    ACON::Output::Verbosity::SILENT
   end
 
   # :inherit:

--- a/src/components/console/src/output/verbosity.cr
+++ b/src/components/console/src/output/verbosity.cr
@@ -4,6 +4,9 @@
 #
 # ```sh
 # # Output nothing
+# ./console my-command --silent
+#
+# # Output only errors
 # ./console my-command -q
 # ./console my-command --quiet
 #
@@ -42,6 +45,10 @@
 # TIP: The full stack trace of an exception is printed in `ACON::Output::Verbosity::VERBOSE` mode or higher.
 enum Athena::Console::Output::Verbosity
   # Silences all output.
+  # Equivalent to `--silent` CLI option or `SHELL_VERBOSITY=-2`.
+  SILENT = -2
+
+  # Output only errors.
   # Equivalent to `-q`, `--quiet` CLI options or `SHELL_VERBOSITY=-1`.
   QUIET = -1
 


### PR DESCRIPTION
## Context

The previous `--quiet` option suppressed _most_ output but did not include errors. This PR introduces a new `--silent` option to totally ignore _everything_.

## Changelog

* Add `ACON::Output::Verbosity::SILENT` verbosity level
  * Existing commands using a `--silent` option will have to rename it

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
