### PR TITLE
Call out the `ADI::AsAlias` annotation must be applied as well

### DIFF
--- a/docs/why_athena.md
+++ b/docs/why_athena.md
@@ -103,7 +103,7 @@ module ArticlePersisterInterface
 end
 ```
 
-From here the constructor of `MyService` should be updated to use it:
+From here the constructor of `MyService` should be updated to be:
 
 ```crystal
 def initialize(
@@ -111,7 +111,8 @@ def initialize(
 ); end
 ```
 
-Also being sure to include the interface in our service:
+Additionally, a [`@[ADI::AsAlias]`](https://athenaframework.org/DependencyInjection/AsAlias/) must be applied to the class.
+Also be sure to include the interface within `ArticlePersister`:
 
 ```crystal
 @[ADI::Register]


### PR DESCRIPTION
## Context

Unlike #506, there is not a _fully_ runnable example to add the annotation to. I added a sentence calling out that the annotation must be added as well as it's not really clear unless you're already familiar with the framework.

Resolves #506 

## Changelog

* Call out that `ADI::AsAlias` annotation must be applied to `MyService` within the "Why Athena" doc page.

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
