### PR TITLE
Coverage tweaks

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,18 +10,18 @@ function runSpecs() (
 #
 # $1 component name
 function runSpecsWithCoverage() (
+  set -e
   rm -rf "coverage/$1"
   mkdir -p coverage/bin "coverage/$1"
   echo "require \"../../src/components/$1/spec/**\"" > "./coverage/bin/$1.cr" && \
   $CRYSTAL build "${DEFAULT_BUILD_OPTIONS[@]}" "./coverage/bin/$1.cr" -o "./coverage/bin/$1" && \
+  kcov $(if $IS_CI != "true"; then echo "--cobertura-only"; fi) --clean --include-path="./src/components/$1" "./coverage/$1" "./coverage/bin/$1" --junit_output="./coverage/$1/junit.xml" "${DEFAULT_OPTIONS[@]}"
 
-  # Run this first so spec failures are reported as an error.
+  # Scope this to only non-compiled tests as that's all it's relevant for.
   if [ $TYPE != "compiled" ]
   then
     $CRYSTAL tool unreachable --format=codecov "./coverage/bin/$1.cr" > "./coverage/$1/unreachable.codecov.json"
   fi
-
-  kcov $(if $IS_CI != "true"; then echo "--cobertura-only"; fi) --clean --include-path="./src/components/$1" "./coverage/$1" "./coverage/bin/$1" --junit_output="./coverage/$1/junit.xml" "${DEFAULT_OPTIONS[@]}"
 )
 
 DEFAULT_BUILD_OPTIONS=(-Dstrict_multi_assign -Dpreview_overload_order --error-on-warnings)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,6 +10,7 @@ function runSpecs() (
 #
 # $1 component name
 function runSpecsWithCoverage() (
+  rm -rf "coverage/$1"
   mkdir -p coverage/bin "coverage/$1"
   echo "require \"../../src/components/$1/spec/**\"" > "./coverage/bin/$1.cr" && \
   $CRYSTAL build "${DEFAULT_BUILD_OPTIONS[@]}" "./coverage/bin/$1.cr" -o "./coverage/bin/$1" && \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,11 +14,11 @@ function runSpecsWithCoverage() (
   mkdir -p coverage/bin
   echo "require \"../../src/components/$1/spec/**\"" > "./coverage/bin/$1.cr" && \
   $CRYSTAL build "${DEFAULT_BUILD_OPTIONS[@]}" "./coverage/bin/$1.cr" -o "./coverage/bin/$1" && \
-  kcov $(if $IS_CI != "true"; then echo "--cobertura-only"; fi) --clean --include-path="./src/components/$1/src" "./coverage/$1" "./coverage/bin/$1" --junit_output="./coverage/$1/junit.xml" "${DEFAULT_OPTIONS[@]}"
+  kcov $(if $IS_CI != "true"; then echo "--cobertura-only"; fi) --clean --include-path="./src/components/$1" "./coverage/$1" "./coverage/bin/$1" --junit_output="./coverage/$1/junit.xml" "${DEFAULT_OPTIONS[@]}"
 
   # We're using nightly Crystal to have access to this for now.
   # When Crystal 1.15 releases, make this no longer scoped to $IS_CI as local `crystal` will also have it.
-  if [ $IS_CI = "true" ] && [ $TYPE != "compiled" ]
+  if [ $TYPE != "compiled" ]
   then
     $CRYSTAL tool unreachable --format=codecov "./coverage/bin/$1.cr" > "./coverage/$1/unreachable.codecov.json"
   fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,18 +10,17 @@ function runSpecs() (
 #
 # $1 component name
 function runSpecsWithCoverage() (
-  set -e
-  mkdir -p coverage/bin
+  mkdir -p coverage/bin "coverage/$1"
   echo "require \"../../src/components/$1/spec/**\"" > "./coverage/bin/$1.cr" && \
   $CRYSTAL build "${DEFAULT_BUILD_OPTIONS[@]}" "./coverage/bin/$1.cr" -o "./coverage/bin/$1" && \
-  kcov $(if $IS_CI != "true"; then echo "--cobertura-only"; fi) --clean --include-path="./src/components/$1" "./coverage/$1" "./coverage/bin/$1" --junit_output="./coverage/$1/junit.xml" "${DEFAULT_OPTIONS[@]}"
 
-  # We're using nightly Crystal to have access to this for now.
-  # When Crystal 1.15 releases, make this no longer scoped to $IS_CI as local `crystal` will also have it.
+  # Run this first so spec failures are reported as an error.
   if [ $TYPE != "compiled" ]
   then
     $CRYSTAL tool unreachable --format=codecov "./coverage/bin/$1.cr" > "./coverage/$1/unreachable.codecov.json"
   fi
+
+  kcov $(if $IS_CI != "true"; then echo "--cobertura-only"; fi) --clean --include-path="./src/components/$1" "./coverage/$1" "./coverage/bin/$1" --junit_output="./coverage/$1/junit.xml" "${DEFAULT_OPTIONS[@]}"
 )
 
 DEFAULT_BUILD_OPTIONS=(-Dstrict_multi_assign -Dpreview_overload_order --error-on-warnings)

--- a/src/components/clock/spec/aware_spec.cr
+++ b/src/components/clock/spec/aware_spec.cr
@@ -1,0 +1,14 @@
+require "./spec_helper"
+
+private class Example
+  include Athena::Clock::Aware
+end
+
+struct AwareTest < ASPEC::TestCase
+  def test_happy_path : Nil
+    instance = Example.new
+    instance.now.should_not be_nil
+    instance.clock = ACLK::Spec::MockClock.new Time.utc 2023, 9, 16, 23, 53, 0
+    instance.now.should eq Time.utc(2023, 9, 16, 23, 53, 0)
+  end
+end

--- a/src/components/clock/src/aware.cr
+++ b/src/components/clock/src/aware.cr
@@ -21,9 +21,9 @@ class Athena::Clock; end
 module Athena::Clock::Aware
   # TODO: Wire this up with an `@[ADI::Required]` annotation.
 
-  setter clock : ACLK? = nil
+  setter clock : ACLK::Interface? = nil
 
-  def now : ACLK::Interface
+  def now : ::Time
     (@clock ||= ACLK.new).now
   end
 end

--- a/src/components/console/spec/application_spec.cr
+++ b/src/components/console/spec/application_spec.cr
@@ -28,6 +28,12 @@ struct ApplicationTest < ASPEC::TestCase
     end
   end
 
+  def test_defaults : Nil
+    application = ACON::Application.new "foo", "1.0.0"
+    application.auto_exit?.should be_true
+    application.catch_exceptions?.should be_true
+  end
+
   def test_long_version : Nil
     ACON::Application.new("foo", "1.2.3").long_version.should eq "foo <info>1.2.3</info>"
   end

--- a/src/components/console/spec/command_tester_spec.cr
+++ b/src/components/console/spec/command_tester_spec.cr
@@ -187,16 +187,11 @@ struct CommandTesterTest < ASPEC::TestCase
 
   def test_error_output : Nil
     command = ACON::Commands::Generic.new "foo" do |_, output|
-      output.as(ACON::Output::ConsoleOutput).error_output.print "foo"
-
-      ACON::Command::Status::SUCCESS
+      ACON::Command::Status::FAILURE
     end
-    command.argument "command"
-    command.argument "foo"
 
     tester = ACON::Spec::CommandTester.new command
-    tester.execute foo: "bar", capture_stderr_separately: true
-
-    tester.error_output.should eq "foo"
+    tester.execute
+    tester.assert_command_is_not_successful
   end
 end

--- a/src/components/console/spec/command_tester_spec.cr
+++ b/src/components/console/spec/command_tester_spec.cr
@@ -186,7 +186,7 @@ struct CommandTesterTest < ASPEC::TestCase
   end
 
   def test_error_output : Nil
-    command = ACON::Commands::Generic.new "foo" do |_, output|
+    command = ACON::Commands::Generic.new "foo" do |_, _|
       ACON::Command::Status::FAILURE
     end
 

--- a/src/components/console/spec/command_tester_spec.cr
+++ b/src/components/console/spec/command_tester_spec.cr
@@ -186,6 +186,21 @@ struct CommandTesterTest < ASPEC::TestCase
   end
 
   def test_error_output : Nil
+    command = ACON::Commands::Generic.new "foo" do |_, output|
+      output.as(ACON::Output::ConsoleOutput).error_output.print "foo"
+
+      ACON::Command::Status::SUCCESS
+    end
+    command.argument "command"
+    command.argument "foo"
+
+    tester = ACON::Spec::CommandTester.new command
+    tester.execute foo: "bar", capture_stderr_separately: true
+
+    tester.error_output.should eq "foo"
+  end
+
+  def test_assert_command_is_not_successful : Nil
     command = ACON::Commands::Generic.new "foo" do |_, _|
       ACON::Command::Status::FAILURE
     end

--- a/src/components/console/spec/commands/list_spec.cr
+++ b/src/components/console/spec/commands/list_spec.cr
@@ -83,6 +83,16 @@ struct ListCommandTest < ASPEC::TestCase
     suggestions.should eq expected_suggestions
   end
 
+  def test_complete_var_arg : Nil
+    app = ACON::Application.new "foo"
+    app.add FooCommand.new
+
+    ACON::Spec::CommandCompletionTester
+      .new(app.get "list")
+      .complete("--format")
+      .should eq ["txt"]
+  end
+
   def complete_provider : Hash
     {
       "--format option"   => {["--format"], ["txt"]},

--- a/src/components/console/spec/completion/input_spec.cr
+++ b/src/components/console/spec/completion/input_spec.cr
@@ -18,6 +18,7 @@ struct CompletionInputTest < ASPEC::TestCase
     input.completion_type.should eq expected_type
     input.completion_name.should eq expected_name
     input.completion_value.should eq expected_value
+    input.must_suggest_option_values_for?("with-required-value").should be_true if expected_value.starts_with? "athe"
   end
 
   def bind_data_provider : Hash
@@ -56,9 +57,9 @@ struct CompletionInputTest < ASPEC::TestCase
   end
 
   @[DataProvider("last_array_argument_provider")]
-  def tets_bind_with_last_array_argument(input : Input, expected_value : String?) : Nil
+  def test_bind_with_last_array_argument(input : Input, expected_value : String?) : Nil
     definition = ACON::Input::Definition.new(
-      ACON::Input::Argument.new("list-arg", Input::Type[:required, :is_array]),
+      ACON::Input::Argument.new("list-arg", ACON::Input::Argument::Mode[:required, :is_array]),
     )
 
     input.bind definition
@@ -70,8 +71,8 @@ struct CompletionInputTest < ASPEC::TestCase
 
   def last_array_argument_provider : Tuple
     {
-      {Input.from_tokens([] of String, 0), nil},
-      {Input.from_tokens(["athena", "crystal"], 2), nil},
+      {Input.from_tokens([] of String, 0), ""},
+      {Input.from_tokens(["athena", "crystal"], 2), ""},
       {Input.from_tokens(["athena", "cry"], 1), "cry"},
     }
   end
@@ -87,6 +88,7 @@ struct CompletionInputTest < ASPEC::TestCase
     input.completion_type.should eq Input::Type::ARGUMENT_VALUE
     input.completion_name.should eq "arg-with-default"
     input.completion_value.should eq ""
+    input.must_suggest_argument_values_for?("arg-with-default").should be_true
   end
 
   @[DataProvider("from_string_provider")]

--- a/src/components/console/spec/cursor_spec.cr
+++ b/src/components/console/spec/cursor_spec.cr
@@ -64,6 +64,16 @@ struct CursorTest < ASPEC::TestCase
     @output.to_s.should eq "\x1b[2K"
   end
 
+  def test_clear_line_after : Nil
+    @cursor.clear_line_after
+    @output.to_s.should eq "\x1b[K"
+  end
+
+  def test_clear_screen : Nil
+    @cursor.clear_screen
+    @output.to_s.should eq "\x1b[2J"
+  end
+
   def test_save_position : Nil
     @cursor.save_position
     @output.to_s.should eq "\x1b7"

--- a/src/components/console/spec/formatter/null_spec.cr
+++ b/src/components/console/spec/formatter/null_spec.cr
@@ -1,0 +1,11 @@
+require "../spec_helper"
+
+struct NullFormatterTest < ASPEC::TestCase
+  def test_has_style : Nil
+    ACON::Formatter::Null.new.has_style?("error").should be_false
+  end
+
+  def test_style : Nil
+    ACON::Formatter::Null.new.style("error").should be_a ACON::Formatter::NullStyle
+  end
+end

--- a/src/components/console/spec/formatter/null_style_spec.cr
+++ b/src/components/console/spec/formatter/null_style_spec.cr
@@ -5,7 +5,7 @@ struct NullStyleTest < ASPEC::TestCase
     ACON::Formatter::NullStyle.new.apply("foo").should eq "foo"
   end
 
-  def test_set_forground : Nil
+  def test_set_foreground : Nil
     style = ACON::Formatter::NullStyle.new
     style.foreground = :red
     style.apply("foo").should eq "foo"

--- a/src/components/console/spec/formatter/null_style_spec.cr
+++ b/src/components/console/spec/formatter/null_style_spec.cr
@@ -1,0 +1,29 @@
+require "../spec_helper"
+
+struct NullStyleTest < ASPEC::TestCase
+  def test_apply : Nil
+    ACON::Formatter::NullStyle.new.apply("foo").should eq "foo"
+  end
+
+  def test_set_forground : Nil
+    style = ACON::Formatter::NullStyle.new
+    style.foreground = :red
+    style.apply("foo").should eq "foo"
+  end
+
+  def test_set_background : Nil
+    style = ACON::Formatter::NullStyle.new
+    style.background = :red
+    style.apply("foo").should eq "foo"
+  end
+
+  def test_options : Nil
+    style = ACON::Formatter::NullStyle.new
+
+    style.add_option :bold
+    style.apply("foo").should eq "foo"
+
+    style.remove_option :bold
+    style.apply("foo").should eq "foo"
+  end
+end

--- a/src/components/console/spec/helper/progress_bar_spec.cr
+++ b/src/components/console/spec/helper/progress_bar_spec.cr
@@ -386,6 +386,16 @@ struct ProgressBarTest < ASPEC::TestCase
     )
   end
 
+  def test_message : Nil
+    bar = ACON::Helper::ProgressBar.new self.output, minimum_seconds_between_redraws: 0
+    bar.message.should be_nil
+    bar.set_message "other message", "other-message"
+    bar.set_message "my message"
+
+    bar.message.should eq "my message"
+    bar.message("other-message").should eq "other message"
+  end
+
   def test_overwrite_with_new_lines_in_message : Nil
     ACON::Helper::ProgressBar.set_format_definition "test", "%current%/%max% [%bar%] %percent:3s%% %message% EXISTING TEXT."
 

--- a/src/components/console/spec/helper/progress_indicator_spec.cr
+++ b/src/components/console/spec/helper/progress_indicator_spec.cr
@@ -15,7 +15,7 @@ struct ProgressIndicatorTest < ASPEC::TestCase
 
     ACON::Helper::ProgressIndicator
       .placeholder_formatter("custom-message")
-      .try(&.call(ACON::Helper::ProgressIndicator.new output = self.output(decorated: false)))
+      .try(&.call(ACON::Helper::ProgressIndicator.new self.output(decorated: false)))
       .should eq "My Custom Message"
   end
 

--- a/src/components/console/spec/helper/progress_indicator_spec.cr
+++ b/src/components/console/spec/helper/progress_indicator_spec.cr
@@ -7,6 +7,18 @@ struct ProgressIndicatorTest < ASPEC::TestCase
     @clock = ACLK::Spec::MockClock.new
   end
 
+  def test_set_placeholder_formatter : Nil
+    ACON::Helper::ProgressIndicator.set_placeholder_formatter "custom-message" do
+      # Return any arbitrary string
+      "My Custom Message"
+    end
+
+    ACON::Helper::ProgressIndicator
+      .placeholder_formatter("custom-message")
+      .try(&.call(ACON::Helper::ProgressIndicator.new output = self.output(decorated: false)))
+      .should eq "My Custom Message"
+  end
+
   def test_default_indicator : Nil
     indicator = ACON::Helper::ProgressIndicator.new output = self.output, clock: @clock
 
@@ -131,10 +143,6 @@ struct ProgressIndicatorTest < ASPEC::TestCase
     indicator.advance
 
     output.io.to_s.should_not be_empty
-  end
-
-  private def output(decorated : Bool = true, verbosity : ACON::Output::Verbosity = :normal) : ACON::Output::Interface
-    ACON::Output::IO.new IO::Memory.new, decorated: decorated, verbosity: verbosity
   end
 
   private def generate_output(expected : String) : String

--- a/src/components/console/spec/helper/table_spec.cr
+++ b/src/components/console/spec/helper/table_spec.cr
@@ -460,9 +460,8 @@ struct TableSpec < ASPEC::TestCase
     }
   end
 
-  @[Pending]
   # TODO: Enable when multi byte string widths are supported
-  def test_render_multi_byte : Nil
+  def ptest_render_multi_byte : Nil
     table = ACON::Helper::Table.new output = self.io_output
     table
       .headers(["🍝"])

--- a/src/components/console/spec/helper/table_style_spec.cr
+++ b/src/components/console/spec/helper/table_style_spec.cr
@@ -1,0 +1,33 @@
+require "../spec_helper"
+
+struct TableStyleSpec < ASPEC::TestCase
+  def test_getter_setters : Nil
+    style = ACON::Helper::Table::Style
+      .new
+      .align(:right)
+      .border_format("BF")
+      .padding_char('c')
+      .header_title_format("HTF")
+      .footer_title_format("FTF")
+      .cell_header_format("CHF")
+      .cell_row_format("CRF")
+      .cell_row_content_format("CRCF")
+      .horizontal_border_chars('o', 'i')
+      .vertical_border_chars('v', 'u')
+      .default_crossing_char('x')
+
+    style.align.should eq ACON::Helper::Table::Alignment::RIGHT
+    style.border_format.should eq "BF"
+    style.padding_char.should eq 'c'
+    style.header_title_format.should eq "HTF"
+    style.footer_title_format.should eq "FTF"
+    style.cell_header_format.should eq "CHF"
+    style.cell_row_format.should eq "CRF"
+    style.cell_row_content_format.should eq "CRCF"
+    style.border_chars.should eq({"o", "v", "i", "u"})
+    style.crossing_chars.should eq({"x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x"})
+
+    style.crossing_chars("c", "tl", "tm", "tr", "mr", "br", "bm", "bl", "ml", "tlb", "tmb", "trb")
+    style.crossing_chars.should eq({"c", "tl", "tm", "tr", "mr", "br", "bm", "bl", "ml", "tlb", "tmb", "trb"})
+  end
+end

--- a/src/components/console/spec/input/value/array_spec.cr
+++ b/src/components/console/spec/input/value/array_spec.cr
@@ -1,139 +1,41 @@
 require "../../spec_helper"
 
-describe ACON::Input::Value::Number do
+describe ACON::Input::Value::Array do
+  describe ".new" do
+    it "without args" do
+      array = ACON::Input::Value::Array.new
+      array.value.should be_empty
+      array.should be_empty
+    end
+
+    it "with args" do
+      array = ACON::Input::Value::Array.from_array [1, "foo", false]
+      array.value.size.should eq 3
+      array << 10
+      array.value.size.should eq 4
+    end
+  end
+
+  it "#to_s" do
+    ACON::Input::Value::Array
+      .from_array([1, "foo", false])
+      .to_s
+      .should eq %(1,foo,false)
+  end
+
   describe "#get" do
-    describe Bool do
-      it "non-nilable" do
-        expect_raises ACON::Exception::Logic, "'123' is not a valid 'Bool'." do
-          ACON::Input::Value::Number.new(123).get Bool
-        end
-      end
-
-      it "nilable" do
-        expect_raises ACON::Exception::Logic, "'123' is not a valid '(Bool | Nil)'." do
-          ACON::Input::Value::Number.new(123).get Bool?
-        end
-      end
+    it "non-nilable" do
+      ACON::Input::Value::Array
+        .from_array(arr = [1, 2, 3])
+        .get(Array(Int32))
+        .should eq arr
     end
 
-    describe String do
-      it "non-nilable" do
-        val = ACON::Input::Value::Number.new(123).get String
-        typeof(val).should eq String
-        val.should eq "123"
-      end
-
-      it "nilable" do
-        val = ACON::Input::Value::Number.new(123).get String?
-        typeof(val).should eq String?
-        val.should eq "123"
-      end
-    end
-
-    describe Int do
-      it "non-nilable" do
-        val = ACON::Input::Value::Number.new(123).get Int32
-        typeof(val).should eq Int32
-        val.should eq 123
-
-        val = ACON::Input::Value::Number.new(123_u8).get UInt8
-        typeof(val).should eq UInt8
-        val.should eq 123_u8
-      end
-
-      it "non-nilable" do
-        val = ACON::Input::Value::Number.new(123).get Int32?
-        typeof(val).should eq Int32?
-        val.should eq 123
-
-        val = ACON::Input::Value::Number.new(123_u8).get UInt8?
-        typeof(val).should eq UInt8?
-        val.should eq 123_u8
-      end
-    end
-
-    describe Float do
-      it "non-nilable" do
-        val = ACON::Input::Value::Number.new(4.69).get Float32
-        typeof(val).should eq Float32
-        val.should eq 4.69_f32
-
-        val = ACON::Input::Value::Number.new(4.69).get Float64
-        typeof(val).should eq Float64
-        val.should eq 4.69
-      end
-
-      it "non-nilable" do
-        val = ACON::Input::Value::Number.new(4.69).get Float32?
-        typeof(val).should eq Float32?
-        val.should eq 4.69_f32
-
-        val = ACON::Input::Value::Number.new(4.69).get Float64?
-        typeof(val).should eq Float64?
-        val.should eq 4.69
-      end
-    end
-
-    describe Array do
-      describe String do
-        it "non-nilable" do
-          expect_raises ACON::Exception::Logic, "'123' is not a valid 'Array(String)'." do
-            ACON::Input::Value::Number.new(123).get Array(String)
-          end
-        end
-
-        it "nilable" do
-          expect_raises ACON::Exception::Logic, "'123' is not a valid '(Array(String) | Nil)'." do
-            ACON::Input::Value::Number.new(123).get Array(String)?
-          end
-        end
-
-        it "nilable generic value" do
-          expect_raises ACON::Exception::Logic, "'123' is not a valid '(Array(String | Nil) | Nil)'." do
-            ACON::Input::Value::Number.new(123).get Array(String?)?
-          end
-        end
-      end
-
-      describe Int32 do
-        it "non-nilable" do
-          expect_raises ACON::Exception::Logic, "'123' is not a valid 'Array(Int32)'." do
-            ACON::Input::Value::Number.new(123).get Array(Int32)
-          end
-        end
-
-        it "nilable" do
-          expect_raises ACON::Exception::Logic, "'123' is not a valid '(Array(Int32) | Nil)'." do
-            ACON::Input::Value::Number.new(123).get Array(Int32)?
-          end
-        end
-
-        it "nilable generic value" do
-          expect_raises ACON::Exception::Logic, "'123' is not a valid '(Array(Int32 | Nil) | Nil)'." do
-            ACON::Input::Value::Number.new(123).get Array(Int32?)?
-          end
-        end
-      end
-
-      describe Bool do
-        it "non-nilable" do
-          expect_raises ACON::Exception::Logic, "'123' is not a valid 'Array(Bool)'." do
-            ACON::Input::Value::Number.new(123).get Array(Bool)
-          end
-        end
-
-        it "nilable" do
-          expect_raises ACON::Exception::Logic, "'123' is not a valid '(Array(Bool) | Nil)'." do
-            ACON::Input::Value::Number.new(123).get Array(Bool)?
-          end
-        end
-
-        it "nilable generic value" do
-          expect_raises ACON::Exception::Logic, "'123' is not a valid '(Array(Bool | Nil) | Nil)'." do
-            ACON::Input::Value::Number.new(123).get Array(Bool?)?
-          end
-        end
-      end
+    it "nilable" do
+      ACON::Input::Value::Array
+        .from_array(arr = ["foo", "bar"])
+        .get(Array(String)?)
+        .should eq arr
     end
   end
 end

--- a/src/components/console/spec/output/console_section_output_spec.cr
+++ b/src/components/console/spec/output/console_section_output_spec.cr
@@ -96,6 +96,9 @@ struct ConsoleSectionOutputTest < ASPEC::TestCase
     output.clear
     expected << "\e[1A\e[0J"
 
+    output.overwrite "biz", "baz"
+    expected << "biz" << EOL << "baz" << EOL
+
     @io.to_s.should eq expected.to_s
   end
 

--- a/src/components/console/spec/output/io_spec.cr
+++ b/src/components/console/spec/output/io_spec.cr
@@ -14,7 +14,15 @@ struct IOTest < ASPEC::TestCase
   def test_do_write : Nil
     output = ACON::Output::IO.new @io
     output.puts "foo"
-    output.to_s.should eq "foo#{EOL}"
+    output.print "bar"
+    output.to_s.should eq "foo#{EOL}bar"
+  end
+
+  def test_do_write_var_args : Nil
+    output = ACON::Output::IO.new @io
+    output.puts "foo", "bar"
+    output.print "biz", "baz"
+    output.to_s.should eq "foo#{EOL}bar#{EOL}bizbaz"
   end
 
   def test_decorated_dumb_term : Nil

--- a/src/components/console/spec/output/null_spec.cr
+++ b/src/components/console/spec/output/null_spec.cr
@@ -6,6 +6,9 @@ struct NullSpec < ASPEC::TestCase
   end
 
   def test_formatter : Nil
-    ACON::Output::Null.new.formatter.should be_a ACON::Formatter::Null
+    output = ACON::Output::Null.new
+    output.formatter.should be_a ACON::Formatter::Null
+    output.formatter = ACON::Formatter::Output.new
+    output.formatter.should be_a ACON::Formatter::Null
   end
 end

--- a/src/components/console/spec/output/output_spec.cr
+++ b/src/components/console/spec/output/output_spec.cr
@@ -50,7 +50,9 @@ struct OutputTest < ASPEC::TestCase
   def test_write_decorated : Nil
     foo_style = ACON::Formatter::OutputStyle.new :yellow, :red, :blink
     output = MockOutput.new
+    output.formatter.has_style?("FOO").should be_false
     output.formatter.set_style "FOO", foo_style
+    output.formatter.has_style?("FOO").should be_true
     output.decorated = true
     output.puts "<foo>foo</foo>"
     output.output.should eq "\e[33;41;5mfoo\e[0m\n"

--- a/src/components/console/spec/question/choice_spec.cr
+++ b/src/components/console/spec/question/choice_spec.cr
@@ -7,6 +7,29 @@ struct ChoiceQuestionTest < ASPEC::TestCase
     end
   end
 
+  def test_custom_validator : Nil
+    question = ACON::Question::Choice.new(
+      "A question",
+      [
+        "First response",
+        "Second response",
+        "Third response",
+        "Fourth response",
+      ]
+    )
+
+    question.validator do
+      "FOO"
+    end
+
+    {"First response", "First response ", " First response", " First response "}.each do |answer|
+      validator = question.validator.not_nil!
+      actual = validator.call answer
+
+      actual.should eq "FOO"
+    end
+  end
+
   def test_validator_exact_match : Nil
     question = ACON::Question::Choice.new(
       "A question",

--- a/src/components/console/spec/question/choice_spec.cr
+++ b/src/components/console/spec/question/choice_spec.cr
@@ -23,10 +23,11 @@ struct ChoiceQuestionTest < ASPEC::TestCase
     end
 
     {"First response", "First response ", " First response", " First response "}.each do |answer|
-      validator = question.validator.not_nil!
-      actual = validator.call answer
+      if validator = question.validator
+        actual = validator.call answer
 
-      actual.should eq "FOO"
+        actual.should eq "FOO"
+      end
     end
   end
 
@@ -42,10 +43,9 @@ struct ChoiceQuestionTest < ASPEC::TestCase
     )
 
     {"First response", "First response ", " First response", " First response "}.each do |answer|
-      validator = question.validator.not_nil!
-      actual = validator.call answer
-
-      actual.should eq "First response"
+      if validator = question.validator
+        validator.call(answer).should eq "First response"
+      end
     end
   end
 
@@ -61,10 +61,9 @@ struct ChoiceQuestionTest < ASPEC::TestCase
     )
 
     {"0"}.each do |answer|
-      validator = question.validator.not_nil!
-      actual = validator.call answer
-
-      actual.should eq "First response"
+      if validator = question.validator
+        validator.call(answer).should eq "First response"
+      end
     end
   end
 
@@ -80,7 +79,9 @@ struct ChoiceQuestionTest < ASPEC::TestCase
 
     question.trimmable = false
 
-    question.validator.not_nil!.call("  Third response  ").should eq "  Third response  "
+    if validator = question.validator
+      validator.not_nil!.call("  Third response  ").should eq "  Third response  "
+    end
   end
 
   @[DataProvider("hash_choice_provider")]
@@ -94,7 +95,9 @@ struct ChoiceQuestionTest < ASPEC::TestCase
       }
     )
 
-    question.validator.not_nil!.call(answer).should eq expected
+    if validator = question.validator
+      validator.call(answer).should eq expected
+    end
   end
 
   def hash_choice_provider : Hash

--- a/src/components/console/spec/question/question_spec.cr
+++ b/src/components/console/spec/question/question_spec.cr
@@ -1,5 +1,20 @@
 require "../spec_helper"
 
+private class QuestionCommand < ACON::Command
+  protected def configure : Nil
+    self
+      .name("question:command")
+  end
+
+  protected def execute(input : ACON::Input::Interface, output : ACON::Output::Interface) : ACON::Command::Status
+    name = self.helper(ACON::Helper::Question).ask input, output, ACON::Question(String?).new "What is your name?", nil
+
+    output.puts "Your name is: #{name}"
+
+    ACON::Command::Status::SUCCESS
+  end
+end
+
 struct QuestionTest < ASPEC::TestCase
   @question : ACON::Question(String?)
 
@@ -50,5 +65,24 @@ struct QuestionTest < ASPEC::TestCase
         ["b", "d"],
       },
     }
+  end
+
+  def test_custom_normalizer : Nil
+    question = ACON::Question(String?).new "A question", nil
+
+    question.normalizer do |val|
+      val.try &.upcase
+    end
+
+    question.normalizer.not_nil!.call("foo").should eq "FOO"
+  end
+
+  def test_with_inputs : Nil
+    command = QuestionCommand.new
+    command.helper_set = ACON::Helper::HelperSet.new ACON::Helper::Question.new
+    tester = ACON::Spec::CommandTester.new command
+    tester.inputs "Jim"
+    tester.execute
+    tester.display.should eq "What is your name?Your name is: Jim\n"
   end
 end

--- a/src/components/console/spec/question/question_spec.cr
+++ b/src/components/console/spec/question/question_spec.cr
@@ -68,13 +68,15 @@ struct QuestionTest < ASPEC::TestCase
   end
 
   def test_custom_normalizer : Nil
-    question = ACON::Question(String?).new "A question", nil
+    question = ACON::Question(String).new "A question", ""
 
     question.normalizer do |val|
-      val.try &.upcase
+      val.upcase
     end
 
-    question.normalizer.not_nil!.call("foo").should eq "FOO"
+    if normalizer = question.normalizer
+      normalizer.call("foo").should eq "FOO"
+    end
   end
 
   def test_with_inputs : Nil
@@ -83,6 +85,6 @@ struct QuestionTest < ASPEC::TestCase
     tester = ACON::Spec::CommandTester.new command
     tester.inputs "Jim"
     tester.execute
-    tester.display.should eq "What is your name?Your name is: Jim\n"
+    tester.display.should eq "What is your name?Your name is: Jim#{EOL}"
   end
 end

--- a/src/components/console/spec/style/athena_style_spec.cr
+++ b/src/components/console/spec/style/athena_style_spec.cr
@@ -443,7 +443,7 @@ struct AthenaStyleTest < ASPEC::TestCase
     style = ACON::Style::Athena.new ACON::Input::Hash.new({} of String => String), output
 
     style.progress_start 123
-    bar = style.@progress_bar.not_nil!
+    bar = style.progress_bar.not_nil!
     bar.max_steps.should eq 123
     bar.progress.should eq 0
 

--- a/src/components/console/spec/style/athena_style_spec.cr
+++ b/src/components/console/spec/style/athena_style_spec.cr
@@ -432,14 +432,14 @@ struct AthenaStyleTest < ASPEC::TestCase
   end
 
   def test_customize_formatter : Nil
-    output = ACON::Output::IO.new io = IO::Memory.new
+    output = ACON::Output::IO.new IO::Memory.new
     style = ACON::Style::Athena.new ACON::Input::Hash.new({} of String => String), output
 
     style.formatter = ACON::Formatter::Null.new
   end
 
   def test_progress_bar : Nil
-    output = ACON::Output::IO.new io = IO::Memory.new
+    output = ACON::Output::IO.new IO::Memory.new
     style = ACON::Style::Athena.new ACON::Input::Hash.new({} of String => String), output
 
     style.progress_start 123

--- a/src/components/console/spec/style/athena_style_spec.cr
+++ b/src/components/console/spec/style/athena_style_spec.cr
@@ -173,6 +173,19 @@ struct AthenaStyleTest < ASPEC::TestCase
         end),
         "style/non_interactive_question.txt",
       },
+      "non-hidden questions do not output anything when input is non-interactive" => {
+        (ACON::Commands::Generic::Proc.new do |input, output|
+          style = ACON::Style::Athena.new input, output
+          style.title "Title"
+          style.ask "Hidden question", nil
+          style.choice "Choice question with default", {"choice1", "choice2"}, "choice1"
+          style.confirm "Confirmation with yes default", true
+          style.text "Duis aute irure dolor in reprehenderit in voluptate velit esse"
+
+          ACON::Command::Status::SUCCESS
+        end),
+        "style/non_interactive_question.txt",
+      },
       # TODO: Test table formatting with multiple headers + TableCell
       "Lines are aligned to the beginning of the first line in a multi-line block" => {
         (ACON::Commands::Generic::Proc.new do |input, output|
@@ -416,5 +429,36 @@ struct AthenaStyleTest < ASPEC::TestCase
 
     tester.execute interactive: false, decorated: false
     self.assert_file_equals_string "style/table_vertical.txt", tester.display true
+  end
+
+  def test_customize_formatter : Nil
+    output = ACON::Output::IO.new io = IO::Memory.new
+    style = ACON::Style::Athena.new ACON::Input::Hash.new({} of String => String), output
+
+    style.formatter = ACON::Formatter::Null.new
+  end
+
+  def test_progress_bar : Nil
+    output = ACON::Output::IO.new io = IO::Memory.new
+    style = ACON::Style::Athena.new ACON::Input::Hash.new({} of String => String), output
+
+    style.progress_start 123
+    bar = style.@progress_bar.not_nil!
+    bar.max_steps.should eq 123
+    bar.progress.should eq 0
+
+    style.progress_advance 4
+    bar.progress.should eq 4
+
+    style.progress_finish
+
+    style.progress_iterate([1, 2, 3]) { }
+
+    output = output.to_s
+    output.should contain "0/123"
+    output.should contain "123/123"
+
+    output.should contain "0/3"
+    output.should contain "3/3"
   end
 end

--- a/src/components/console/src/completion/input.cr
+++ b/src/components/console/src/completion/input.cr
@@ -102,11 +102,11 @@ class Athena::Console::Completion::Input < Athena::Console::Input::ARGV
       argument_value = @arguments[arg_name]
       @completion_name = arg_name
 
-      if argument_value.is_a? Array
-        @completion_value = argument_value.empty? ? "" : argument_value.last.to_s
-      else
-        @completion_value = argument_value.to_s
-      end
+      @completion_value = if argument_value.is_a?(Array) || argument_value.is_a?(ACON::Input::Value::Array)
+                            argument_value.empty? ? "" : argument_value.last.to_s
+                          else
+                            argument_value.to_s
+                          end
     end
 
     if @current_index >= @tokens.size
@@ -123,7 +123,7 @@ class Athena::Console::Completion::Input < Athena::Console::Input::ARGV
   end
 
   # Returns `true` if this input is able to suggest values for the provided *option_name*.
-  def must_suggest_values_for?(option_name : String) : Bool
+  def must_suggest_option_values_for?(option_name : String) : Bool
     @completion_type.option_value? && option_name == @completion_name
   end
 

--- a/src/components/console/src/formatter/null.cr
+++ b/src/components/console/src/formatter/null.cr
@@ -4,7 +4,7 @@ require "./interface"
 class Athena::Console::Formatter::Null
   include Athena::Console::Formatter::Interface
 
-  @style : ACON::Formatter::OutputStyle? = nil
+  @style : ACON::Formatter::NullStyle? = nil
 
   def decorated=(@decorated : Bool)
   end

--- a/src/components/console/src/helper/table_style.cr
+++ b/src/components/console/src/helper/table_style.cr
@@ -66,8 +66,6 @@ class Athena::Console::Helper::Table::Style
   # +-----+
   # ```
   def padding_char(char : Char) : self
-    raise ACON::Exception::Logic.new "The padding char cannot be empty" if char.empty?
-
     @padding_char = char
 
     self

--- a/src/components/console/src/input/value/array.cr
+++ b/src/components/console/src/input/value/array.cr
@@ -23,18 +23,29 @@ struct Athena::Console::Input::Value::Array < Athena::Console::Input::Value
   end
 
   def get(type : ::Array(T).class) : ::Array(T) forall T
-    @value.map &.get(T)
+    arr = ::Array(T).new
+
+    @value.each do |v|
+      arr << v.get T
+    end
+
+    arr
   end
 
   def get(type : ::Array(T)?.class) : ::Array(T)? forall T
-    @value.map(&.get(T)) || nil
-  end
+    arr = ::Array(T).new
 
-  def resolve
-    self.value.map &.resolve
+    @value.each do |v|
+      arr << v.get T
+    end
+
+    arr || nil
   end
 
   def to_s(io : IO) : ::Nil
     @value.join io, ','
   end
+
+  # :nodoc:
+  forward_missing_to @value
 end

--- a/src/components/console/src/input/value/value.cr
+++ b/src/components/console/src/input/value/value.cr
@@ -21,7 +21,7 @@ abstract struct Athena::Console::Input::Value
     self.to_s.presence
   end
 
-  def get(type : T.class) : NoReturn forall T
+  def get(type : T.class) forall T
     raise ACON::Exception::Logic.new "'#{self.value}' is not a valid '#{T}'."
   end
 

--- a/src/components/console/src/spec.cr
+++ b/src/components/console/src/spec.cr
@@ -52,6 +52,11 @@ module Athena::Console::Spec
       self.status.should ACON::Spec::Expectations::CommandIsSuccessful.new, file: file, line: line, failure_message: message.presence
     end
 
+    # Asserts that the return `#status` is _NOT_ successful.
+    def assert_command_is_not_successful(message : String = "", *, file : String = __FILE__, line : Int32 = __LINE__) : Nil
+      self.status.should_not ACON::Spec::Expectations::CommandIsSuccessful.new, file: file, line: line, failure_message: message.presence
+    end
+
     protected def init_output(
       decorated : Bool? = nil,
       interactive : Bool? = nil,
@@ -316,7 +321,7 @@ module Athena::Console::Spec
     end
 
     def complete(input : Enumerable(String)) : Array(String)
-      completion_input = ACON::Completion::Input.from_tokens input, (input.size - 1).clamp(0, nil)
+      completion_input = ACON::Completion::Input.from_tokens input.to_a, (input.size - 1).clamp(0, nil)
       completion_input.bind @command.definition
       suggestions = ACON::Completion::Suggestions.new
 

--- a/src/components/console/src/style/athena.cr
+++ b/src/components/console/src/style/athena.cr
@@ -454,7 +454,8 @@ class Athena::Console::Style::Athena < Athena::Console::Style::Output
     @buffered_output.write message, new_line, verbosity, output_type
   end
 
-  private def progress_bar : ACON::Helper::ProgressBar
+  # Used in specs
+  protected def progress_bar : ACON::Helper::ProgressBar
     @progress_bar || raise ACON::Exception::Runtime.new "The ProgressBar is not started."
   end
 end

--- a/src/components/console/src/style/athena.cr
+++ b/src/components/console/src/style/athena.cr
@@ -36,8 +36,8 @@ class Athena::Console::Style::Athena < Athena::Console::Style::Output
   end
 
   # :inherit:
-  def ask(question : String, default : _)
-    self.ask ACON::Question.new question, default
+  def ask(question : String, default : String?)
+    self.ask ACON::Question(String?).new question, default
   end
 
   # :ditto:

--- a/src/components/event_dispatcher/spec/generic_event_spec.cr
+++ b/src/components/event_dispatcher/spec/generic_event_spec.cr
@@ -1,0 +1,27 @@
+require "./spec_helper"
+
+struct GenericEventTest < ASPEC::TestCase
+  def test_with_arguments : Nil
+    event = AED::GenericEvent(String, Int32 | String).new(
+      "foo",
+      args = {"counter" => 0, "data" => "bar"}
+    )
+
+    event.subject.should eq "foo"
+    event.arguments.should eq args
+    event.arguments = {"counter" => 2} of String => Int32 | String
+    event.arguments.should eq({"counter" => 2})
+
+    event["counter"].should eq 2
+    event["foo"]?.should be_nil
+    event["counter"] = 5
+    event["counter"].should eq 5
+    event.has_key?("counter").should be_true
+  end
+
+  def test_without_arguments : Nil
+    event = AED::GenericEvent.new "foo"
+    event.subject.should eq "foo"
+    event.arguments.should be_empty
+  end
+end

--- a/src/components/framework/spec/binary_file_response_spec.cr
+++ b/src/components/framework/spec/binary_file_response_spec.cr
@@ -285,4 +285,9 @@ struct ATH::BinaryFileResponseTest < ASPEC::TestCase
       {"bytes=40-50"},
     }
   end
+
+  def test_content_disposition_to_s : Nil
+    ATH::BinaryFileResponse::ContentDisposition::Attachment.to_s.should eq "attachment"
+    ATH::BinaryFileResponse::ContentDisposition::Inline.to_s.should eq "inline"
+  end
 end

--- a/src/components/framework/spec/controller_spec.cr
+++ b/src/components/framework/spec/controller_spec.cr
@@ -40,4 +40,18 @@ describe ATH::Controller do
       response.content.should be_empty
     end
   end
+
+  it "#redirect_view" do
+    response = TestController.new.redirect_view "URL", :im_a_teapot
+    view = response.should be_a ATH::View(Nil)
+    view.location.should eq "URL"
+    view.status.should eq HTTP::Status::IM_A_TEAPOT
+  end
+
+  it "#route_redirect_view" do
+    response = TestController.new.route_redirect_view "get_user_me"
+    view = response.should be_a ATH::View(Nil)
+    view.route.should eq "get_user_me"
+    view.route_params.should be_empty
+  end
 end

--- a/src/components/framework/spec/controllers/routing_controller.cr
+++ b/src/components/framework/spec/controllers/routing_controller.cr
@@ -38,6 +38,11 @@ class RoutingController < ATH::Controller
     response
   end
 
+  @[ARTA::Post("unprocessable")]
+  def unprocessable : ATH::Response
+    ATH::Response.new "", :unprocessable_entity
+  end
+
   @[ARTA::Get("art/response")]
   def response : ATH::Response
     ATH::Response.new "FOO", 418, HTTP::Headers{"content-type" => "BAR"}

--- a/src/components/framework/spec/exception/bad_gateway_spec.cr
+++ b/src/components/framework/spec/exception/bad_gateway_spec.cr
@@ -1,0 +1,12 @@
+require "../spec_helper"
+
+describe ATH::Exception::BadGateway do
+  describe "#initialize" do
+    it "sets the message, and status" do
+      exception = ATH::Exception::BadGateway.new "MESSAGE"
+      exception.headers.should be_empty
+      exception.status.should eq HTTP::Status::BAD_GATEWAY
+      exception.message.should eq "MESSAGE"
+    end
+  end
+end

--- a/src/components/framework/spec/exception/http_exception_spec.cr
+++ b/src/components/framework/spec/exception/http_exception_spec.cr
@@ -1,0 +1,12 @@
+require "../spec_helper"
+
+describe ATH::Exception::HTTPException do
+  describe "#initialize" do
+    it "sets the message, and status" do
+      exception = ATH::Exception::HTTPException.new 200, "MESSAGE"
+      exception.headers.should be_empty
+      exception.status.should eq HTTP::Status::OK
+      exception.message.should eq "MESSAGE"
+    end
+  end
+end

--- a/src/components/framework/spec/listeners/view_spec.cr
+++ b/src/components/framework/spec/listeners/view_spec.cr
@@ -59,6 +59,19 @@ describe ATH::Listeners::View do
       view_handler.view.context.groups.try &.should be_empty
     end
 
+    it "mutating response" do
+      request = new_request
+      event = ATH::Events::View.new request, "FOO"
+      view_handler = MockViewHandler.new
+
+      event.action_result = "BAR"
+      ATH::Listeners::View.new(view_handler).on_view event
+
+      view_handler.view.data.should eq "BAR"
+      view_handler.view.format.should eq "json"
+      view_handler.view.context.groups.try &.should be_empty
+    end
+
     describe ATHA::View do
       describe "status" do
         it "with status" do

--- a/src/components/framework/spec/request_spec.cr
+++ b/src/components/framework/spec/request_spec.cr
@@ -504,4 +504,11 @@ struct ATH::RequestTest < ASPEC::TestCase
     request.headers["host"] = "localhost"
     request.host.should eq "localhost"
   end
+
+  def test_request_data : Nil
+    request = ATH::Request.new "GET", "/", body: "foo=bar&biz=baz"
+    params = request.request_data
+    params.should eq p = URI::Params.new({"foo" => ["bar"], "biz" => ["baz"]})
+    request.request_data.should eq p
+  end
 end

--- a/src/components/framework/spec/routing_spec.cr
+++ b/src/components/framework/spec/routing_spec.cr
@@ -127,6 +127,7 @@ struct RoutingTest < ATH::Spec::APITestCase
   {% for method in ["POST", "PUT", "PATCH", "DELETE", "LINK", "UNLINK"] %}
     def test_macro_dsl_{{method.downcase.id}} : Nil
       self.request({{method}}, "/macro").body.should eq %({{method}})
+      self.{{method.downcase.id}}("/macro").body.should eq %({{method}})
     end
   {% end %}
 
@@ -246,5 +247,11 @@ struct RoutingTest < ATH::Spec::APITestCase
     self.post "/art/response/"
 
     self.assert_response_has_status :not_found
+  end
+
+  def test_unprocessable : Nil
+    self.post "/unprocessable"
+
+    self.assert_response_is_unprocessable
   end
 end

--- a/src/components/framework/spec/spec/expectations/response/cookie_value_equals_spec.cr
+++ b/src/components/framework/spec/spec/expectations/response/cookie_value_equals_spec.cr
@@ -92,19 +92,19 @@ struct CookieValueEqualsExpectationTest < ASPEC::TestCase
       .should contain "Failed asserting that the response does not have cookie 'foo' with value 'bar'."
   end
 
-  def test_failure_message_with_path : Nil
+  def test_negative_failure_message_with_path : Nil
     ATH::Spec::Expectations::Response::CookieValueEquals.new("foo", "bar", path: "/path")
       .negative_failure_message(new_response)
       .should contain "Failed asserting that the response does not have cookie 'foo' with path '/path' with value 'bar'."
   end
 
-  def test_failure_message_with_domain : Nil
+  def test_negative_failure_message_with_domain : Nil
     ATH::Spec::Expectations::Response::CookieValueEquals.new("foo", "bar", domain: "example.com")
       .negative_failure_message(new_response)
       .should contain "Failed asserting that the response does not have cookie 'foo' for domain 'example.com' with value 'bar'."
   end
 
-  def test_failure_message_with_path_and_domain : Nil
+  def test_negative_failure_message_with_path_and_domain : Nil
     ATH::Spec::Expectations::Response::CookieValueEquals.new("foo", "bar", path: "/path", domain: "example.com")
       .negative_failure_message(new_response)
       .should contain "Failed asserting that the response does not have cookie 'foo' with path '/path' for domain 'example.com' with value 'bar'."

--- a/src/components/framework/spec/spec/expectations/response/format_equals_spec.cr
+++ b/src/components/framework/spec/spec/expectations/response/format_equals_spec.cr
@@ -33,7 +33,7 @@ struct FormatEqualsExpectationTest < ASPEC::TestCase
       .should contain "Failed asserting that the response format is not 'json':\nHTTP/1.1 200"
   end
 
-  def test_failure_message_no_format : Nil
+  def test_negative_failure_message_no_format : Nil
     ATH::Spec::Expectations::Response::FormatEquals.new(new_request)
       .negative_failure_message(new_response)
       .should contain "Failed asserting that the response format is not 'null':\nHTTP/1.1 200"

--- a/src/components/framework/spec/spec/expectations/response/has_cookie_spec.cr
+++ b/src/components/framework/spec/spec/expectations/response/has_cookie_spec.cr
@@ -92,19 +92,19 @@ struct HasCookieExpectationTest < ASPEC::TestCase
       .should contain "Failed asserting that the response does not have cookie 'foo'."
   end
 
-  def test_failure_message_with_path : Nil
+  def test_negative_failure_message_with_path : Nil
     ATH::Spec::Expectations::Response::HasCookie.new("foo", path: "/path")
       .negative_failure_message(new_response)
       .should contain "Failed asserting that the response does not have cookie 'foo' with path '/path'."
   end
 
-  def test_failure_message_with_domain : Nil
+  def test_negative_failure_message_with_domain : Nil
     ATH::Spec::Expectations::Response::HasCookie.new("foo", domain: "example.com")
       .negative_failure_message(new_response)
       .should contain "Failed asserting that the response does not have cookie 'foo' for domain 'example.com'."
   end
 
-  def test_failure_message_with_path_and_domain : Nil
+  def test_negative_failure_message_with_path_and_domain : Nil
     ATH::Spec::Expectations::Response::HasCookie.new("foo", path: "/path", domain: "example.com")
       .negative_failure_message(new_response)
       .should contain "Failed asserting that the response does not have cookie 'foo' with path '/path' for domain 'example.com'."

--- a/src/components/framework/spec/spec_helper.cr
+++ b/src/components/framework/spec/spec_helper.cr
@@ -72,10 +72,6 @@ macro create_action(return_type = String, &)
   )
 end
 
-def new_context(*, request : ATH::Request = new_request, response : HTTP::Server::Response = new_response) : HTTP::Server::Context
-  HTTP::Server::Context.new request, response
-end
-
 def new_parameter : ATH::Controller::ParameterMetadata
   ATH::Controller::ParameterMetadata(Int32).new "id"
 end

--- a/src/components/framework/spec/streamed_response_spec.cr
+++ b/src/components/framework/spec/streamed_response_spec.cr
@@ -33,6 +33,17 @@ describe ATH::StreamedResponse do
       io.to_s.should eq "FOO"
     end
 
+    it "allows overriding the callback" do
+      io = IO::Memory.new
+
+      response = (ATH::StreamedResponse.new &.<<("BAZ"))
+      response.content = ->(i : IO) { i << "BAR" }
+
+      response.write io
+
+      io.to_s.should eq "BAR"
+    end
+
     it "accepts an Int status" do
       (ATH::StreamedResponse.new(status: 201, &.<<("BAZ"))).status.should eq HTTP::Status::CREATED
     end

--- a/src/components/framework/spec/view/view_spec.cr
+++ b/src/components/framework/spec/view/view_spec.cr
@@ -58,6 +58,12 @@ struct ViewTest < ASPEC::TestCase
     headers = view.response.headers
     view.headers.has_key?("foo").should be_true
     headers["foo"].should eq "bar"
+
+    view.set_header "string", "str"
+    view.set_header "non-string", 10
+
+    headers["string"].should eq "str"
+    headers["non-string"].should eq "10"
   end
 
   def test_status : Nil

--- a/src/components/framework/src/binary_file_response.cr
+++ b/src/components/framework/src/binary_file_response.cr
@@ -30,10 +30,10 @@ class Athena::Framework::BinaryFileResponse < Athena::Framework::Response
     Inline
 
     # :inherit:
-    def to_s(io : IO) : Nil
+    def to_s : String
       case self
-      in .attachment? then io << "attachment"
-      in .inline?     then io << "inline"
+      in .attachment? then "attachment"
+      in .inline?     then "inline"
       end
     end
   end

--- a/src/components/framework/src/controller.cr
+++ b/src/components/framework/src/controller.cr
@@ -244,14 +244,14 @@ abstract class Athena::Framework::Controller
   # Returns an `ATH::View` that'll redirect to the provided *url*, optionally with the provided *status* and *headers*.
   #
   # Is essentially the same as `#redirect`, but invokes the [view](/getting_started/middleware#4-view-event) layer.
-  def redirect_view(url : Status, status : HTTP::Status = HTTP::Status::FOUND, headers : HTTP::Headers = HTTP::Headers.new) : ATH::View
+  def redirect_view(url : String, status : HTTP::Status = HTTP::Status::FOUND, headers : HTTP::Headers = HTTP::Headers.new) : ATH::View
     ATH::View.create_redirect url, status, headers
   end
 
   # Returns an `ATH::View` that'll redirect to the provided *route*, optionally with the provided *params*, *status*, and *headers*.
   #
   # Is essentially the same as `#redirect_to_route`, but invokes the [view](/getting_started/middleware#4-view-event) layer.
-  def route_redirect_view(route : Status, params : Hash(String, _) = Hash(String, String?).new, status : HTTP::Status = HTTP::Status::CREATED, headers : HTTP::Headers = HTTP::Headers.new) : ATH::View
+  def route_redirect_view(route : String, params : Hash(String, _) = Hash(String, String?).new, status : HTTP::Status = HTTP::Status::CREATED, headers : HTTP::Headers = HTTP::Headers.new) : ATH::View
     ATH::View.create_route_redirect route, params
   end
 

--- a/src/components/framework/src/spec/api_test_case.cr
+++ b/src/components/framework/src/spec/api_test_case.cr
@@ -157,7 +157,7 @@ abstract struct Athena::Framework::Spec::APITestCase < ATH::Spec::WebTestCase
 
   # Makes a `UNLINK` request to the provided *path*, optionally with the provided *headers*.
   def unlink(path : String, headers : HTTP::Headers = HTTP::Headers.new) : HTTP::Server::Response
-    self.request "UNLINK", path, body, headers
+    self.request "UNLINK", path, headers: headers
   end
 
   # See `AbstractBrowser#request`.

--- a/src/components/image_size/spec/athena-image_size_spec.cr
+++ b/src/components/image_size/spec/athena-image_size_spec.cr
@@ -18,6 +18,7 @@ struct ImageTest < ASPEC::TestCase
 
       image.width.should eq expected_width.to_i
       image.height.should eq expected_height.to_i
+      image.size.should eq({expected_width.to_i, expected_height.to_i})
       image.bits.should eq expected_bits
       image.channels.should eq expected_channels
       image.format.should eq AIS::Image::Format.parse(expected_format)

--- a/src/components/mercure/spec/hub/hub_spec.cr
+++ b/src/components/mercure/spec/hub/hub_spec.cr
@@ -53,4 +53,15 @@ describe Athena::Mercure::Hub do
       end
     end
   end
+
+  it "#url" do
+    AMC::Hub
+      .new(URL, AMC::TokenProvider::Static.new("FOO"), http_client: MockHTTPClient.new URI.parse URL)
+      .url.should eq URL
+  end
+
+  it "#publish" do
+    foo_hub = AMC::Spec::MockHub.new("https://foo.com", AMC::TokenProvider::Static.new("FOO")) { "foo" }
+    foo_hub.publish(AMC::Update.new("https://demo.mercure.rocks/demo/books/1.jsonld")).should eq "foo"
+  end
 end

--- a/src/components/negotiation/spec/accept_language_spec.cr
+++ b/src/components/negotiation/spec/accept_language_spec.cr
@@ -28,4 +28,13 @@ struct AcceptLanguageTest < ASPEC::TestCase
       {"en-GB;q=0.8", "en-GB;q=0.8"},
     }
   end
+
+  @[TestWith(
+    {"en;q=0.7", "en"},
+    {"en-GB;q=0.8", "en-gb"},
+    {"zh-Hans-CN;q=0.8", "zh-hans-cn"},
+  )]
+  def test_language_range(header : String, expected : String) : Nil
+    ANG::AcceptLanguage.new(header).language_range.should eq expected
+  end
 end

--- a/src/components/routing/spec/generator/url_generator_spec.cr
+++ b/src/components/routing/spec/generator/url_generator_spec.cr
@@ -268,7 +268,7 @@ struct URLGeneratorTest < ASPEC::TestCase
       .generate("test").should eq "ftp://localhost/base/"
   end
 
-  def test_generate_scheme_requirement_creates_url_for_first_required_scheme : Nil
+  def test_path_with_two_starting_slashes : Nil
     self
       .generator(self.routes(ART::Route.new("//path-and-not-domain")), context: ART::RequestContext.new)
       .generate("test").should eq "/path-and-not-domain"

--- a/src/components/routing/spec/matcher/abstract_url_matcher_test_case.cr
+++ b/src/components/routing/spec/matcher/abstract_url_matcher_test_case.cr
@@ -752,7 +752,7 @@ abstract struct AbstractURLMatcherTestCase < ASPEC::TestCase
     end
   end
 
-  def test_match_scheme_and_method_mismatch : Nil
+  def test_sibling_routes : Nil
     routes = self.build_collection do
       add "a", ART::Route.new "/a{a}", methods: "POST"
       add "b", ART::Route.new "/a{a}", methods: "PUT"

--- a/src/components/routing/spec/request_context_spec.cr
+++ b/src/components/routing/spec/request_context_spec.cr
@@ -1,0 +1,144 @@
+require "./spec_helper"
+
+struct RequestContextTest < ASPEC::TestCase
+  def test_constructor : Nil
+    request_context = ART::RequestContext.new(
+      "foo",
+      "post",
+      "foo.bar",
+      "HTTPS",
+      8080,
+      444,
+      "/baz",
+      "bar=foobar",
+    )
+
+    request_context.base_url.should eq "foo"
+    request_context.method.should eq "POST"
+    request_context.host.should eq "foo.bar"
+    request_context.scheme.should eq "https"
+    request_context.http_port.should eq 8080
+    request_context.https_port.should eq 444
+    request_context.path.should eq "/baz"
+    request_context.query_string.should eq "bar=foobar"
+  end
+
+  def test_getters_setters : Nil
+    request_context = ART::RequestContext.new
+
+    request_context.base_url = "foo"
+    request_context.method = "POST"
+    request_context.host = "foo.bar"
+    request_context.scheme = "https"
+    request_context.http_port = 8080
+    request_context.https_port = 444
+    request_context.path = "/baz"
+    request_context.query_string = "bar=foobar"
+
+    request_context.base_url.should eq "foo"
+    request_context.method.should eq "POST"
+    request_context.host.should eq "foo.bar"
+    request_context.scheme.should eq "https"
+    request_context.http_port.should eq 8080
+    request_context.https_port.should eq 444
+    request_context.path.should eq "/baz"
+    request_context.query_string.should eq "bar=foobar"
+  end
+
+  def test_from_uri_with_base_url : Nil
+    request_context = ART::RequestContext.from_uri "https://test.com:444/index.html"
+
+    request_context.method.should eq "GET"
+    request_context.host.should eq "test.com"
+    request_context.scheme.should eq "https"
+    request_context.http_port.should eq 80
+    request_context.https_port.should eq 444
+    request_context.base_url.should eq "/index.html"
+    request_context.path.should eq "/"
+  end
+
+  def test_from_uri_trailing_slash : Nil
+    request_context = ART::RequestContext.from_uri "http://test.com:8080/"
+
+    request_context.scheme.should eq "http"
+    request_context.host.should eq "test.com"
+    request_context.http_port.should eq 8080
+    request_context.https_port.should eq 443
+    request_context.base_url.should eq "/"
+    request_context.path.should eq "/"
+  end
+
+  def test_from_uri_without_trailing_slash : Nil
+    request_context = ART::RequestContext.from_uri "https://test.com"
+
+    request_context.scheme.should eq "https"
+    request_context.host.should eq "test.com"
+    request_context.base_url.should be_empty
+    request_context.path.should eq "/"
+  end
+
+  def test_from_uri_empty : Nil
+    request_context = ART::RequestContext.from_uri ""
+
+    request_context.scheme.should eq "http"
+    request_context.host.should eq "localhost"
+    request_context.base_url.should be_empty
+    request_context.path.should eq "/"
+  end
+
+  @[TestWith(
+    {"http://foo.com\\bar"},
+    {"\\\\foo.com/bar"},
+    {"a\rb"},
+    {"a\nb"},
+    {"a\tb"},
+    {"\0foo"},
+    {"foo\0"},
+    {" foo"},
+    {"foo "},
+    # {":"},
+  )]
+  def test_from_uri_invalid(uri : String) : Nil
+    request_context = ART::RequestContext.from_uri uri
+
+    request_context.scheme.should eq "http"
+    request_context.host.should eq "localhost"
+    request_context.base_url.should be_empty
+    request_context.path.should eq "/"
+  end
+
+  def test_from_request : Nil
+    request = ART::Request.new "GET", "/foo?bar=baz", headers: HTTP::Headers{"host" => "test.com:444"}
+
+    request_context = ART::RequestContext.new
+    request_context.apply request
+
+    request_context.base_url.should be_empty
+    request_context.method.should eq "GET"
+    request_context.host.should eq "test.com"
+    request_context.path.should eq "/foo"
+    request_context.query_string.should eq "bar=baz"
+
+    # Don't really have a way to determine these via `HTTP::Request` at the moment :/
+    request_context.scheme.should eq "http"
+    request_context.http_port.should eq 80
+    request_context.https_port.should eq 443
+  end
+
+  def test_parameters : Nil
+    request_context = ART::RequestContext.new
+    request_context.parameters.should be_empty
+
+    request_context.parameters = {"foo" => "bar"} of String => String?
+    request_context.parameters.should eq({"foo" => "bar"})
+
+    request_context.parameter("foo").should eq "bar"
+  end
+
+  def test_has_parameter : Nil
+    request_context = ART::RequestContext.new
+    request_context.has_parameter?("foo").should be_false
+    request_context.set_parameter "foo", "bar"
+    request_context.has_parameter?("foo").should be_true
+  end
+end

--- a/src/components/routing/spec/route_collection_spec.cr
+++ b/src/components/routing/spec/route_collection_spec.cr
@@ -27,6 +27,17 @@ struct RouteCollectionTest < ASPEC::TestCase
     collection["foo"].should be route2
   end
 
+  def test_each_iterator : Nil
+    collection = ART::RouteCollection.new
+    route1 = ART::Route.new "/foo"
+    route2 = ART::Route.new "/bar"
+
+    collection.add "foo", route1
+    collection.add "bar", route2
+
+    assert_iterates_iterator [{"foo", route1}, {"bar", route2}], collection.each
+  end
+
   def test_deep_overridden_route : Nil
     collection = ART::RouteCollection.new
     collection.add "foo", ART::Route.new "/foo"
@@ -204,7 +215,7 @@ struct RouteCollectionTest < ASPEC::TestCase
     b.schemes.should eq Set{"http", "https"}
   end
 
-  def test_set_scheme : Nil
+  def test_set_methods : Nil
     collection = ART::RouteCollection.new
     collection.add "a", a = ART::Route.new "/a", methods: {"get", "POST"}
     collection.add "b", b = ART::Route.new "/b"

--- a/src/components/routing/spec/router_spec.cr
+++ b/src/components/routing/spec/router_spec.cr
@@ -1,0 +1,38 @@
+require "./spec_helper"
+
+struct RouterTest < ASPEC::TestCase
+  def test_generate : Nil
+    self.router.generate("foo").should eq "/foo"
+    self.router.generate("foo", id: "1").should eq "/foo?id=1"
+  end
+
+  def test_match : Nil
+    self.router.match("/foo").should eq({"_route" => "foo"})
+    self.router.match(ART::Request.new "GET", "/bar").should eq({"_route" => "bar"})
+  end
+
+  def test_match? : Nil
+    self.router.match?("/foo").should eq({"_route" => "foo"})
+    self.router.match?(ART::Request.new "GET", "/bar").should eq({"_route" => "bar"})
+
+    self.router.match?("/baz").should be_nil
+    self.router.match?(ART::Request.new "GET", "/baz").should be_nil
+  end
+
+  private def router : ART::Router
+    collection = ART::RouteCollection.new
+    route1 = ART::Route.new "/foo"
+    route2 = ART::Route.new "/bar"
+
+    collection.add "foo", route1
+    collection.add "bar", route2
+
+    ART.compile collection
+
+    router = ART::Router.new collection
+
+    router.context = ART::RequestContext.new
+
+    router
+  end
+end

--- a/src/components/routing/spec/spec_helper.cr
+++ b/src/components/routing/spec/spec_helper.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "spec/helpers/iterate"
 require "athena-spec"
 require "../src/athena-routing"
 

--- a/src/components/routing/src/request_context.cr
+++ b/src/components/routing/src/request_context.cr
@@ -19,6 +19,8 @@ class Athena::Routing::RequestContext
 
   # Creates a new instance of self from the provided *uri*.
   # The *host*, *scheme*, *http_port*, and *https_port* optionally act as fallbacks if they are not contained within the *uri*.
+  #
+  # ameba:disable Metrics/CyclomaticComplexity:
   def self.from_uri(uri : String, host : String = "localhost", scheme : String = "http", http_port : Int32 = 80, https_port : Int32 = 443) : self
     if (idx = uri.index('\\')) && (i = uri.index(/\?|\#/) || uri.bytesize) && idx < i
       uri = ""

--- a/src/components/routing/src/request_context.cr
+++ b/src/components/routing/src/request_context.cr
@@ -20,6 +20,14 @@ class Athena::Routing::RequestContext
   # Creates a new instance of self from the provided *uri*.
   # The *host*, *scheme*, *http_port*, and *https_port* optionally act as fallbacks if they are not contained within the *uri*.
   def self.from_uri(uri : String, host : String = "localhost", scheme : String = "http", http_port : Int32 = 80, https_port : Int32 = 443) : self
+    if (idx = uri.index('\\')) && (i = uri.index(/\?|\#/) || uri.bytesize) && idx < i
+      uri = ""
+    end
+
+    if (u = uri.presence) && (u[0].ord <= 32 || u[-1].ord <= 32 || ((idx = u.index(/\r|\n|\t/) || u.bytesize) && (u.bytesize != idx)))
+      uri = ""
+    end
+
     self.from_uri URI.parse(uri), host, scheme, http_port, https_port
   end
 
@@ -72,6 +80,7 @@ class Athena::Routing::RequestContext
                   "localhost"
                 end
 
+    self.path = request.path
     self.query_string = request.query || ""
 
     # TODO: Support this once it's exposed.
@@ -112,13 +121,29 @@ class Athena::Routing::RequestContext
     self
   end
 
+  def http_port=(@http_port : Int32) : self
+    self
+  end
+
+  def https_port=(@https_port : Int32) : self
+    self
+  end
+
+  def parameter(name : String)
+    @parameters[name]
+  end
+
   def set_parameter(name : String, value : String?) : self
     @parameters[name] = value
 
     self
   end
 
+  def parameters=(@parameters : Hash(String, String?)) : self
+    self
+  end
+
   def has_parameter?(name : String) : Bool
-    @parameters.has_key name
+    @parameters.has_key? name
   end
 end

--- a/src/components/validator/spec/constraints/greater_than_or_equal_validator_spec.cr
+++ b/src/components/validator/spec/constraints/greater_than_or_equal_validator_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 private alias CONSTRAINT = AVD::Constraints::GreaterThanOrEqual
 
-struct GreaterThanValidatorTest < AVD::Spec::ComparisonConstraintValidatorTestCase
+struct GreaterThanOrEqualValidatorTest < AVD::Spec::ComparisonConstraintValidatorTestCase
   def valid_comparisons : Tuple
     {
       {3, 2},

--- a/src/components/validator/spec/constraints/isbn_validator_spec.cr
+++ b/src/components/validator/spec/constraints/isbn_validator_spec.cr
@@ -42,7 +42,7 @@ struct ISBNValidatorTest < AVD::Spec::ConstraintValidatorTestCase
   end
 
   @[DataProvider("valid_isbn13s")]
-  def test_valid_isbn10s(value : String) : Nil
+  def test_valid_isbn13s(value : String) : Nil
     self.validator.validate value, self.new_constraint type: CONSTRAINT::Type::ISBN13
     self.assert_no_violation
   end

--- a/src/components/validator/spec/constraints/negative_or_zero_validator_spec.cr
+++ b/src/components/validator/spec/constraints/negative_or_zero_validator_spec.cr
@@ -1,0 +1,43 @@
+private alias CONSTRAINT = AVD::Constraints::NegativeOrZero
+
+struct NegativeOrZeroValidatorTest < AVD::Spec::ConstraintValidatorTestCase
+  def test_nil_is_valid : Nil
+    self.validator.validate nil, self.new_constraint
+    self.assert_no_violation
+  end
+
+  def test_zero_is_valid : Nil
+    self.validator.validate 0, self.new_constraint
+    self.assert_no_violation
+  end
+
+  def test_valid_value : Nil
+    self.validator.validate -1, self.new_constraint
+    self.assert_no_violation
+  end
+
+  @[DataProvider("invalid_values")]
+  def test_invalid_values(value : _) : Nil
+    self.validator.validate value, self.new_constraint message: "my_message"
+    self
+      .build_violation("my_message", CONSTRAINT::TOO_HIGH_ERROR, value)
+      .add_parameter("{{ compared_value }}", "0")
+      .add_parameter("{{ compared_value_type }}", "Int32")
+      .assert_violation
+  end
+
+  def invalid_values : Tuple
+    {
+      {1},
+      {1234},
+    }
+  end
+
+  private def create_validator : AVD::ConstraintValidatorInterface
+    CONSTRAINT::Validator.new
+  end
+
+  private def constraint_class : AVD::Constraint.class
+    CONSTRAINT
+  end
+end

--- a/src/components/validator/spec/constraints/negative_validator_spec.cr
+++ b/src/components/validator/spec/constraints/negative_validator_spec.cr
@@ -1,0 +1,39 @@
+private alias CONSTRAINT = AVD::Constraints::Negative
+
+struct NegativeValidatorTest < AVD::Spec::ConstraintValidatorTestCase
+  def test_nil_is_valid : Nil
+    self.validator.validate nil, self.new_constraint
+    self.assert_no_violation
+  end
+
+  def test_valid_value : Nil
+    self.validator.validate -1, self.new_constraint
+    self.assert_no_violation
+  end
+
+  @[DataProvider("invalid_values")]
+  def test_invalid_values(value : _) : Nil
+    self.validator.validate value, self.new_constraint message: "my_message"
+    self
+      .build_violation("my_message", CONSTRAINT::TOO_HIGH_ERROR, value)
+      .add_parameter("{{ compared_value }}", "0")
+      .add_parameter("{{ compared_value_type }}", "Int32")
+      .assert_violation
+  end
+
+  def invalid_values : Tuple
+    {
+      {0},
+      {1},
+      {1234},
+    }
+  end
+
+  private def create_validator : AVD::ConstraintValidatorInterface
+    CONSTRAINT::Validator.new
+  end
+
+  private def constraint_class : AVD::Constraint.class
+    CONSTRAINT
+  end
+end

--- a/src/components/validator/spec/constraints/positive_or_zero_validator_spec.cr
+++ b/src/components/validator/spec/constraints/positive_or_zero_validator_spec.cr
@@ -1,0 +1,43 @@
+private alias CONSTRAINT = AVD::Constraints::PositiveOrZero
+
+struct PositiveOrZeroValidatorTest < AVD::Spec::ConstraintValidatorTestCase
+  def test_nil_is_valid : Nil
+    self.validator.validate nil, self.new_constraint
+    self.assert_no_violation
+  end
+
+  def test_zero_is_valid : Nil
+    self.validator.validate 0, self.new_constraint
+    self.assert_no_violation
+  end
+
+  def test_valid_value : Nil
+    self.validator.validate 1, self.new_constraint
+    self.assert_no_violation
+  end
+
+  @[DataProvider("invalid_values")]
+  def test_invalid_values(value : _) : Nil
+    self.validator.validate value, self.new_constraint message: "my_message"
+    self
+      .build_violation("my_message", CONSTRAINT::TOO_LOW_ERROR, value)
+      .add_parameter("{{ compared_value }}", "0")
+      .add_parameter("{{ compared_value_type }}", "Int32")
+      .assert_violation
+  end
+
+  def invalid_values : Tuple
+    {
+      {-1},
+      {-1234},
+    }
+  end
+
+  private def create_validator : AVD::ConstraintValidatorInterface
+    CONSTRAINT::Validator.new
+  end
+
+  private def constraint_class : AVD::Constraint.class
+    CONSTRAINT
+  end
+end

--- a/src/components/validator/spec/constraints/range_validator_spec.cr
+++ b/src/components/validator/spec/constraints/range_validator_spec.cr
@@ -90,13 +90,13 @@ struct RangeValidatorTest < AVD::Spec::ConstraintValidatorTestCase
   end
 
   @[DataProvider("ten_to_twnentieth_april_2020")]
-  def test_valid_datetimes_min(value : Time) : Nil
+  def test_valid_datetimes_max(value : Time) : Nil
     self.validator.validate value, self.new_constraint range: (..Time.utc(2020, 4, 20))
     self.assert_no_violation
   end
 
   @[DataProvider("ten_to_twnentieth_april_2020")]
-  def test_valid_datetimes_min(value : Time) : Nil
+  def test_valid_datetimes_range(value : Time) : Nil
     self.validator.validate value, self.new_constraint range: (Time.utc(2020, 4, 10)..Time.utc(2020, 4, 20))
     self.assert_no_violation
   end

--- a/src/components/validator/spec/positive_validator_spec.cr
+++ b/src/components/validator/spec/positive_validator_spec.cr
@@ -1,0 +1,39 @@
+private alias CONSTRAINT = AVD::Constraints::Positive
+
+struct PositiveValidatorTest < AVD::Spec::ConstraintValidatorTestCase
+  def test_nil_is_valid : Nil
+    self.validator.validate nil, self.new_constraint
+    self.assert_no_violation
+  end
+
+  def test_valid_value : Nil
+    self.validator.validate 1, self.new_constraint
+    self.assert_no_violation
+  end
+
+  @[DataProvider("invalid_values")]
+  def test_invalid_values(value : _) : Nil
+    self.validator.validate value, self.new_constraint message: "my_message"
+    self
+      .build_violation("my_message", CONSTRAINT::TOO_LOW_ERROR, value)
+      .add_parameter("{{ compared_value }}", "0")
+      .add_parameter("{{ compared_value_type }}", "Int32")
+      .assert_violation
+  end
+
+  def invalid_values : Tuple
+    {
+      {0},
+      {-1},
+      {-1234},
+    }
+  end
+
+  private def create_validator : AVD::ConstraintValidatorInterface
+    CONSTRAINT::Validator.new
+  end
+
+  private def constraint_class : AVD::Constraint.class
+    CONSTRAINT
+  end
+end

--- a/src/components/validator/src/constraints/abstract_comparison_validator.cr
+++ b/src/components/validator/src/constraints/abstract_comparison_validator.cr
@@ -16,9 +16,8 @@ abstract class Athena::Validator::Constraints::ComparisonValidator < Athena::Val
 
     self
       .context
-      .build_violation(constraint.message, self.error_code, value)
-      .add_parameter("{{ compared_value }}", compared_value)
-      .add_parameter("{{ compared_value_type }}", constraint.value_type)
+      .build_violation(constraint.message, self.error_code)
+      .set_parameters({"{{ value }}" => value.to_s, "{{ compared_value }}" => compared_value.to_s, "{{ compared_value_type }}" => constraint.value_type.to_s})
       .add
   end
 end


### PR DESCRIPTION
## Context

As primarily a one person developer, I rely heavily on Athena's test suite to ensure things are working as expected as I make changes. The recent push to better integrate code coverage reporting is a direct result of this.

This PR makes some minor tweaks to how coverage is handled locally and does a pass on the methods flagged via `crystal tool unreachable`, fixing a fair amount of holes in Athena's test coverage and fixes several bugs as a result.

## Changelog

* **Breaking:** Rename `ACON::Completion::Input#must_suggest_values_for?` to `ACON::Completion::Input#must_suggest_option_values_for?` to better describe what it does
* Clear component `coverage/` dir when running coverage specs for that component
* Include `spec/` directories in code coverage reporting to allow capturing duplicate named spec methods
* Fix typing of `#now` and `#clock=` for `Athena::Clock::Aware`
* Fix various methods that were failing once they started being used
* Improve test coverage in most components

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
