### PR TITLE
Add missing triple backticks to some constraint example codeblocks

### DIFF
--- a/src/components/validator/src/constraints/size.cr
+++ b/src/components/validator/src/constraints/size.cr
@@ -9,6 +9,7 @@
 #   @[Assert::Size(3..30)]
 #   property username : String
 # end
+# ```
 #
 # # Configuration
 #

--- a/src/components/validator/src/constraints/unique.cr
+++ b/src/components/validator/src/constraints/unique.cr
@@ -9,6 +9,7 @@
 #   @[Assert::Unique]
 #   property rooms : Array(String)
 # end
+# ```
 #
 # # Configuration
 #

--- a/src/components/validator/src/constraints/url.cr
+++ b/src/components/validator/src/constraints/url.cr
@@ -13,6 +13,7 @@
 #   @[Assert::URL]
 #   property avatar_url : String
 # end
+# ```
 #
 # # Configuration
 #


### PR DESCRIPTION
## Context

Follow up to #483. Some of the codeblocks were missing the trailing triple backticks, resulting in the code example being formatted incorrectly.

## Changelog

* Add missing triple backticks to some constraint example codeblocks

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
