### PR TITLE
Add `AVD::Spec::CompoundConstraintTestCase`

### DIFF
--- a/src/components/validator/spec/spec/compound_constraint_test_case_spec.cr
+++ b/src/components/validator/spec/spec/compound_constraint_test_case_spec.cr
@@ -11,7 +11,6 @@ private class DummyCompoundConstraint < AVD::Constraints::Compound
   end
 end
 
-@[ASPEC::TestCase::Focus]
 struct CompoundConstraintTestCaseTest < AVD::Spec::CompoundConstraintTestCase(String)
   protected def create_compound : AVD::Constraints::Compound
     DummyCompoundConstraint.new

--- a/src/components/validator/spec/spec/compound_constraint_test_case_spec.cr
+++ b/src/components/validator/spec/spec/compound_constraint_test_case_spec.cr
@@ -1,0 +1,33 @@
+require "../spec_helper"
+
+private class DummyCompoundConstraint < AVD::Constraints::Compound
+  def constraints : Type
+    [
+      AVD::Constraints::NotBlank.new,
+      AVD::Constraints::Size.new(..3),
+      AVD::Constraints::Regex.new(/[a-z]+/),
+      AVD::Constraints::Regex.new(/[0-9]+/),
+    ]
+  end
+end
+
+@[ASPEC::TestCase::Focus]
+struct CompoundConstraintTestCaseTest < AVD::Spec::CompoundConstraintTestCase(String)
+  protected def create_compound : AVD::Constraints::Compound
+    DummyCompoundConstraint.new
+  end
+
+  def test_assert_no_violation : Nil
+    self.validate_value "ab1"
+
+    self.assert_no_violation
+    self.assert_violation_count 0
+  end
+
+  def test_assert_is_raised_by_component : Nil
+    self.validate_value "ab1"
+
+    self.assert_violations_raised_by_compound AVD::Constraints::NotBlank.new
+    self.assert_violation_count 1
+  end
+end

--- a/src/components/validator/spec/spec/compound_constraint_test_case_spec.cr
+++ b/src/components/validator/spec/spec/compound_constraint_test_case_spec.cr
@@ -4,7 +4,7 @@ private class DummyCompoundConstraint < AVD::Constraints::Compound
   def constraints : Type
     [
       AVD::Constraints::NotBlank.new,
-      AVD::Constraints::Size.new(..3),
+      AVD::Constraints::Size.new(...3),
       AVD::Constraints::Regex.new(/[a-z]+/),
       AVD::Constraints::Regex.new(/[0-9]+/),
     ]
@@ -25,9 +25,50 @@ struct CompoundConstraintTestCaseTest < AVD::Spec::CompoundConstraintTestCase(St
   end
 
   def test_assert_is_raised_by_component : Nil
-    self.validate_value "ab1"
+    self.validate_value ""
 
     self.assert_violations_raised_by_compound AVD::Constraints::NotBlank.new
     self.assert_violation_count 1
+  end
+
+  def test_multiple_assert_are_raised_by_compound : Nil
+    self.validate_value "1234"
+
+    self.assert_violations_raised_by_compound(
+      AVD::Constraints::Size.new(...3),
+      AVD::Constraints::Regex.new(/[a-z]+/),
+    )
+    self.assert_violation_count 2
+  end
+
+  def test_no_assert_raised_but_expected : Nil
+    self.validate_value "azert"
+
+    expect_raises ::Spec::AssertionFailed, "Expected violation(s) for constraint(s) 'Athena::Validator::Constraints::Size, Athena::Validator::Constraints::Regex' to be raised by compound." do
+      self.assert_violations_raised_by_compound(
+        AVD::Constraints::Size.new(..5),
+        AVD::Constraints::Regex.new(/^[A-Z]+$/),
+      )
+    end
+  end
+
+  def test_assert_raised_by_compound_is_not_exactly_the_same : Nil
+    self.validate_value "123"
+
+    expect_raises ::Spec::AssertionFailed, "Expected violation(s) for constraint(s) 'Athena::Validator::Constraints::Regex' to be raised by compound." do
+      self.assert_violations_raised_by_compound(
+        AVD::Constraints::Regex.new(/^[A-Z]+$/),
+      )
+    end
+  end
+
+  def test_assert_raised_by_compound_but_got_none : Nil
+    self.validate_value "123"
+
+    expect_raises ::Spec::AssertionFailed, "Expected at least one violation for constraint(s): 'Athena::Validator::Constraints::Size', got none." do
+      self.assert_violations_raised_by_compound(
+        AVD::Constraints::Size.new(..5),
+      )
+    end
   end
 end

--- a/src/components/validator/src/constraint.cr
+++ b/src/components/validator/src/constraint.cr
@@ -313,6 +313,17 @@ abstract class Athena::Validator::Constraint
       def validated_by : AVD::ConstraintValidator.class
         Validator
       end
+
+      # :nodoc:
+      def ==(other : self) : Bool
+        \{% if @type.class? %}
+          return true if same?(other)
+        \{% end %}
+        \{% for field in @type.instance_vars %}
+          return false unless @\{{field.id}} == other.@\{{field.id}}
+        \{% end %}
+        true
+      end
     {% end %}
   end
 end

--- a/src/components/validator/src/spec.cr
+++ b/src/components/validator/src/spec.cr
@@ -1,6 +1,7 @@
 require "athena-spec"
 
 require "./spec/abstract_validator_test_case"
+require "./spec/compound_constraint_test_case"
 require "./spec/constraint_validator_test_case"
 require "./spec/validator_test_case"
 

--- a/src/components/validator/src/spec/compound_constraint_test_case.cr
+++ b/src/components/validator/src/spec/compound_constraint_test_case.cr
@@ -1,3 +1,34 @@
+# The `AVD::Constraints::Compound` constraint allows grouping other constraints into a single reusable constraint.
+# Such as for defining requirements of a user's password.
+#
+# This type may be used to more easily test compound constraints.
+# For example, using the `AVD::Constraints::ValidPassword` constraint in the usage docs for the `Compound` constraint:
+#
+# ```
+# # The generic should be set to the type(s) that the compound constraint supports.
+# struct ValidPasswordTest < AVD::Spec::CompoundConstraintTestCase(String?)
+#   protected def create_compound : AVD::Constraints::Compound
+#     AVD::Constraints::ValidPassword.new
+#   end
+#
+#   def test_valid_password : Nil
+#     self.validate_value "1VeryStr0ngP4$$wOrD"
+#
+#     self.assert_no_violation
+#   end
+#
+#   @[TestWith(
+#     nil: {nil, AVD::Constraints::NotBlank.new},
+#     too_short: {"123", AVD::Constraints::Size.new(12..)},
+#     letter_first: {"abc12345qwerty", AVD::Constraints::Regex.new(/^\d.*/)},
+#   )]
+#   def test_invalid_password(password : String?, expected_failing_constraint : AVD::Constraint) : Nil
+#     self.validate_value password
+#
+#     self.assert_violations_raised_by_compound expected_failing_constraint
+#   end
+# end
+# ```
 abstract struct Athena::Validator::Spec::CompoundConstraintTestCase(T) < ASPEC::TestCase
   @validator : AVD::Validator::ValidatorInterface
   @violation_list : Array(AVD::Violation::ConstraintViolationListInterface)? = nil
@@ -16,15 +47,21 @@ abstract struct Athena::Validator::Spec::CompoundConstraintTestCase(T) < ASPEC::
     end
   end
 
-  def initialize
+  protected def initialize
     @root = "root"
     @validator = validator = create_validator
     @context = create_context validator
   end
 
+  # :showdoc:
+  #
+  # Returns the compound constraint instance to be tested.
   protected abstract def create_compound : AVD::Constraints::Compound
 
-  def assert_violations_raised_by_compound(*constraints : AVD::Constraint) : Nil
+  # :showdoc:
+  #
+  # Asserts that each of the provided *constraints* were properly raised.
+  protected def assert_violations_raised_by_compound(*constraints : AVD::Constraint) : Nil
     validator = AVD::Constraints::Compound::Validator.new
     context = self.create_context
     validator.context = context
@@ -46,24 +83,33 @@ abstract struct Athena::Validator::Spec::CompoundConstraintTestCase(T) < ASPEC::
     failed_to_assert_violations.should be_empty, failure_message: "Expected violation(s) for constraint(s) '#{failed_to_assert_violations.join(", ", &.constraint.class)}' to be raised by compound."
   end
 
+  # :showdoc:
+  #
+  # Validates the provided *value*, populating the data required for further assertions.
   protected def validate_value(value : T) : Nil
     @validated_value = AVD::ValueContainer(T).new(value)
     @validator.in_context(@context).validate(value, self.create_compound)
   end
 
+  # :showdoc:
+  #
+  # Asserts there are *count* violations after calling `#validate_value`.
   protected def assert_violation_count(count : Int) : Nil
     @context.violations.size.should eq count
   end
 
+  # :showdoc:
+  #
+  # Asserts there are no violations after calling `#validate_value`.
   protected def assert_no_violation : Nil
     @context.violations.should be_empty
   end
 
-  protected def create_validator : AVD::Validator::ValidatorInterface
+  private def create_validator : AVD::Validator::ValidatorInterface
     AVD.validator
   end
 
-  protected def create_context(validator : AVD::Validator::ValidatorInterface? = nil) : AVD::ExecutionContextInterface
+  private def create_context(validator : AVD::Validator::ValidatorInterface? = nil) : AVD::ExecutionContextInterface
     AVD::ExecutionContext.new validator || create_validator, @root
   end
 end

--- a/src/components/validator/src/spec/compound_constraint_test_case.cr
+++ b/src/components/validator/src/spec/compound_constraint_test_case.cr
@@ -1,0 +1,71 @@
+abstract struct Athena::Validator::Spec::CompoundConstraintTestCase(T) < ASPEC::TestCase
+  @validator : AVD::Validator::ValidatorInterface
+  @violation_list : Array(AVD::Violation::ConstraintViolationListInterface)? = nil
+  @context : AVD::ExecutionContextInterface
+  @root : String
+
+  private getter! validated_value : AVD::ValueContainer(T)
+
+  private class MockCompoundValidator < AVD::Constraints::Compound
+    def initialize(@tested_constraints : Array(AVD::Constraint))
+      super()
+    end
+
+    def constraints : AVD::Constraints::Composite::Type
+      @tested_constraints
+    end
+  end
+
+  def initialize
+    @root = "root"
+    @validator = validator = create_validator
+    @context = create_context validator
+  end
+
+  protected abstract def create_compound : AVD::Constraints::Compound
+
+  def assert_violations_raised_by_compound(constraints : AVD::Constraint | Array(AVD::Constraint)) : Nil
+    constraints = constraints.is_a?(AVD::Constraint) ? [constraints] : constraints
+
+    validator = AVD::Constraints::Compound::Validator.new
+    context = self.create_context
+    validator.context = context
+
+    validator.validate self.validated_value.value, MockCompoundValidator.new(constraints.map(&.as(AVD::Constraint)))
+
+    violations = context.violations
+
+    violations.should_not be_empty, failure_message: "Expected at least one violation for constraint(s): '#{constraints.join(", ", &.class)}', got none."
+
+    failed_to_assert_violations = [] of AVD::Violation::ConstraintViolationInterface
+
+    context.violations.each_with_index do |violation, idx|
+      if violation != violations[idx]
+        failed_to_assert_violations << violation
+      end
+    end
+
+    failed_to_assert_violations.should be_empty
+  end
+
+  protected def validate_value(value : T) : Nil
+    @validated_value = AVD::ValueContainer(T).new(value)
+    @validator.in_context(@context).validate(value, self.create_compound)
+  end
+
+  protected def assert_violation_count(count : Int) : Nil
+    @context.violations.size.should eq count
+  end
+
+  protected def assert_no_violation : Nil
+    @context.violations.should be_empty
+  end
+
+  protected def create_validator : AVD::Validator::ValidatorInterface
+    AVD.validator
+  end
+
+  protected def create_context(validator : AVD::Validator::ValidatorInterface? = nil) : AVD::ExecutionContextInterface
+    AVD::ExecutionContext.new validator || create_validator, @root
+  end
+end


### PR DESCRIPTION
## Context

Compound constraints are useful, but previously were quite hard to test. This PR introduces a new abstract test case specifically suited to testing them.

## Changelog

* Add `AVD::Spec::CompoundConstraintTestCase`
* Fix equality between `AVD::Constraint` instances

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
