### PR TITLE
Prevent auto registering of already registered services

### DIFF
--- a/src/components/dependency_injection/spec/compiler_passes/register_services_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/register_services_spec.cr
@@ -115,6 +115,29 @@ describe ADI::ServiceContainer::RegisterServices do
       CR
     end
 
+    it "errors if the service is already registered" do
+      assert_error "Failed to auto register service for 'my_service' (MyService). It is already registered.", <<-CR
+        @[ADI::Register]
+        record MyService
+
+        module MyExtension
+          macro included
+            macro finished
+              {% verbatim do %}
+                {%
+                  SERVICE_HASH["my_service"] = {
+                    class:      MyService,
+                  }
+                %}
+              {% end %}
+            end
+          end
+        end
+
+        ADI.add_compiler_pass MyExtension, :before_optimization, 1028
+        CR
+    end
+
     describe "factory" do
       it "errors if method is an instance method" do
         assert_error "Failed to auto register service 'foo'. Factory method 'foo' within 'Foo' is an instance method.", <<-CR

--- a/src/components/dependency_injection/src/compiler_passes/register_services.cr
+++ b/src/components/dependency_injection/src/compiler_passes/register_services.cr
@@ -119,6 +119,12 @@ module Athena::DependencyInjection::ServiceContainer::RegisterServices
               %}
 
               {%
+                unless SERVICE_HASH[service_id].nil?
+                  ann.raise "Failed to auto register service for '#{service_id.id}' (#{klass}). It is already registered."
+                end
+              %}
+
+              {%
                 SERVICE_HASH[service_id] = {
                   class:             klass.resolve,
                   factory:           factory,

--- a/src/components/framework/src/view/view_handler.cr
+++ b/src/components/framework/src/view/view_handler.cr
@@ -2,7 +2,6 @@ require "./configurable_view_handler_interface"
 
 ADI.bind format_handlers : Array(Athena::Framework::View::FormatHandlerInterface), "!athena.format_handler"
 
-@[ADI::Register]
 @[ADI::AsAlias(ATH::View::ConfigurableViewHandlerInterface)]
 @[ADI::AsAlias(ATH::View::ViewHandlerInterface)]
 # Default implementation of `ATH::View::ConfigurableViewHandlerInterface`.


### PR DESCRIPTION
## Context

When you manually register a service in an extension, but also applied the `ADI::Register` annotation, the latter was overriding the settings applied to the service. This can lead to subtle bugs, like the one this PR fixes.

This can always be changed in the future, but I felt it would be best to prevent this scenario. This PR will raise a compile time error when it happens.

Fixes #517 

## Changelog

* Prevent auto registering services that are manually registered
  * This is technically breaking, but the extension feature is internal so unlikely for anyone to be affected
* Fix `ATH::ViewHandler` bundle configuration values not being correctly set

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
