### PR TITLE
Make `ATH::Controller.render` specs more robust by ignoring trailing newlines

### DIFF
--- a/src/components/framework/spec/controller_spec.cr
+++ b/src/components/framework/spec/controller_spec.cr
@@ -9,7 +9,7 @@ describe ATH::Controller do
 
       response.status.should eq HTTP::Status::OK
       response.headers["content-type"].should eq "text/html"
-      response.content.should eq "Greetings, TEST!#{EOL}"
+      response.content.chomp.should eq "Greetings, TEST!"
     end
 
     it "creates a proper response for the template with a layout" do
@@ -19,7 +19,7 @@ describe ATH::Controller do
 
       response.status.should eq HTTP::Status::OK
       response.headers["content-type"].should eq "text/html"
-      response.content.should eq "<h1>Content:</h1> Greetings, TEST!#{EOL}"
+      response.content.chomp.should eq "<h1>Content:</h1> Greetings, TEST!"
     end
   end
 


### PR DESCRIPTION
## Context

Windows and Unix based OSs use different trailing newlines. This can lead to failing specs due to `\n` not being equal to `\r\n`. This PR removes them entirely from two specs as they are not important for what's being tested here.

## Changelog

* Make `ATH::Controller.render` specs more robust by ignoring trailing newlines

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
