### PR TITLE
Prevent defining `ASPEC::TestCase#initialize` methods that accepts arguments/blocks

### DIFF
--- a/src/components/framework/spec/spec/web_test_case_spec.cr
+++ b/src/components/framework/spec/spec/web_test_case_spec.cr
@@ -2,11 +2,7 @@ require "../spec_helper"
 
 @[ASPEC::TestCase::Skip]
 private struct MockWebTestCase < ATH::Spec::WebTestCase
-  def initialize(@client : ATH::Spec::AbstractBrowser); end
-
-  def create_client : ATH::Spec::AbstractBrowser
-    @client
-  end
+  def client=(@client : ATH::Spec::AbstractBrowser); end
 end
 
 private class MockClient < ATH::Spec::AbstractBrowser
@@ -201,6 +197,8 @@ struct WebTestCaseTest < ASPEC::TestCase
   end
 
   private def tester(client : ATH::Spec::AbstractBrowser) : ATH::Spec::WebTestCase
-    MockWebTestCase.new client
+    obj = MockWebTestCase.new
+    obj.client = client
+    obj
   end
 end

--- a/src/components/spec/spec/compiler_spec.cr
+++ b/src/components/spec/spec/compiler_spec.cr
@@ -93,5 +93,21 @@ describe Athena::Spec do
         CODE
       end
     end
+
+    it "errors if defining a non-argless initializer" do
+      assert_error "`ASPEC::TestCase` initializers must be argless and non-yielding.", <<-CODE
+        struct TestTestCase < ASPEC::TestCase
+          def initialize(id : Int32); end
+        end
+        CODE
+    end
+
+    it "errors if defining a yielding initializer" do
+      assert_error "`ASPEC::TestCase` initializers must be argless and non-yielding.", <<-CODE
+        struct TestTestCase < ASPEC::TestCase
+          def initialize(&); end
+        end
+        CODE
+    end
   end
 end

--- a/src/components/spec/src/test_case.cr
+++ b/src/components/spec/src/test_case.cr
@@ -305,6 +305,20 @@ abstract struct Athena::Spec::TestCase
   def initialize(__init init : Nil)
   end
 
+  macro inherited
+    macro finished
+      {% verbatim do %}
+        {%
+          @type.methods.select(&.name.==("initialize")).each do |a_def|
+            if a_def.accepts_block? || a_def.args.size > 0
+              a_def.raise "`ASPEC::TestCase` initializers must be argless and non-yielding."
+            end
+          end
+        %}
+      {% end %}
+    end
+  end
+
   # Runs the tests contained within `self`.
   #
   # See `Athena::Spec.run_all` to run all test cases.


### PR DESCRIPTION
## Context

These methods must not accept parameters so some internal implementation details work as expected.

Resolves #515 

## Changelog

* Prevent defining `ASPEC::TestCase#initialize` methods that accepts arguments/blocks

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
