### PR TITLE
Add request matchers for headers and query parameters

### DIFF
--- a/src/components/framework/spec/request_matcher/header_spec.cr
+++ b/src/components/framework/spec/request_matcher/header_spec.cr
@@ -1,0 +1,21 @@
+require "../spec_helper"
+
+struct HeaderRequestMatcherTest < ASPEC::TestCase
+  @[TestWith(
+    {HTTP::Headers{"x-foo" => "foo", "bar" => "bar", "baz" => "baz"}, true},
+    {HTTP::Headers{"x-foo" => "foo", "bar" => "bar"}, true},
+    {HTTP::Headers{"bar" => "bar", "baz" => "baz"}, false},
+    {HTTP::Headers{"bar" => "bar"}, false},
+    {HTTP::Headers.new, false},
+  )]
+  def test_matches(headers : HTTP::Headers, is_match : Bool) : Nil
+    matcher = ATH::RequestMatcher::Header.new "x-foo", "bar"
+    request = ATH::Request.new "GET", "/"
+
+    headers.each do |k, v|
+      request.headers[k] = v
+    end
+
+    matcher.matches?(request).should eq is_match
+  end
+end

--- a/src/components/framework/spec/request_matcher/query_parameter_spec.cr
+++ b/src/components/framework/spec/request_matcher/query_parameter_spec.cr
@@ -1,0 +1,18 @@
+require "../spec_helper"
+
+struct QueryParameterRequestMatcherTest < ASPEC::TestCase
+  @[TestWith(
+    {"foo=&bar=", true},
+    {"foo=foo1&bar=bar1", true},
+    {"foo=foo1&bar=bar1&baz=baz1", true},
+    {"foo=", false},
+    {"", false},
+  )]
+  def test_matches(query_string : String, is_match : Bool) : Nil
+    matcher = ATH::RequestMatcher::QueryParameter.new "foo", "bar"
+    request = ATH::Request.new "GET", "/"
+    request.query = query_string
+
+    matcher.matches?(request).should eq is_match
+  end
+end

--- a/src/components/framework/src/request_matcher/header.cr
+++ b/src/components/framework/src/request_matcher/header.cr
@@ -1,0 +1,25 @@
+# Checks the presence of HTTP headers in an `ATH::Request`.
+struct Athena::Framework::RequestMatcher::Header
+  include Interface
+
+  @headers : Array(String)
+
+  def self.new(*headers : String)
+    new headers.to_a
+  end
+
+  def initialize(@headers : Array(String)); end
+
+  # :inherit:
+  def matches?(request : ATH::Request) : Bool
+    return true if @headers.empty?
+
+    headers = request.headers
+
+    @headers.each do |header|
+      return false unless headers.has_key? header
+    end
+
+    true
+  end
+end

--- a/src/components/framework/src/request_matcher/query_parameter.cr
+++ b/src/components/framework/src/request_matcher/query_parameter.cr
@@ -1,0 +1,25 @@
+# Checks the presence of HTTP query parameters in an `ATH::Request`.
+struct Athena::Framework::RequestMatcher::QueryParameter
+  include Interface
+
+  @parameters : Array(String)
+
+  def self.new(*parameters : String)
+    new parameters.to_a
+  end
+
+  def initialize(@parameters : Array(String)); end
+
+  # :inherit:
+  def matches?(request : ATH::Request) : Bool
+    return true if @parameters.empty?
+
+    query_params = request.query_params
+
+    @parameters.each do |parameter|
+      return false unless query_params.has_key? parameter
+    end
+
+    true
+  end
+end


### PR DESCRIPTION
## Context

Resolves #437
Resolves #438

## Changelog

* Add request matchers for headers and query parameters

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
