### PR TITLE
Fix incorrectly aligned block

### DIFF
--- a/src/components/console/spec/helper/formatter_spec.cr
+++ b/src/components/console/spec/helper/formatter_spec.cr
@@ -38,7 +38,7 @@ describe ACON::Helper::Formatter do
     it "escapes < within the block" do
       ACON::Helper::Formatter.new.format_block("<info>some info</info>", "error", true).should eq normalize <<-BLOCK
       <error>                            </error>
-      <error>  \\<info>some info\\</info>  </error>
+      <error>  \\<info>some info\\</info>    </error>
       <error>                            </error>
       BLOCK
     end

--- a/src/components/console/src/helper/formatter.cr
+++ b/src/components/console/src/helper/formatter.cr
@@ -42,7 +42,7 @@ class Athena::Console::Helper::Formatter < Athena::Console::Helper
     messages = large ? [" " * len] : [] of String
 
     lines.each do |line|
-      messages << %(#{line}#{" " * (len - line.gsub('\\', nil).size)})
+      messages << %(#{line}#{" " * (len - line.delete('\\').size)})
     end
 
     if large

--- a/src/components/console/src/helper/formatter.cr
+++ b/src/components/console/src/helper/formatter.cr
@@ -42,7 +42,7 @@ class Athena::Console::Helper::Formatter < Athena::Console::Helper
     messages = large ? [" " * len] : [] of String
 
     lines.each do |line|
-      messages << %(#{line}#{" " * (len - line.size)})
+      messages << %(#{line}#{" " * (len - line.gsub('\\', nil).size)})
     end
 
     if large


### PR DESCRIPTION
## Context

This bug is due to the number of backslashes in the message content; as a result, the block has not colored the exact block size for the first and the last line. The solution is to remove these antislashes.

```crystal
lines.each do |line|
  messages << %(#{line}#{" " * (len - line.gsub('\\', nil).size)})
end
```

Thanks to `#gsub` method, the block is formated correctly.

![image](https://github.com/user-attachments/assets/ddc7b7cd-2acf-491b-ae0a-96cc271d6f3b)

## Changelog

- Fix incorrectly aligned block

Fixes #202

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
