### PR TITLE
Do not fail fast on formatter CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
         uses: crate-ci/typos@v1.29.0
   check_format:
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         crystal:
           - latest
           - nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
   check_format:
     strategy:
       matrix:
+        fail-fast: false
         crystal:
           - latest
           - nightly


### PR DESCRIPTION
## Context

GHA matrix configuration defaults `fail-fast` to `true`. This makes it so if `nightly` fails, then `latest` is cancelled. This is not ideal so this PR disables `fail-fast` for this job.

## Changelog

* Do not fail fast on formatter CI jobs

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
