### PR TITLE
Remove too broad regex preventing detection of short word typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -2,7 +2,6 @@
 extend-ignore-re = [
   "(?Rm)^.*#\\s*spellchecker:disable-line$", # All disabling specific lines
   "[=0-9A-F \n\r]{2}", # Disable checking Quoted-Printable encoded strings
-  "\\b[0-9A-Za-z+/]{0, 60}(=|==)?\\b", # Disable for Base64 like strings that are 60 chars or less all together
 ]
 
 [default.extend-words]
@@ -11,5 +10,6 @@ referer = "referrer"
 [files]
 extend-exclude = [
   "src/components/routing/spec/fixtures/route_provider/*",
+  "src/components/mime/src/types/data.cr",
   "src/components/mime/spec/fixtures/*",
 ]

--- a/gen_doc_stubs.py
+++ b/gen_doc_stubs.py
@@ -28,24 +28,24 @@ handler.update_env = patched_update_env
 
 root = handler.collector.root
 
-for typ in root.lookup("Athena").walk_types():
+for type in root.lookup("Athena").walk_types():
     # Athena::Validator::Violation -> Validator/Violation/index.md
-    filename = '/'.join(typ.abs_id.split('::')[2:] + ['index.md'])
+    filename = '/'.join(type.abs_id.split('::')[2:] + ['index.md'])
 
     # Rename the root `index.md` to `top_level.md` so that the user lands on the introduction page instead of the root component module docs.
     # But only do this for non-framework components as the site itself is the contextual docs for the framework.
-    if typ.full_name != 'Athena::Framework' and filename == 'index.md':
+    if type.full_name != 'Athena::Framework' and filename == 'index.md':
         filename = 'top_level.md'
 
     with mkdocs_gen_files.open(filename, 'w') as f:
-        f.write(f'# ::: {typ.abs_id}\n\n')
+        f.write(f'# ::: {type.abs_id}\n\n')
 
-    if typ.locations:
-        mkdocs_gen_files.set_edit_path(filename, typ.locations[0].url)
+    if type.locations:
+        mkdocs_gen_files.set_edit_path(filename, type.locations[0].url)
 
-for typ in root.types:
+for type in root.types:
     # Write the entry of a top-level alias (e.g. `AED`) to its appropriate section.
-    if typ.kind == 'alias':
+    if type.kind == 'alias':
         # Athena::Validator::Annotations -> Validator/aliases.md
         with mkdocs_gen_files.open('aliases.md', 'a') as f:
-            f.write(f'::: {typ.abs_id}\n\n')
+            f.write(f'::: {type.abs_id}\n\n')

--- a/src/components/mime/spec/encoder/base64_content_spec.cr
+++ b/src/components/mime/spec/encoder/base64_content_spec.cr
@@ -56,11 +56,12 @@ struct Base64ContentEncoderTest < ASPEC::TestCase
     AMIME::Encoder::Base64Content
       .new
       .encode(input)
-      .should eq <<-TXT
-        YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJT
-        VFVWV1hZWjEyMzQ1Njc4OTBhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFC
-        Q0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaMTIzNDU2Nzg5MEFCQ0RFRkdISUpL
-        TE1OT1BRUlNUVVZXWFla\n
-        TXT
+      .lines(chomp: false) # Use lines here to allow ignoring the typos
+      .should eq([
+        "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJT\n",
+        "VFVWV1hZWjEyMzQ1Njc4OTBhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFC\n", # spellchecker:disable-line
+        "Q0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaMTIzNDU2Nzg5MEFCQ0RFRkdISUpL\n", # spellchecker:disable-line
+        "TE1OT1BRUlNUVVZXWFla\n",                                         # spellchecker:disable-line
+      ])
   end
 end


### PR DESCRIPTION
## Context

As it turns out this regex was matching essentially any word less than 60 chars and thus preventing typo detection.

## Changelog

* Remove too broad regex preventing detection of short word typos

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
