### PR TITLE
More robust `AVD::Constraints::File` MIME type validation

### DIFF
--- a/src/components/validator/shard.yml
+++ b/src/components/validator/shard.yml
@@ -20,3 +20,6 @@ dependencies:
   athena-image_size:
     github: athena-framework/image-size
     version: ~> 0.1.0
+  athena-mime:
+    github: athena-framework/mime
+    version: ~> 0.2.0

--- a/src/components/validator/src/constraints/file.cr
+++ b/src/components/validator/src/constraints/file.cr
@@ -1,4 +1,4 @@
-require "mime"
+require "athena-mime"
 
 # Validates that a value is a valid file.
 # If the underlying value is a [::File](https://crystal-lang.org/api/File.html), then its path is used as the value.
@@ -294,7 +294,7 @@ class Athena::Validator::Constraints::File < Athena::Validator::Constraint
         return
       end
 
-      if (mime_types = constraint.mime_types) && (mime = MIME.from_filename? path)
+      if (mime_types = constraint.mime_types) && (mime = AMIME::Types.default.guess_mime_type path)
         mime_types.each do |mime_type|
           return if mime == mime_type
 


### PR DESCRIPTION
## Context

Leverage the new capabilities of `athena-mime` from #534 within the `validator` component 

## Changelog

* More robust `AVD::Constraints::File` MIME type validation via the `mime` component 

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
