### PR TITLE
Fix typo in `Assert::Blank` and `Assert::ISSN` constraints

### DIFF
--- a/src/components/validator/src/constraints/blank.cr
+++ b/src/components/validator/src/constraints/blank.cr
@@ -6,7 +6,7 @@
 #
 #   def initialize(@username : String); end
 #
-#   @[Assert::NotBlank]
+#   @[Assert::Blank]
 #   property username : String
 # end
 # ```

--- a/src/components/validator/src/constraints/issn.cr
+++ b/src/components/validator/src/constraints/issn.cr
@@ -8,7 +8,7 @@
 # class Journal
 #   include AVD::Validatable
 #
-#   def initialize(@isin : String); end
+#   def initialize(@issn : String); end
 #
 #   @[Assert::ISSN]
 #   property issn : String


### PR DESCRIPTION
## Context
In the PR #483, some typo are present in two constraints : `Assert::Blank` and `Assert::ISSN`, even after review.

## Changelog

- Fix typo in `Assert::Blank` and `Assert::ISSN` constraints.

PR reference : #483

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
