### PR TITLE
Allow customizing the finished state of an `ACON::Helper::ProgressIndicator`

### DIFF
--- a/src/components/console/spec/helper/progress_indicator_spec.cr
+++ b/src/components/console/spec/helper/progress_indicator_spec.cr
@@ -52,11 +52,11 @@ struct ProgressIndicatorTest < ASPEC::TestCase
       self.generate_output(" \\ Starting..."),
       self.generate_output(" \\ Advancing..."),
       self.generate_output(" | Advancing..."),
-      self.generate_output(" | Done..."),
+      self.generate_output(" ✔ Done..."),
       EOL,
       self.generate_output(" - Starting Again..."),
       self.generate_output(" \\ Starting Again..."),
-      self.generate_output(" \\ Done Again..."),
+      self.generate_output(" ✔ Done Again..."),
       EOL,
     )
   end
@@ -97,6 +97,36 @@ struct ProgressIndicatorTest < ASPEC::TestCase
       self.generate_output(" b Starting..."),
       self.generate_output(" c Starting..."),
       self.generate_output(" a Starting..."),
+    )
+  end
+
+  def test_custom_finished_indicator_value : Nil
+    indicator = ACON::Helper::ProgressIndicator.new output = self.output, finished_indicator: "✅", clock: @clock
+
+    indicator.start "Starting..."
+    @clock.sleep 101.milliseconds
+    indicator.finish "Done"
+
+    self.assert_output(
+      output,
+      self.generate_output(" - Starting..."),
+      self.generate_output(" ✅ Done"),
+      EOL
+    )
+  end
+
+  def test_custom_finished_indicator_value_finish : Nil
+    indicator = ACON::Helper::ProgressIndicator.new output = self.output, clock: @clock
+
+    indicator.start "Starting..."
+    @clock.sleep 101.milliseconds
+    indicator.finish "Done", "|==|"
+
+    self.assert_output(
+      output,
+      self.generate_output(" - Starting..."),
+      self.generate_output(" |==| Done"),
+      EOL
     )
   end
 


### PR DESCRIPTION
## Context

Previously when an `ACON::Helper::ProcessIndicator` finished, it would just stop and display on whatever indicator was last displayed. This PR allows customizing it to display a unique character once it's fnished.

## Changelog

* Allow customizing the finished state of an `ACON::Helper::ProgressIndicator`

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
