### PR TITLE
Fix `ACON::Helper::ProgressBar` messing up output in console section with EOL

### DIFF
--- a/src/components/console/spec/helper/progress_bar_spec.cr
+++ b/src/components/console/spec/helper/progress_bar_spec.cr
@@ -1126,6 +1126,78 @@ struct ProgressBarTest < ASPEC::TestCase
     )
   end
 
+  def test_overwrite_with_section_output_and_eol : Nil
+    sections = Array(ACON::Output::Section).new
+    acon_output = self.output
+
+    output = ACON::Output::Section.new acon_output.io, sections, verbosity: acon_output.verbosity, decorated: acon_output.decorated?, formatter: ACON::Formatter::Output.new
+
+    bar = ACON::Helper::ProgressBar.new output, 50, 0
+    bar.format = "[%bar%] %percent:3s%%#{EOL}%message%#{EOL}"
+    bar.set_message ""
+    bar.start
+    bar.display
+    bar.set_message "Doing something..."
+    bar.advance
+    bar.set_message "Doing something foo..."
+    bar.advance
+
+    self.assert_output(
+      output,
+      "[>---------------------------]   0%#{EOL}#{EOL}",
+      "\x1b[2A\x1b[0J[>---------------------------]   2%#{EOL}Doing something...#{EOL}",
+      "\x1b[2A\x1b[0J[=>--------------------------]   4%#{EOL}Doing something foo...#{EOL}",
+    )
+  end
+
+  def test_overwrite_with_section_output_and_eol_with_empty_message : Nil
+    sections = Array(ACON::Output::Section).new
+    acon_output = self.output
+
+    output = ACON::Output::Section.new acon_output.io, sections, verbosity: acon_output.verbosity, decorated: acon_output.decorated?, formatter: ACON::Formatter::Output.new
+
+    bar = ACON::Helper::ProgressBar.new output, 50, 0
+    bar.format = "[%bar%] %percent:3s%%#{EOL}%message%"
+    bar.set_message "Start"
+    bar.start
+    bar.display
+    bar.set_message ""
+    bar.advance
+    bar.set_message "Doing something..."
+    bar.advance
+
+    self.assert_output(
+      output,
+      "[>---------------------------]   0%#{EOL}Start#{EOL}",
+      "\x1b[2A\x1b[0J[>---------------------------]   2%#{EOL}",
+      "\x1b[1A\x1b[0J[=>--------------------------]   4%#{EOL}Doing something...#{EOL}",
+    )
+  end
+
+  def test_overwrite_with_section_output_and_eol_with_empty_message_comment : Nil
+    sections = Array(ACON::Output::Section).new
+    acon_output = self.output
+
+    output = ACON::Output::Section.new acon_output.io, sections, verbosity: acon_output.verbosity, decorated: acon_output.decorated?, formatter: ACON::Formatter::Output.new
+
+    bar = ACON::Helper::ProgressBar.new output, 50, 0
+    bar.format = "[%bar%] %percent:3s%%#{EOL}<comment>%message%</comment>"
+    bar.set_message "Start"
+    bar.start
+    bar.display
+    bar.set_message ""
+    bar.advance
+    bar.set_message "Doing something..."
+    bar.advance
+
+    self.assert_output(
+      output,
+      "[>---------------------------]   0%#{EOL}\x1b[33mStart\x1b[0m#{EOL}",
+      "\x1b[2A\x1b[0J[>---------------------------]   2%#{EOL}",
+      "\x1b[1A\x1b[0J[=>--------------------------]   4%#{EOL}\x1b[33mDoing something...\x1b[0m#{EOL}",
+    )
+  end
+
   private def generate_output(*expected : String) : String
     self.generate_output expected.join
   end

--- a/src/components/console/src/helper/progress_bar.cr
+++ b/src/components/console/src/helper/progress_bar.cr
@@ -752,8 +752,15 @@ class Athena::Console::Helper::ProgressBar
     if @overwrite
       if previous_message = @previous_message
         if (output = @output).is_a? ACON::Output::Section
-          message_lines = previous_message.lines
+          message_lines = previous_message.split '\n' # Don't use `#lines` to retain empty values
           line_count = message_lines.size
+
+          last_line_without_decoration = ACON::Helper.remove_decoration output.formatter, (message_lines.last? || "")
+
+          # When the last previous line is empty (without formatting) it is already cleared by the section output, so we don't need to clear it again
+          if last_line_without_decoration.empty?
+            line_count -= 1
+          end
 
           message_lines.each do |line|
             message_line_length = ACON::Helper.width ACON::Helper.remove_decoration output.formatter, line


### PR DESCRIPTION
## Context

If there was an EOL within a console output section the progress bar would previously always clear one more line than it needed to. This made it so it would slowly "eat" up your terminal instead of staying in place as it should.

## Changelog

* Fix `ACON::Helper::ProgressBar` messing up output in console section with EOL

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
