### PR TITLE
Always cleanup/override `COLUMNS` env var

### DIFF
--- a/src/components/console/spec/application_spec.cr
+++ b/src/components/console/spec/application_spec.cr
@@ -1,19 +1,8 @@
 require "./spec_helper"
 
 struct ApplicationTest < ASPEC::TestCase
-  @col_size : Int32?
-
-  def initialize
-    @col_size = ENV["COLUMNS"]?.try &.to_i
-  end
-
   def tear_down : Nil
-    if size = @col_size
-      ENV["COLUMNS"] = size.to_s
-    else
-      ENV.delete "COLUMNS"
-    end
-
+    ENV.delete "COLUMNS"
     ENV.delete "SHELL_VERBOSITY"
   end
 

--- a/src/components/console/spec/helper/progress_bar_spec.cr
+++ b/src/components/console/spec/helper/progress_bar_spec.cr
@@ -1,21 +1,15 @@
 require "../spec_helper"
 
 struct ProgressBarTest < ASPEC::TestCase
-  @col_size : String?
   @clock : ACLK::Spec::MockClock
 
   def initialize
-    @col_size = ENV["COLUMNS"]?
     ENV["COLUMNS"] = "120"
     @clock = ACLK::Spec::MockClock.new
   end
 
   protected def tear_down : Nil
-    if col_size = @col_size
-      ENV["COLUMNS"] = col_size
-    else
-      ENV.delete "COLUMNS"
-    end
+    ENV.delete "COLUMNS"
   end
 
   def test_multiple_start : Nil

--- a/src/components/console/spec/style/athena_style_spec.cr
+++ b/src/components/console/spec/style/athena_style_spec.cr
@@ -1,19 +1,12 @@
 require "../spec_helper"
 
 struct AthenaStyleTest < ASPEC::TestCase
-  @col_size : String?
-
   def initialize
-    @col_size = ENV["COLUMNS"]?
     ENV["COLUMNS"] = "121"
   end
 
   def tear_down : Nil
-    if size = @col_size
-      ENV["COLUMNS"] = size
-    else
-      ENV.delete "COLUMNS"
-    end
+    ENV.delete "COLUMNS"
   end
 
   private def assert_file_equals_string(filepath : String, string : String, *, file : String = __FILE__, line : Int32 = __LINE__) : Nil


### PR DESCRIPTION
## Context

Follow up to #550. As I still saw some indirect changes being reported.

## Changelog

* Always cleanup/override `COLUMNS` env var

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
