### PR TITLE
Add initial `docs/README.md` to `mime` component

### DIFF
--- a/src/components/mime/.gitignore
+++ b/src/components/mime/.gitignore
@@ -1,4 +1,3 @@
-/docs/
 /lib/
 /bin/
 /.shards/

--- a/src/components/mime/docs/README.md
+++ b/src/components/mime/docs/README.md
@@ -1,0 +1,16 @@
+The `Athena::MIME` component allows manipulating the MIME messages used to send emails and provides utilities related to MIME types.
+
+## Installation
+
+First, install the component by adding the following to your `shard.yml`, then running `shards install`:
+
+```yaml
+dependencies:
+  athena-mime:
+    github: athena-framework/mime
+    version: ~> 0.1.0
+```
+
+## Usage
+
+TODO: Write me


### PR DESCRIPTION
## Context

Add initial `docs/README.md` to `mime` component. Not having this was preventing the docs CI job from passing. Updated the component template repo to include this so won't happen again in the future.

## Changelog

* Add initial `docs/README.md` to `mime` component

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
