### PR TITLE
Fix `framework` changelog entry

### DIFF
--- a/src/components/framework/CHANGELOG.md
+++ b/src/components/framework/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
--Fix `ATH::ViewHandler` bundle configuration values not being correctly set ([#520](https://github.com/athena-framework/athena/pull/520)) (George Dietrich)
+- Fix `ATH::ViewHandler` bundle configuration values not being correctly set ([#520](https://github.com/athena-framework/athena/pull/520)) (George Dietrich)
 
 ## [0.20.0] - 2025-01-26
 


### PR DESCRIPTION
## Changelog

- Fix `framework` changelog entry

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
