### PR TITLE
Centralize handling of adding `of Type` to array values

### DIFF
--- a/src/components/dependency_injection/spec/compiler_passes/define_getters_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/define_getters_spec.cr
@@ -23,6 +23,29 @@ class TypedGetterAlias
   include TypedGetterAliasInterface
 end
 
+module ExplicitArrayServiceInterface; end
+
+@[ADI::Register]
+@[ADI::AsAlias]
+struct ExplicitArrayOne
+  include ExplicitArrayServiceInterface
+end
+
+@[ADI::Register]
+@[ADI::AsAlias]
+struct ExplicitArrayTwo
+  include ExplicitArrayServiceInterface
+end
+
+@[ADI::Register]
+@[ADI::AsAlias]
+struct ExplicitArrayThree
+  include ExplicitArrayServiceInterface
+end
+
+@[ADI::Register(_services: ["@explicit_array_one", "@explicit_array_three"], public: true)]
+record ExplicitArrayClient, services : Array(ExplicitArrayServiceInterface)
+
 describe ADI::ServiceContainer::DefineGetters, tags: "compiled" do
   describe "compiler errors" do
     describe "aliases" do
@@ -63,6 +86,10 @@ describe ADI::ServiceContainer::DefineGetters, tags: "compiled" do
 
     it "exposes typed getter for public typed alias" do
       ADI.container.get(TypedGetterAliasInterface).should be_a TypedGetterAlias
+    end
+
+    it "applies `of Type` restrictions to array values" do
+      ADI.container.explicit_array_client.services.should eq [ExplicitArrayOne.new, ExplicitArrayThree.new]
     end
   end
 end

--- a/src/components/dependency_injection/spec/compiler_passes/define_getters_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/define_getters_spec.cr
@@ -23,28 +23,31 @@ class TypedGetterAlias
   include TypedGetterAliasInterface
 end
 
-module ExplicitArrayServiceInterface; end
+module ArrayServiceInterface; end
 
 @[ADI::Register]
 @[ADI::AsAlias]
-struct ExplicitArrayOne
-  include ExplicitArrayServiceInterface
+struct ArrayOne
+  include ArrayServiceInterface
 end
 
 @[ADI::Register]
 @[ADI::AsAlias]
-struct ExplicitArrayTwo
-  include ExplicitArrayServiceInterface
+struct ArrayTwo
+  include ArrayServiceInterface
 end
 
 @[ADI::Register]
 @[ADI::AsAlias]
-struct ExplicitArrayThree
-  include ExplicitArrayServiceInterface
+struct ArrayThree
+  include ArrayServiceInterface
 end
 
-@[ADI::Register(_services: ["@explicit_array_one", "@explicit_array_three"], public: true)]
-record ExplicitArrayClient, services : Array(ExplicitArrayServiceInterface)
+@[ADI::Register(_services: ["@array_one", "@array_three"], public: true)]
+record ImplicitArrayClient, services : Array(ArrayServiceInterface)
+
+@[ADI::Register(public: true)]
+record ExplicitArrayClient, services : Array(ArrayServiceInterface) = [] of ArrayServiceInterface
 
 describe ADI::ServiceContainer::DefineGetters, tags: "compiled" do
   describe "compiler errors" do
@@ -88,8 +91,12 @@ describe ADI::ServiceContainer::DefineGetters, tags: "compiled" do
       ADI.container.get(TypedGetterAliasInterface).should be_a TypedGetterAlias
     end
 
-    it "applies `of Type` restrictions to array values" do
-      ADI.container.explicit_array_client.services.should eq [ExplicitArrayOne.new, ExplicitArrayThree.new]
+    it "implicitly applies `of Type` restrictions to array values" do
+      ADI.container.implicit_array_client.services.should eq [ArrayOne.new, ArrayThree.new]
+    end
+
+    it "does not apply `of Type` restriction to values that already explicitly have one" do
+      ADI.container.explicit_array_client.services.should be_empty
     end
   end
 end

--- a/src/components/dependency_injection/src/compiler_passes/define_getters.cr
+++ b/src/components/dependency_injection/src/compiler_passes/define_getters.cr
@@ -22,7 +22,13 @@ module Athena::DependencyInjection::ServiceContainer::DefineGetters
             {% if !metadata[:public] %}protected {% end %}getter {{service_id.id}} : {{ivar_type}} do
               instance = {{constructor_service}}.{{constructor_method.id}}({{
                                                                              metadata["parameters"].map do |name, param|
-                                                                               "#{name.id}: #{param["value"]}".id
+                                                                               str = "#{name.id}: #{param["value"]}"
+
+                                                                               if (resolved_restriction = param["resolved_restriction"]) && resolved_restriction <= Array
+                                                                                 str += " of Union(#{resolved_restriction.type_vars.splat})"
+                                                                               end
+
+                                                                               str.id
                                                                              end.splat
                                                                            }})
 

--- a/src/components/dependency_injection/src/compiler_passes/define_getters.cr
+++ b/src/components/dependency_injection/src/compiler_passes/define_getters.cr
@@ -24,7 +24,7 @@ module Athena::DependencyInjection::ServiceContainer::DefineGetters
                                                                              metadata["parameters"].map do |name, param|
                                                                                str = "#{name.id}: #{param["value"]}"
 
-                                                                               if (resolved_restriction = param["resolved_restriction"]) && resolved_restriction <= Array
+                                                                               if (resolved_restriction = param["resolved_restriction"]) && resolved_restriction <= Array && param["value"].of.is_a?(Nop)
                                                                                  str += " of Union(#{resolved_restriction.type_vars.splat})"
                                                                                end
 

--- a/src/components/dependency_injection/src/compiler_passes/resolve_values.cr
+++ b/src/components/dependency_injection/src/compiler_passes/resolve_values.cr
@@ -52,7 +52,7 @@ module Athena::DependencyInjection::ServiceContainer::ResolveValues
                   end
                 end
 
-                resolved_value = %((#{tagged_services.map(&.first.id)} of Union(#{param["resolved_restriction"].type_vars.splat}))).id
+                resolved_value = tagged_services.map &.first.id
 
                 # Array, could contain nested references
               elsif unresolved_value.is_a?(ArrayLiteral) || unresolved_value.is_a?(TupleLiteral)


### PR DESCRIPTION
## Context

The logic for handling tagged services was adding an `of T` so that the array was properly typed as what the constructor argument is expecting vs possibly a union of the array contents which might not play nicely with interface based arrays.

This PR centralizes that logic when the getters are defined so will properly handle this context no matter where the array value originates from.

Fixes #507 

## Changelog

* Centralize handling of adding `of Type` to array values

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
