### PR TITLE
Contracts package

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ These include:
 
 * [Clock](/Clock) (`ACLK`) - Decouples applications from the system clock
 * [Console](/Console) (`ACON`) - Allows the creation of CLI based commands
+* [Contracts](/Contracts) (`ACTR`) - A set of abstractions extracted out of the Athena components
 * [DependencyInjection](/DependencyInjection) (`ADI`) - Robust dependency injection service container framework
 * [Dotenv](/Dotenv) - Registers environment variables from a `.env` file
 * [EventDispatcher](/EventDispatcher) (`AED`) - A Mediator and Observer pattern event library

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,33 +21,34 @@ nav:
   - Introducton: README.md
   - Why Athena: why_athena.md
   - Getting Started:
-    - getting_started/README.md
-    - Routing & HTTP: getting_started/routing.md
-    - Configuration: getting_started/configuration.md
-    - Middleware: getting_started/middleware.md
-    - Error Handling: getting_started/error_handling.md
-    - Commands: getting_started/commands.md
-    - Validation: getting_started/validation.md
-    - Testing: getting_started/testing.md
+      - getting_started/README.md
+      - Routing & HTTP: getting_started/routing.md
+      - Configuration: getting_started/configuration.md
+      - Middleware: getting_started/middleware.md
+      - Error Handling: getting_started/error_handling.md
+      - Commands: getting_started/commands.md
+      - Validation: getting_started/validation.md
+      - Testing: getting_started/testing.md
   - Guides:
-    - guides/README.md
-    - Proxies & Load Balancers: guides/proxies.md
+      - guides/README.md
+      - Proxies & Load Balancers: guides/proxies.md
   - API Reference:
-    - api_reference.md
-    - project://clock
-    - project://console
-    - project://dependency_injection
-    - project://dotenv
-    - project://event_dispatcher
-    - project://framework
-    - project://image_size
-    - project://mercure
-    - project://mime
-    - project://negotiation
-    - project://routing
-    - project://serializer
-    - project://spec
-    - project://validator
+      - api_reference.md
+      - project://clock
+      - project://console
+      - project://contracts
+      - project://dependency_injection
+      - project://dotenv
+      - project://event_dispatcher
+      - project://framework
+      - project://image_size
+      - project://mercure
+      - project://mime
+      - project://negotiation
+      - project://routing
+      - project://serializer
+      - project://spec
+      - project://validator
 
 extra:
   social:

--- a/scripts/diff.sh
+++ b/scripts/diff.sh
@@ -40,6 +40,7 @@ fi
 
 diff clock
 diff console
+diff contracts
 diff dependency-injection
 diff dotenv
 diff event-dispatcher

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -25,6 +25,7 @@ function tag()
   declare -A componentNameMap
   componentNameMap[clock]=Clock
   componentNameMap[console]=Console
+  componentNameMap[contracts]=Contracts
   componentNameMap[dependency-injection]="Dependency Injection"
   componentNameMap[dotenv]="Dotenv"
   componentNameMap[event-dispatcher]="Event Dispatcher"

--- a/scripts/repo.sh
+++ b/scripts/repo.sh
@@ -32,6 +32,7 @@ case $METHOD in
   sync)
     maybeSync "src/components/clock" clock https://github.com/athena-framework/clock.git
     maybeSync "src/components/console" console https://github.com/athena-framework/console.git
+    maybeSync "src/components/contracts" contracts https://github.com/athena-framework/contracts.git
     maybeSync "src/components/dependency_injection" dependency-injection https://github.com/athena-framework/dependency-injection.git
     maybeSync "src/components/dotenv" dotenv https://github.com/athena-framework/dotenv.git
     maybeSync "src/components/event_dispatcher" event-dispatcher https://github.com/athena-framework/event-dispatcher.git

--- a/shard.dev.yml
+++ b/shard.dev.yml
@@ -6,6 +6,8 @@ dependencies:
     path: ./src/components/clock
   athena-console:
     path: ./src/components/console
+  athena-contracts:
+    path: ./src/components/contracts
   athena-dependency_injection:
     path: ./src/components/dependency_injection
   athena-dotenv:

--- a/shard.prod.yml
+++ b/shard.prod.yml
@@ -10,6 +10,9 @@ dependencies:
   athena-console:
     github: athena-framework/console
     branch: docs
+  athena-contracts:
+    github: athena-framework/contracts
+    branch: docs
   athena-dependency_injection:
     github: athena-framework/dependency-injection
     branch: docs

--- a/shard.yml
+++ b/shard.yml
@@ -20,6 +20,8 @@ dependencies:
     github: athena-framework/clock
   athena-console:
     github: athena-framework/console
+  athena-contracts:
+    github: athena-framework/contracts
   athena-dependency_injection:
     github: athena-framework/dependency-injection
   athena-dotenv:

--- a/src/components/contracts/CHANGELOG.md
+++ b/src/components/contracts/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 _Initial release._
 
-[0.1.0]: https://github.com/athena-framework/COMPONENT_NAME/releases/tag/v0.1.0
+[0.1.0]: https://github.com/athena-framework/contracts/releases/tag/v0.1.0

--- a/src/components/contracts/LICENSE
+++ b/src/components/contracts/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 CREATOR_NAME
+Copyright (c) 2025 George Dietrich
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/components/contracts/README.md
+++ b/src/components/contracts/README.md
@@ -1,40 +1,14 @@
-# README
-
-Template repo for creating a new Athena component. Scaffolds the Crystal shard's structure as well as define CI etc.
-
-**NOTE:** This repo assumes the component will be in the `athena-framework` org.  If it is to be used outside of the org, be sure to update URLs accordingly.
-
-1. Find/replace `COMPONENT_NAME` with the name of the component.  This is used as the shard's name.  E.x. `logger`.
-  1.1 Be sure to rename the file in `./src` as well.
-
-1. Replace `NAMESPACE_NAME` with the name of the component's namespace.  Documentation for this component will be grouped under this. E.x. `Logger`.
-
-1. Find/replace `CREATOR_NAME` with your Github display name. E.x. `George Dietrich`.
-
-1. Find/replace `CREATOR_USERNAME` with your Github username. E.x. `blacksmoke16`.
-
-1. Find/replace `CREATOR_EMAIL` with your desired email
-
-   5.1 Can remove this if you don't wish to expose an email.
-
-1. Find/replace `ALIAS_NAME` with the three letter alias for this component; A + 2 letter shortcut to `NAMESPACE_NAME`.  E.x. `ALG`.
-
-1. Find/replace `DESCRIPTION` with a short description of what the component does.
-
-1. Add some initial documentation to `docs/README.md`.
-
-Delete from here up
-# NAMESPACE_NAME
+# Contracts
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
 [![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
-[![Latest release](https://img.shields.io/github/release/athena-framework/COMPONENT_NAME.svg)](https://github.com/athena-framework/COMPONENT_NAME/releases)
+[![Latest release](https://img.shields.io/github/release/athena-framework/contracts.svg)](https://github.com/athena-framework/contracts/releases)
 
-DESCRIPTION.
+A set of abstractions extracted out of the Athena components.
 
 ## Getting Started
 
-Checkout the [Documentation](https://athenaframework.org/NAMESPACE_NAME).
+Checkout the [Documentation](https://athenaframework.org/Contracts).
 
 ## Contributing
 

--- a/src/components/contracts/docs/README.md
+++ b/src/components/contracts/docs/README.md
@@ -1,16 +1,21 @@
-TODO: Write me
+A set of abstractions extracted out of the Athena components.
+Can be used to build on semantics that the Athena components proved useful.
 
-## Installation
+## Design Principles
 
-First, install the component by adding the following to your `shard.yml`, then running `shards install`:
+This component is a bit special in that it includes two different "kinds" of types,
+which have different semantics.
 
-```yaml
-dependencies:
-  athena-COMPONENT_NAME:
-    github: athena-framework/COMPONENT_NAME
-    version: ~> 0.1.0
-```
+### Contracts
 
-## Usage
+The types defined within the `Athena::Contracts` namespace includes the types and interfaces to achieve loose coupling and interoperability.
+These types have backwards compatibility guarantees tied to the version of the `contracts` shard itself.
 
-TODO: Write me
+The intended use case is that other components, or third party libraries, can depend upon the `contracts` component and use its interfaces.
+Then, the code could be usable with any implementation that is also based on them.
+It could be an Athena component, or another one provided by the greater Crystal community.
+
+### Common
+
+The types not under the `Contracts` namespace are considered just "common" code shared between components.
+The backwards compatibility of these types are tied to the component the types related to, _NOT_ the `contracts` shard itself.

--- a/src/components/contracts/mkdocs.yml
+++ b/src/components/contracts/mkdocs.yml
@@ -1,16 +1,14 @@
 INHERIT: ../../../mkdocs-common.yml
 
-site_name: NAMESPACE_NAME
-site_url: https://athenaframework.org/NAMESPACE_NAME/
-repo_url: https://github.com/athena-framework/COMPONENT_NAME
+site_name: Contracts
+site_url: https://athenaframework.org/Contracts/
+repo_url: https://github.com/athena-framework/contracts
 
 nav:
   - Introduction: README.md
   - Back to Manual: project://.
   - API:
-    - Aliases: aliases.md
-    - Top Level: top_level.md
-    - '*'
+      - '*'
 
 plugins:
   - search
@@ -26,6 +24,6 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena-COMPONENT_NAME/src/athena-COMPONENT_NAME.cr
+            - ../../../lib/athena-contracts/src/athena-contracts.cr
           source_locations:
-            lib/athena-COMPONENT_NAME: https://github.com/athena-framework/COMPONENT_NAME/blob/v{shard_version}/{file}#L{line}
+            lib/athena-contracts: https://github.com/athena-framework/contracts/blob/v{shard_version}/{file}#L{line}

--- a/src/components/contracts/shard.yml
+++ b/src/components/contracts/shard.yml
@@ -1,4 +1,4 @@
-name: athena-COMPONENT_NAME
+name: athena-contracts
 
 version: 0.1.0
 
@@ -6,12 +6,12 @@ crystal: '>= 0.36.0'
 
 license: MIT
 
-repository: https://github.com/athena-framework/COMPONENT_NAME
+repository: https://github.com/athena-framework/contracts
 
-documentation: https://athenaframework.org/NAMESPACE_NAME
+documentation: https://athenaframework.org/Contracts
 
 description: |
-  DESCRIPTION.
+  A set of abstractions extracted out of the Athena components.
 
 authors:
-  - CREATOR_NAME <CREATOR_EMAIL>
+  - George Dietrich <dev@dietrich.pub>

--- a/src/components/contracts/spec/spec_helper.cr
+++ b/src/components/contracts/spec/spec_helper.cr
@@ -1,7 +1,0 @@
-require "spec"
-
-require "athena-spec"
-
-require "../src/athena-COMPONENT_NAME"
-
-ASPEC.run_all

--- a/src/components/contracts/src/athena-COMPONENT_NAME.cr
+++ b/src/components/contracts/src/athena-COMPONENT_NAME.cr
@@ -1,6 +1,0 @@
-# Convenience alias to make referencing `Athena::NAMESPACE_NAME` types easier.
-alias ALIAS_NAME = Athena::NAMESPACE_NAME
-
-module Athena::NAMESPACE_NAME
-  VERSION = "0.1.0"
-end

--- a/src/components/validator/spec/spec/compound_constraint_test_case_spec.cr
+++ b/src/components/validator/spec/spec/compound_constraint_test_case_spec.cr
@@ -1,0 +1,73 @@
+require "../spec_helper"
+
+private class DummyCompoundConstraint < AVD::Constraints::Compound
+  def constraints : Type
+    [
+      AVD::Constraints::NotBlank.new,
+      AVD::Constraints::Size.new(...3),
+      AVD::Constraints::Regex.new(/[a-z]+/),
+      AVD::Constraints::Regex.new(/[0-9]+/),
+    ]
+  end
+end
+
+struct CompoundConstraintTestCaseTest < AVD::Spec::CompoundConstraintTestCase(String)
+  protected def create_compound : AVD::Constraints::Compound
+    DummyCompoundConstraint.new
+  end
+
+  def test_assert_no_violation : Nil
+    self.validate_value "ab1"
+
+    self.assert_no_violation
+    self.assert_violation_count 0
+  end
+
+  def test_assert_is_raised_by_component : Nil
+    self.validate_value ""
+
+    self.assert_violations_raised_by_compound AVD::Constraints::NotBlank.new
+    self.assert_violation_count 1
+  end
+
+  def test_multiple_assert_are_raised_by_compound : Nil
+    self.validate_value "1234"
+
+    self.assert_violations_raised_by_compound(
+      AVD::Constraints::Size.new(...3),
+      AVD::Constraints::Regex.new(/[a-z]+/),
+    )
+    self.assert_violation_count 2
+  end
+
+  def test_no_assert_raised_but_expected : Nil
+    self.validate_value "azert"
+
+    expect_raises ::Spec::AssertionFailed, "Expected violation(s) for constraint(s) 'Athena::Validator::Constraints::Size, Athena::Validator::Constraints::Regex' to be raised by compound." do
+      self.assert_violations_raised_by_compound(
+        AVD::Constraints::Size.new(..5),
+        AVD::Constraints::Regex.new(/^[A-Z]+$/),
+      )
+    end
+  end
+
+  def test_assert_raised_by_compound_is_not_exactly_the_same : Nil
+    self.validate_value "123"
+
+    expect_raises ::Spec::AssertionFailed, "Expected violation(s) for constraint(s) 'Athena::Validator::Constraints::Regex' to be raised by compound." do
+      self.assert_violations_raised_by_compound(
+        AVD::Constraints::Regex.new(/^[A-Z]+$/),
+      )
+    end
+  end
+
+  def test_assert_raised_by_compound_but_got_none : Nil
+    self.validate_value "123"
+
+    expect_raises ::Spec::AssertionFailed, "Expected at least one violation for constraint(s): 'Athena::Validator::Constraints::Size', got none." do
+      self.assert_violations_raised_by_compound(
+        AVD::Constraints::Size.new(..5),
+      )
+    end
+  end
+end

--- a/src/components/validator/src/constraint.cr
+++ b/src/components/validator/src/constraint.cr
@@ -313,6 +313,17 @@ abstract class Athena::Validator::Constraint
       def validated_by : AVD::ConstraintValidator.class
         Validator
       end
+
+      # :nodoc:
+      def ==(other : self) : Bool
+        \{% if @type.class? %}
+          return true if same?(other)
+        \{% end %}
+        \{% for field in @type.instance_vars %}
+          return false unless @\{{field.id}} == other.@\{{field.id}}
+        \{% end %}
+        true
+      end
     {% end %}
   end
 end

--- a/src/components/validator/src/spec.cr
+++ b/src/components/validator/src/spec.cr
@@ -1,6 +1,7 @@
 require "athena-spec"
 
 require "./spec/abstract_validator_test_case"
+require "./spec/compound_constraint_test_case"
 require "./spec/constraint_validator_test_case"
 require "./spec/validator_test_case"
 

--- a/src/components/validator/src/spec/compound_constraint_test_case.cr
+++ b/src/components/validator/src/spec/compound_constraint_test_case.cr
@@ -1,0 +1,115 @@
+# The `AVD::Constraints::Compound` constraint allows grouping other constraints into a single reusable constraint.
+# Such as for defining requirements of a user's password.
+#
+# This type may be used to more easily test compound constraints.
+# For example, using the `AVD::Constraints::ValidPassword` constraint in the usage docs for the `Compound` constraint:
+#
+# ```
+# # The generic should be set to the type(s) that the compound constraint supports.
+# struct ValidPasswordTest < AVD::Spec::CompoundConstraintTestCase(String?)
+#   protected def create_compound : AVD::Constraints::Compound
+#     AVD::Constraints::ValidPassword.new
+#   end
+#
+#   def test_valid_password : Nil
+#     self.validate_value "1VeryStr0ngP4$$wOrD"
+#
+#     self.assert_no_violation
+#   end
+#
+#   @[TestWith(
+#     nil: {nil, AVD::Constraints::NotBlank.new},
+#     too_short: {"123", AVD::Constraints::Size.new(12..)},
+#     letter_first: {"abc12345qwerty", AVD::Constraints::Regex.new(/^\d.*/)},
+#   )]
+#   def test_invalid_password(password : String?, expected_failing_constraint : AVD::Constraint) : Nil
+#     self.validate_value password
+#
+#     self.assert_violations_raised_by_compound expected_failing_constraint
+#   end
+# end
+# ```
+abstract struct Athena::Validator::Spec::CompoundConstraintTestCase(T) < ASPEC::TestCase
+  @validator : AVD::Validator::ValidatorInterface
+  @violation_list : Array(AVD::Violation::ConstraintViolationListInterface)? = nil
+  @context : AVD::ExecutionContextInterface
+  @root : String
+
+  private getter! validated_value : AVD::ValueContainer(T)
+
+  private class MockCompoundValidator < AVD::Constraints::Compound
+    def initialize(@tested_constraints : Array(AVD::Constraint))
+      super()
+    end
+
+    def constraints : AVD::Constraints::Composite::Type
+      @tested_constraints
+    end
+  end
+
+  protected def initialize
+    @root = "root"
+    @validator = validator = create_validator
+    @context = create_context validator
+  end
+
+  # :showdoc:
+  #
+  # Returns the compound constraint instance to be tested.
+  protected abstract def create_compound : AVD::Constraints::Compound
+
+  # :showdoc:
+  #
+  # Asserts that each of the provided *constraints* were properly raised.
+  protected def assert_violations_raised_by_compound(*constraints : AVD::Constraint) : Nil
+    validator = AVD::Constraints::Compound::Validator.new
+    context = self.create_context
+    validator.context = context
+
+    validator.validate self.validated_value.value, MockCompoundValidator.new(constraints.to_a.map(&.as(AVD::Constraint)))
+
+    expected_violations = context.violations
+
+    expected_violations.should_not be_empty, failure_message: "Expected at least one violation for constraint(s): '#{constraints.join(", ", &.class)}', got none."
+
+    failed_to_assert_violations = [] of AVD::Violation::ConstraintViolationInterface
+
+    @context.violations.each_with_index do |violation, idx|
+      if violation != expected_violations[idx]?
+        failed_to_assert_violations << violation
+      end
+    end
+
+    failed_to_assert_violations.should be_empty, failure_message: "Expected violation(s) for constraint(s) '#{failed_to_assert_violations.join(", ", &.constraint.class)}' to be raised by compound."
+  end
+
+  # :showdoc:
+  #
+  # Validates the provided *value*, populating the data required for further assertions.
+  protected def validate_value(value : T) : Nil
+    @validated_value = AVD::ValueContainer(T).new(value)
+    @validator.in_context(@context).validate(value, self.create_compound)
+  end
+
+  # :showdoc:
+  #
+  # Asserts there are *count* violations after calling `#validate_value`.
+  protected def assert_violation_count(count : Int) : Nil
+    @context.violations.size.should eq count
+  end
+
+  # :showdoc:
+  #
+  # Asserts there are no violations after calling `#validate_value`.
+  protected def assert_no_violation : Nil
+    @context.violations.should be_empty
+  end
+
+  private def create_validator : AVD::Validator::ValidatorInterface
+    AVD.validator
+  end
+
+  private def create_context(validator : AVD::Validator::ValidatorInterface? = nil) : AVD::ExecutionContextInterface
+    AVD::ExecutionContext.new validator || create_validator, @root
+  end
+end


### PR DESCRIPTION
TODO: Move this to `src/contracts` as it's not a component. But this was easier than dealing with mkdocs projects plugin limitations.