### PR TITLE
Fix state leaking from `console` specs with some specific seeds

### DIFF
--- a/src/components/console/spec/helper/question_spec.cr
+++ b/src/components/console/spec/helper/question_spec.cr
@@ -10,6 +10,10 @@ struct QuestionHelperTest < AbstractQuestionHelperTest
     super
   end
 
+  def tear_down : Nil
+    ENV.delete "COLUMNS"
+  end
+
   def test_ask_choice_question : Nil
     heroes = ["Superman", "Batman", "Spiderman"]
     self.with_input "\n1\n  1  \nGeorge\n1\nGeorge\n\n\n" do |input|

--- a/src/components/console/spec/spec_helper.cr
+++ b/src/components/console/spec/spec_helper.cr
@@ -45,7 +45,8 @@ struct MockCommandLoader
 end
 
 def with_isolated_env(&) : Nil
-  old_values = ENV.dup
+  old_values = ENV.to_h
+
   begin
     ENV.clear
 

--- a/src/components/console/src/helper/question.cr
+++ b/src/components/console/src/helper/question.cr
@@ -122,11 +122,8 @@ class Athena::Console::Helper::Question < Athena::Console::Helper
         begin
           hidden_response = self.hidden_response output, input_stream
           response = question.trimmable? ? hidden_response.strip : hidden_response
-        rescue ex : ::Exception
-          # TODO: Make this part of the `rescue` after Crystal 1.13
-          if ex.is_a?(ACON::Exception)
-            raise ex unless question.hidden_fallback?
-          end
+        rescue ex : ACON::Exception
+          raise ex unless question.hidden_fallback?
         end
       end
 

--- a/src/components/console/src/terminal.cr
+++ b/src/components/console/src/terminal.cr
@@ -4,12 +4,10 @@ require "./ext/terminal"
 struct Athena::Console::Terminal
   @@width : Int32? = nil
   @@height : Int32? = nil
-  @@stty : Bool = false
+  @@stty : Bool? = nil
 
   def self.has_stty_available? : Bool
-    if stty = @@stty
-      return stty
-    end
+    @@stty.try { |stty| return stty }
 
     @@stty = !Process.find_executable("stty").nil?
   end


### PR DESCRIPTION
## Context

I noticed in the codecov reports there were some `console` files that always seem to change even if the PR was totally unrelated. As it turns out there were a few bugs that were causing non-deterministic runs depending on the order the specs ran. This PR attempts to resolve those.

## Changelog

* Fix state leaking from `console` specs with some specific seeds

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
