### PR TITLE
Relax DI argument validation for string parameters

### DIFF
--- a/src/components/dependency_injection/src/compiler_passes/validate_arguments.cr
+++ b/src/components/dependency_injection/src/compiler_passes/validate_arguments.cr
@@ -14,7 +14,7 @@ module Athena::DependencyInjection::ServiceContainer::ValidateArguments
                 value = param["value"]
                 restriction = param["resolved_restriction"]
 
-                if restriction && restriction <= String && !value.is_a? StringLiteral
+                if restriction && restriction <= String && (!value.is_a?(StringLiteral) && !value.is_a?(Call))
                   error = "Parameter '#{param["declaration"]}' of service '#{service_id.id}' (#{definition["class"]}) expects a String but got '#{value}'."
                 end
 


### PR DESCRIPTION
## Context

The CI container does some light validation of the arguments provided to a service's constructor. Previously for `String` parameters, it would only allow `StringLiteral` values. This PR relaxes this to also allow `Call` such that the value could be a more complex value that still returns a string.

There currently isn't a way to know the return type of a `Call`, so things like `"123".to_i` would be missed. However it'll still error, just without the customized error message.

## Changelog

* Relax DI argument validation for string parameters

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
