### PR TITLE
Bump min Crystal version to `~> 1.14` for `framework` component

### DIFF
--- a/src/components/framework/shard.yml
+++ b/src/components/framework/shard.yml
@@ -2,7 +2,7 @@ name: athena
 
 version: 0.19.2
 
-crystal: ~> 1.13
+crystal: ~> 1.14
 
 license: MIT
 


### PR DESCRIPTION
## Context

The `URI::Params::Serializable` feature was added in Crystal `1.14`. As we're now using that via #477 we need to bump the min supported Crystal version for the `framework` component.

## Changelog

* Bump min Crystal version to `~> 1.14` for `framework` component

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
