### PR TITLE
Use Crystal `latest` for generating coverage reports in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v2
       - name: Install kcov
-        if: matrix.crystal == 'nightly'
+        if: matrix.crystal == 'latest'
         run: |
           sudo apt-get update &&
           sudo apt-get install binutils-dev libssl-dev libcurl4-openssl-dev libelf-dev libstdc++-12-dev zlib1g-dev libdw-dev libiberty-dev
@@ -89,7 +89,7 @@ jobs:
         run: just test-compiled
         shell: bash
       - uses: codecov/codecov-action@v5
-        if: matrix.crystal == 'nightly' && github.event_name != 'schedule' # Only want to upload coverage report once in the matrix
+        if: matrix.crystal == 'latest' && github.event_name != 'schedule' # Only want to upload coverage report once in the matrix
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -98,7 +98,7 @@ jobs:
           flags: compiled
           verbose: true
       - uses: codecov/test-results-action@v1
-        if: matrix.crystal == 'nightly' && github.event_name != 'schedule' # Only want to upload coverage report once in the matrix
+        if: matrix.crystal == 'latest' && github.event_name != 'schedule' # Only want to upload coverage report once in the matrix
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -127,7 +127,7 @@ jobs:
           fetch-depth: 0
       - uses: extractions/setup-just@v2
       - name: Install kcov
-        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'nightly'
+        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest'
         run: |
           sudo apt-get update &&
           sudo apt-get install binutils-dev libssl-dev libcurl4-openssl-dev libelf-dev libstdc++-12-dev zlib1g-dev libdw-dev libiberty-dev
@@ -152,7 +152,7 @@ jobs:
         run: just test-unit
         shell: bash
       - uses: codecov/codecov-action@v5
-        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'nightly' && github.event_name != 'schedule' # Only want to upload coverage report once in the matrix
+        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest' && github.event_name != 'schedule' # Only want to upload coverage report once in the matrix
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -161,7 +161,7 @@ jobs:
           flags: unit
           verbose: true
       - uses: codecov/test-results-action@v1
-        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'nightly' && github.event_name != 'schedule' # Only want to upload coverage report once in the matrix
+        if: matrix.os == 'ubuntu-latest' && matrix.crystal == 'latest' && github.event_name != 'schedule' # Only want to upload coverage report once in the matrix
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
## Context

With nightly CI being so flakey as of late due to https://github.com/crystal-lang/distribution-scripts/issues/330, it made me realize we haven't been producing coverage reports as a result since they were still configure to run on nightlies.

However now that Crystal 1.15 is released we can switch it back to `latest` for now.

## Changelog

* Use Crystal `latest` for generating coverage reports in CI

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
