### PR TITLE
Fix duplicate test case runs with abstract generic parent test case

### DIFF
--- a/src/components/spec/CHANGELOG.md
+++ b/src/components/spec/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.11] - 2025-05-19
+
+### Fixed
+
+- Fix duplicate test case runs with abstract generic parent test case ([#538](https://github.com/athena-framework/athena/pull/538)) (George Dietrich)
+
 ## [0.3.10] - 2025-02-08
 
 ### Changed
@@ -124,6 +130,8 @@ _First release a part of the monorepo._
 
 _Initial release._
 
+[0.3.11]: https://github.com/athena-framework/spec/releases/tag/v0.3.11
+[0.3.10]: https://github.com/athena-framework/spec/releases/tag/v0.3.10
 [0.3.9]: https://github.com/athena-framework/spec/releases/tag/v0.3.9
 [0.3.8]: https://github.com/athena-framework/spec/releases/tag/v0.3.8
 [0.3.7]: https://github.com/athena-framework/spec/releases/tag/v0.3.7

--- a/src/components/spec/shard.yml
+++ b/src/components/spec/shard.yml
@@ -1,6 +1,6 @@
 name: athena-spec
 
-version: 0.3.10
+version: 0.3.11
 
 crystal: ~> 1.4
 

--- a/src/components/spec/spec/athena-spec_spec.cr
+++ b/src/components/spec/spec/athena-spec_spec.cr
@@ -163,3 +163,32 @@ struct BeforeAllTest < ASPEC::TestCase
     # no-op
   end
 end
+
+abstract struct GenericTestCase(T) < ASPEC::TestCase
+end
+
+struct GenericIntTest < GenericTestCase(Int32)
+  @@count : Int32 = 0
+
+  def test_runs_once
+    1.should eq 1
+    @@count += 1
+  end
+
+  def after_all : Nil
+    it "runs generic string inheritance test cases only once" { @@count.should eq 1 }
+  end
+end
+
+struct GenericStringTest < GenericTestCase(String)
+  @@count : Int32 = 0
+
+  def test_runs_once
+    1.should eq 1
+    @@count += 1
+  end
+
+  def after_all : Nil
+    it "runs generic int inheritance test cases only once" { @@count.should eq 1 }
+  end
+end

--- a/src/components/spec/src/athena-spec.cr
+++ b/src/components/spec/src/athena-spec.cr
@@ -12,7 +12,7 @@ module Athena::Spec
   #
   # Is equivalent to manually calling `.run` on each test case.
   def self.run_all : Nil
-    {% for unit_test in ASPEC::TestCase.all_subclasses.reject { |tc| tc.abstract? || tc.annotation(ASPEC::TestCase::Skip) } %}
+    {% for unit_test in ASPEC::TestCase.all_subclasses.reject { |tc| tc.abstract? || tc.annotation(ASPEC::TestCase::Skip) }.uniq %}
       {{unit_test.id}}.run
     {% end %}
   end

--- a/src/components/spec/src/athena-spec.cr
+++ b/src/components/spec/src/athena-spec.cr
@@ -6,7 +6,7 @@ require "./test_case"
 
 # A set of common [Spec](https://crystal-lang.org/api/Spec.html) compliant testing utilities/types.
 module Athena::Spec
-  VERSION = "0.3.10"
+  VERSION = "0.3.11"
 
   # Runs all `ASPEC::TestCase`s.
   #

--- a/src/components/spec/src/athena-spec.cr
+++ b/src/components/spec/src/athena-spec.cr
@@ -12,6 +12,7 @@ module Athena::Spec
   #
   # Is equivalent to manually calling `.run` on each test case.
   def self.run_all : Nil
+    # `#uniq` is to work around https://github.com/crystal-lang/crystal/issues/15793.
     {% for unit_test in ASPEC::TestCase.all_subclasses.reject { |tc| tc.abstract? || tc.annotation(ASPEC::TestCase::Skip) }.uniq %}
       {{unit_test.id}}.run
     {% end %}


### PR DESCRIPTION
## Context

Work around https://github.com/crystal-lang/crystal/issues/15793 by ignoring duplicate concrete implementation types that were resulting in test cases that have generic parents to run more than once. 

## Changelog

* Fix duplicate test case runs with abstract generic parent test case

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
