### PR TITLE
Fix serialization of value when its type is different type than the ivar

### DIFF
--- a/src/components/serializer/spec/athena-serializer_spec.cr
+++ b/src/components/serializer/spec/athena-serializer_spec.cr
@@ -16,6 +16,21 @@ describe ASR::Serializable do
         p.type.should eq String
         p.class.should eq GetterAccessor
       end
+
+      it "handles when getter value has a diff type than ivar" do
+        properties = GetterAccessorDiffType.new.serialization_properties
+        properties.size.should eq 1
+
+        p = properties[0]
+
+        p.name.should eq "value"
+        p.external_name.should eq "value"
+        p.value.should eq "100"
+        p.value.should be_a String
+        p.skip_when_empty?.should be_false
+        p.type.should eq Int32
+        p.class.should eq GetterAccessorDiffType
+      end
     end
 
     describe ASRA::AccessorOrder do

--- a/src/components/serializer/spec/models/accessor.cr
+++ b/src/components/serializer/spec/models/accessor.cr
@@ -11,6 +11,19 @@ class GetterAccessor
   end
 end
 
+class GetterAccessorDiffType
+  include ASR::Serializable
+
+  def initialize; end
+
+  @[ASRA::Accessor(getter: get_value)]
+  @value : Int32 = 10
+
+  private def get_value : String
+    (@value * 10).to_s
+  end
+end
+
 class SetterAccessor
   include ASR::Serializable
 

--- a/src/components/serializer/src/serializable.cr
+++ b/src/components/serializer/src/serializable.cr
@@ -110,16 +110,20 @@ module Athena::Serializer::Serializable
               {% annotation_configurations[ann_class] = "#{annotations} of ADI::AnnotationConfigurations::ConfigurationBase".id unless annotations.empty? %}
             {% end %}
 
-            {% property_hash[external_name] = %(ASR::PropertyMetadata(#{ivar.type}, #{ivar.type}, #{@type}).new(
+            {%
+              value = (accessor = ivar.annotation(ASRA::Accessor)) && nil != accessor[:getter] ? accessor[:getter].id : %(@#{ivar.id}).id
+
+              property_hash[external_name] = %(ASR::PropertyMetadata(#{ivar.type}, typeof(#{value}), #{@type}).new(
                 name: #{ivar.name.stringify},
                 external_name: #{external_name},
                 annotation_configurations: ADI::AnnotationConfigurations.new(#{annotation_configurations} of ADI::AnnotationConfigurations::Classes => Array(ADI::AnnotationConfigurations::ConfigurationBase)),
-                value: #{(accessor = ivar.annotation(ASRA::Accessor)) && nil != accessor[:getter] ? accessor[:getter].id : %(@#{ivar.id}).id},
+                value: #{value},
                 skip_when_empty: #{!!ivar.annotation(ASRA::SkipWhenEmpty)},
                 groups: #{(ann = ivar.annotation(ASRA::Groups)) && !ann.args.empty? ? [ann.args.splat] : ["default"]},
                 since_version: #{(ann = ivar.annotation(ASRA::Since)) && nil != ann[0] ? "SemanticVersion.parse(#{ann[0]})".id : nil},
                 until_version: #{(ann = ivar.annotation(ASRA::Until)) && nil != ann[0] ? "SemanticVersion.parse(#{ann[0]})".id : nil},
-              )).id %}
+              )).id
+            %}
             {% end %}
 
           {% for m in @type.methods.select &.annotation(ASRA::VirtualProperty) %}


### PR DESCRIPTION
## Context

The logic was previously assuming the type of the ivar and the type of the value were the same, which could technically not be true when using accessor.

Fixes #513

## Changelog

* Fix serialization of value when its type is different type than the ivar

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
