### PR TITLE
Add fallback MIME types guesser based on stdlib `MIME` module

### DIFF
--- a/src/components/mime/spec/abstract_types_guesser_test_case.cr
+++ b/src/components/mime/spec/abstract_types_guesser_test_case.cr
@@ -3,14 +3,6 @@ require "./spec_helper"
 abstract struct AbstractTypesGuesserTestCase < ASPEC::TestCase
   protected abstract def guesser : AMIME::TypesGuesserInterface
 
-  def test_guess_with_leading_dash : Nil
-    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/-test").should eq "image/gif"
-  end
-
-  def test_guess_without_extension : Nil
-    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test").should eq "image/gif"
-  end
-
   def test_guess_directory : Nil
     expect_raises AMIME::Exception::InvalidArgument, "The file '#{__DIR__}/fixtures/mimetypes/directory' does not exist or is not readable." do
       self.guesser.guess_mime_type "#{__DIR__}/fixtures/mimetypes/directory"
@@ -19,14 +11,6 @@ abstract struct AbstractTypesGuesserTestCase < ASPEC::TestCase
 
   def test_guess_with_known_extension : Nil
     self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test.gif").should eq "image/gif"
-  end
-
-  def test_guess_with_unknown_extension : Nil
-    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/.unknownextension").should eq "application/octet-stream"
-  end
-
-  def test_guess_with_duplicated_file_type : Nil
-    self.guesser.guess_mime_type("#{__DIR__}/fixtures/test.docx").should eq "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
   end
 
   def test_guess_incorrect_path : Nil

--- a/src/components/mime/spec/abstract_types_guesser_test_case.cr
+++ b/src/components/mime/spec/abstract_types_guesser_test_case.cr
@@ -9,10 +9,6 @@ abstract struct AbstractTypesGuesserTestCase < ASPEC::TestCase
     end
   end
 
-  def test_guess_with_known_extension : Nil
-    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test.gif").should eq "image/gif"
-  end
-
   def test_guess_incorrect_path : Nil
     expect_raises AMIME::Exception::InvalidArgument, "The file '#{__DIR__}/fixtures/mimetypes/not_here' does not exist or is not readable." do
       self.guesser.guess_mime_type "#{__DIR__}/fixtures/mimetypes/not_here"

--- a/src/components/mime/spec/abstract_types_guesser_test_case.cr
+++ b/src/components/mime/spec/abstract_types_guesser_test_case.cr
@@ -4,52 +4,34 @@ abstract struct AbstractTypesGuesserTestCase < ASPEC::TestCase
   protected abstract def guesser : AMIME::TypesGuesserInterface
 
   def test_guess_with_leading_dash : Nil
-    assert_supported!
-
     self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/-test").should eq "image/gif"
   end
 
   def test_guess_without_extension : Nil
-    assert_supported!
-
     self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test").should eq "image/gif"
   end
 
   def test_guess_directory : Nil
-    assert_supported!
-
     expect_raises AMIME::Exception::InvalidArgument, "The file '#{__DIR__}/fixtures/mimetypes/directory' does not exist or is not readable." do
       self.guesser.guess_mime_type "#{__DIR__}/fixtures/mimetypes/directory"
     end
   end
 
   def test_guess_with_known_extension : Nil
-    assert_supported!
-
     self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test.gif").should eq "image/gif"
   end
 
   def test_guess_with_unknown_extension : Nil
-    assert_supported!
-
     self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/.unknownextension").should eq "application/octet-stream"
   end
 
   def test_guess_with_duplicated_file_type : Nil
-    assert_supported!
-
     self.guesser.guess_mime_type("#{__DIR__}/fixtures/test.docx").should eq "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
   end
 
   def test_guess_incorrect_path : Nil
-    assert_supported!
-
     expect_raises AMIME::Exception::InvalidArgument, "The file '#{__DIR__}/fixtures/mimetypes/not_here' does not exist or is not readable." do
       self.guesser.guess_mime_type "#{__DIR__}/fixtures/mimetypes/not_here"
     end
-  end
-
-  private def assert_supported! : Nil
-    pending! "Guesser is not supported" unless self.guesser.supported?
   end
 end

--- a/src/components/mime/spec/magic_types_guesser_spec.cr
+++ b/src/components/mime/spec/magic_types_guesser_spec.cr
@@ -5,4 +5,20 @@ struct MagicTypesGuesserTest < AbstractTypesGuesserTestCase
   protected def guesser : AMIME::TypesGuesserInterface
     AMIME::MagicTypesGuesser.new
   end
+
+  def test_guess_with_leading_dash : Nil
+    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/-test").should eq "image/gif"
+  end
+
+  def test_guess_without_extension : Nil
+    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test").should eq "image/gif"
+  end
+
+  def test_guess_with_unknown_extension : Nil
+    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/.unknownextension").should eq "application/octet-stream"
+  end
+
+  def test_guess_with_duplicated_file_type : Nil
+    self.guesser.guess_mime_type("#{__DIR__}/fixtures/test.docx").should eq "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+  end
 end

--- a/src/components/mime/spec/magic_types_guesser_spec.cr
+++ b/src/components/mime/spec/magic_types_guesser_spec.cr
@@ -7,18 +7,30 @@ struct MagicTypesGuesserTest < AbstractTypesGuesserTestCase
   end
 
   def test_guess_with_leading_dash : Nil
+    assert_pending
+
     self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/-test").should eq "image/gif"
   end
 
   def test_guess_without_extension : Nil
+    assert_pending
+
     self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test").should eq "image/gif"
   end
 
   def test_guess_with_unknown_extension : Nil
+    assert_pending
+
     self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/.unknownextension").should eq "application/octet-stream"
   end
 
   def test_guess_with_duplicated_file_type : Nil
+    assert_pending
+
     self.guesser.guess_mime_type("#{__DIR__}/fixtures/test.docx").should eq "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+  end
+
+  private def assert_pending : Nil
+    pending! "Guesser is not supported" if {{ flag?("windows") && !flag?("gnu") }}
   end
 end

--- a/src/components/mime/spec/magic_types_guesser_spec.cr
+++ b/src/components/mime/spec/magic_types_guesser_spec.cr
@@ -6,6 +6,12 @@ struct MagicTypesGuesserTest < AbstractTypesGuesserTestCase
     AMIME::MagicTypesGuesser.new
   end
 
+  def test_guess_with_known_extension : Nil
+    assert_pending
+
+    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test.gif").should eq "image/gif"
+  end
+
   def test_guess_with_leading_dash : Nil
     assert_pending
 

--- a/src/components/mime/spec/native_types_guessuer_spec.cr
+++ b/src/components/mime/spec/native_types_guessuer_spec.cr
@@ -1,0 +1,28 @@
+require "./abstract_types_guesser_test_case"
+require "./spec_helper"
+
+struct NativeTypesGuesserTest < AbstractTypesGuesserTestCase
+  protected def guesser : AMIME::TypesGuesserInterface
+    AMIME::NativeTypesGuesser.new
+  end
+
+  # Override these tests as the native types guesser only works on the file extension.
+
+  def test_guess_with_leading_dash : Nil
+    assert_supported!
+
+    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/-test").should be_nil
+  end
+
+  def test_guess_without_extension : Nil
+    assert_supported!
+
+    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test").should be_nil
+  end
+
+  def test_guess_with_unknown_extension : Nil
+    assert_supported!
+
+    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/.unknownextension").should be_nil
+  end
+end

--- a/src/components/mime/spec/native_types_guessuer_spec.cr
+++ b/src/components/mime/spec/native_types_guessuer_spec.cr
@@ -6,5 +6,19 @@ struct NativeTypesGuesserTest < AbstractTypesGuesserTestCase
     AMIME::NativeTypesGuesser.new
   end
 
-  include FileExtensionOnlyOverrides
+  def test_guess_with_leading_dash : Nil
+    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/-test").should be_nil
+  end
+
+  def test_guess_without_extension : Nil
+    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test").should be_nil
+  end
+
+  def test_guess_with_unknown_extension : Nil
+    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/.unknownextension").should be_nil
+  end
+
+  def test_guess_with_duplicated_file_type : Nil
+    self.guesser.guess_mime_type("#{__DIR__}/fixtures/test.docx").should eq "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+  end
 end

--- a/src/components/mime/spec/native_types_guessuer_spec.cr
+++ b/src/components/mime/spec/native_types_guessuer_spec.cr
@@ -6,23 +6,5 @@ struct NativeTypesGuesserTest < AbstractTypesGuesserTestCase
     AMIME::NativeTypesGuesser.new
   end
 
-  # Override these tests as the native types guesser only works on the file extension.
-
-  def test_guess_with_leading_dash : Nil
-    assert_supported!
-
-    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/-test").should be_nil
-  end
-
-  def test_guess_without_extension : Nil
-    assert_supported!
-
-    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test").should be_nil
-  end
-
-  def test_guess_with_unknown_extension : Nil
-    assert_supported!
-
-    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/.unknownextension").should be_nil
-  end
+  include FileExtensionOnlyOverrides
 end

--- a/src/components/mime/spec/native_types_guessuer_spec.cr
+++ b/src/components/mime/spec/native_types_guessuer_spec.cr
@@ -19,6 +19,9 @@ struct NativeTypesGuesserTest < AbstractTypesGuesserTestCase
   end
 
   def test_guess_with_duplicated_file_type : Nil
+    # The MIME DB on windows CI doesn't know about this type, but works elsewhere
+    pending! "Guesser is not supported" if {{ flag?("windows") && !flag?("gnu") }}
+
     self.guesser.guess_mime_type("#{__DIR__}/fixtures/test.docx").should eq "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
   end
 end

--- a/src/components/mime/spec/spec_helper.cr
+++ b/src/components/mime/spec/spec_helper.cr
@@ -3,26 +3,4 @@ require "athena-spec"
 
 require "../src/athena-mime"
 
-# Override these tests as the native types guesser only works on the file extension.
-# This'll be the default and only working guesser on MSVC windows.
-module FileExtensionOnlyOverrides
-  def test_guess_with_leading_dash : Nil
-    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/-test").should be_nil
-  end
-
-  def test_guess_without_extension : Nil
-    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test").should be_nil
-  end
-
-  def test_guess_with_unknown_extension : Nil
-    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/.unknownextension").should be_nil
-  end
-
-  {% if flag?("windows") && !flag?("gnu") %}
-    def test_guess_with_duplicated_file_type : Nil
-      self.guesser.guess_mime_type("#{__DIR__}/fixtures/test.docx").should be_nil
-    end
-  {% end %}
-end
-
 ASPEC.run_all

--- a/src/components/mime/spec/spec_helper.cr
+++ b/src/components/mime/spec/spec_helper.cr
@@ -3,4 +3,26 @@ require "athena-spec"
 
 require "../src/athena-mime"
 
+# Override these tests as the native types guesser only works on the file extension.
+# This'll be the default and only working guesser on MSVC windows.
+module FileExtensionOnlyOverrides
+  def test_guess_with_leading_dash : Nil
+    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/-test").should be_nil
+  end
+
+  def test_guess_without_extension : Nil
+    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test").should be_nil
+  end
+
+  def test_guess_with_unknown_extension : Nil
+    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/.unknownextension").should be_nil
+  end
+
+  {% if flag?("windows") && !flag?("gnu") %}
+    def test_guess_with_duplicated_file_type : Nil
+      self.guesser.guess_mime_type("#{__DIR__}/fixtures/test.docx").should be_nil
+    end
+  {% end %}
+end
+
 ASPEC.run_all

--- a/src/components/mime/spec/types_spec.cr
+++ b/src/components/mime/spec/types_spec.cr
@@ -18,14 +18,23 @@ struct MIMETypesTest < AbstractTypesGuesserTestCase
     AMIME::Types.new
   end
 
-  def test_unsupported_guesser : Nil
-    assert_supported!
+  {% if flag?("windows") && !flag?("gnu") %}
+    include FileExtensionOnlyOverrides
 
-    guesser = self.guesser
-    guesser.register_guesser MockGuesser.new
+    def test_unsupported_guesser : Nil
+      guesser = self.guesser
+      guesser.register_guesser MockGuesser.new
 
-    self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test").should eq "image/gif"
-  end
+      self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test").should be_nil
+    end
+  {% else %}
+    def test_unsupported_guesser : Nil
+      guesser = self.guesser
+      guesser.register_guesser MockGuesser.new
+
+      self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test").should eq "image/gif"
+    end
+  {% end %}
 
   def test_no_supported_guessers_raise : Nil
     guesser = self.guesser

--- a/src/components/mime/spec/types_spec.cr
+++ b/src/components/mime/spec/types_spec.cr
@@ -18,24 +18,6 @@ struct MIMETypesTest < AbstractTypesGuesserTestCase
     AMIME::Types.new
   end
 
-  {% if flag?("windows") && !flag?("gnu") %}
-    include FileExtensionOnlyOverrides
-
-    def test_unsupported_guesser : Nil
-      guesser = self.guesser
-      guesser.register_guesser MockGuesser.new
-
-      self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test").should be_nil
-    end
-  {% else %}
-    def test_unsupported_guesser : Nil
-      guesser = self.guesser
-      guesser.register_guesser MockGuesser.new
-
-      self.guesser.guess_mime_type("#{__DIR__}/fixtures/mimetypes/test").should eq "image/gif"
-    end
-  {% end %}
-
   def test_no_supported_guessers_raise : Nil
     guesser = self.guesser
     guesser.@guessers.clear

--- a/src/components/mime/spec/types_spec.cr
+++ b/src/components/mime/spec/types_spec.cr
@@ -18,6 +18,10 @@ struct MIMETypesTest < AbstractTypesGuesserTestCase
     AMIME::Types.new
   end
 
+  def test_supported : Nil
+    self.guesser.supported?.should be_true
+  end
+
   def test_no_supported_guessers_raise : Nil
     guesser = self.guesser
     guesser.@guessers.clear

--- a/src/components/mime/src/athena-mime.cr
+++ b/src/components/mime/src/athena-mime.cr
@@ -12,6 +12,7 @@ require "./part/*"
 require "./part/multipart/*"
 require "./types"
 require "./magic_types_guesser"
+require "./native_types_guesser"
 
 # Convenience alias to make referencing `Athena::MIME` types easier.
 alias AMIME = Athena::MIME

--- a/src/components/mime/src/magic_types_guesser.cr
+++ b/src/components/mime/src/magic_types_guesser.cr
@@ -88,6 +88,10 @@ struct Athena::MIME::MagicTypesGuesser
 
     # :inherit:
     def guess_mime_type(path : String | Path) : String?
+      if !File.file?(path) || !File::Info.readable?(path)
+        raise AMIME::Exception::InvalidArgument.new "The file '#{path}' does not exist or is not readable."
+      end
+
       nil
     end
   {% end %}

--- a/src/components/mime/src/magic_types_guesser.cr
+++ b/src/components/mime/src/magic_types_guesser.cr
@@ -56,10 +56,6 @@ struct Athena::MIME::MagicTypesGuesser
         raise AMIME::Exception::InvalidArgument.new "The file '#{path}' does not exist or is not readable."
       end
 
-      unless self.supported?
-        raise AMIME::Exception::Logic.new "The '#{self.class}' guesser is not supported."
-      end
-
       unless magic = LibMagic.magic_open LibMagic::Flags::MIME_TYPE
         raise AMIME::Exception::Runtime.new "Failed to open libmagic."
       end

--- a/src/components/mime/src/native_types_guesser.cr
+++ b/src/components/mime/src/native_types_guesser.cr
@@ -1,0 +1,26 @@
+require "./types_guesser_interface"
+require "mime"
+
+# A `AMIME::TypesGuesserInterface` implementation based Crystal's [MIME](https://crystal-lang.org/api/MIME.html) module.
+#
+# This guesser is mainly intended as a fallback for when `AMIME::MagicTypesGuesser` isn't available.
+#
+struct Athena::MIME::NativeTypesGuesser
+  include Athena::MIME::TypesGuesserInterface
+
+  # :inherit:
+  def supported? : Bool
+    true
+  end
+
+  # :inherit:
+  #
+  # NOTE: Guessing is based solely on the extension of the provided *path*.
+  def guess_mime_type(path : String | Path) : String?
+    if !File.file?(path) || !File::Info.readable?(path)
+      raise AMIME::Exception::InvalidArgument.new "The file '#{path}' does not exist or is not readable."
+    end
+
+    ::MIME.from_filename? path
+  end
+end

--- a/src/components/mime/src/native_types_guesser.cr
+++ b/src/components/mime/src/native_types_guesser.cr
@@ -3,8 +3,7 @@ require "mime"
 
 # A `AMIME::TypesGuesserInterface` implementation based Crystal's [MIME](https://crystal-lang.org/api/MIME.html) module.
 #
-# This guesser is mainly intended as a fallback for when `AMIME::MagicTypesGuesser` isn't available.
-#
+# This guesser is mainly intended as a fallback for when `AMIME::MagicTypesGuesser` isn't available (MSVC Windows).
 struct Athena::MIME::NativeTypesGuesser
   include Athena::MIME::TypesGuesserInterface
 

--- a/src/components/mime/src/types.cr
+++ b/src/components/mime/src/types.cr
@@ -38,6 +38,7 @@ class Athena::MIME::Types
       end
     end
 
+    self.register_guesser AMIME::NativeTypesGuesser.new
     self.register_guesser AMIME::MagicTypesGuesser.new
   end
 

--- a/src/components/mime/src/types.cr
+++ b/src/components/mime/src/types.cr
@@ -39,7 +39,9 @@ class Athena::MIME::Types
     end
 
     self.register_guesser AMIME::NativeTypesGuesser.new
-    self.register_guesser AMIME::MagicTypesGuesser.new
+    {% if flag?("windows") && !flag?("gnu") %}
+      self.register_guesser AMIME::MagicTypesGuesser.new
+    {% end %}
   end
 
   # Registers the provided *guesser*.

--- a/src/components/mime/src/types.cr
+++ b/src/components/mime/src/types.cr
@@ -38,10 +38,10 @@ class Athena::MIME::Types
       end
     end
 
-    self.register_guesser AMIME::NativeTypesGuesser.new
     {% if flag?("windows") && !flag?("gnu") %}
-      self.register_guesser AMIME::MagicTypesGuesser.new
+      self.register_guesser AMIME::NativeTypesGuesser.new
     {% end %}
+    self.register_guesser AMIME::MagicTypesGuesser.new
   end
 
   # Registers the provided *guesser*.

--- a/src/components/mime/src/types.cr
+++ b/src/components/mime/src/types.cr
@@ -38,9 +38,7 @@ class Athena::MIME::Types
       end
     end
 
-    {% if flag?("windows") && !flag?("gnu") %}
-      self.register_guesser AMIME::NativeTypesGuesser.new
-    {% end %}
+    self.register_guesser AMIME::NativeTypesGuesser.new
     self.register_guesser AMIME::MagicTypesGuesser.new
   end
 


### PR DESCRIPTION
## Context

Follow up to #534 that adds another `AMIME::TypesGuesserInterface` implementation based on the stdlib's `MIME` module. This'll ensure that the component can be used on msvc windows. Unix/msys2 will still require `libmagic`.

## Changelog

* Add fallback MIME types guesser based on stdlib `MIME` module

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
