### PR TITLE
Use scheduled CI on `master` for status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Athena
 
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/framework.svg)](https://github.com/athena-framework/framework/releases)
 
 A monorepo representing the ecosystem of reusable, independent components provided by Athena.

--- a/src/components/clock/README.md
+++ b/src/components/clock/README.md
@@ -1,7 +1,7 @@
 # Clock
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/clock.svg)](https://github.com/athena-framework/clock/releases)
 
 Decouples applications from the system clock.

--- a/src/components/console/README.md
+++ b/src/components/console/README.md
@@ -1,7 +1,7 @@
 # Console
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/console.svg)](https://github.com/athena-framework/console/releases)
 
 Allows for the creation of CLI based commands.

--- a/src/components/contracts/README.md
+++ b/src/components/contracts/README.md
@@ -1,7 +1,7 @@
 # Contracts
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/contracts.svg)](https://github.com/athena-framework/contracts/releases)
 
 A set of abstractions extracted out of the Athena components.

--- a/src/components/dependency_injection/README.md
+++ b/src/components/dependency_injection/README.md
@@ -1,7 +1,7 @@
 # Dependency Injection
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/dependency-injection.svg)](https://github.com/athena-framework/dependency-injection/releases)
 
 Robust dependency injection service container framework.

--- a/src/components/dotenv/README.md
+++ b/src/components/dotenv/README.md
@@ -1,7 +1,7 @@
 # Dotenv
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/dotenv.svg)](https://github.com/athena-framework/dotenv/releases)
 
 Registers environment variables from a .env file.

--- a/src/components/event_dispatcher/README.md
+++ b/src/components/event_dispatcher/README.md
@@ -1,7 +1,7 @@
 # Event Dispatcher
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/event-dispatcher.svg?style=flat-square)](https://github.com/athena-framework/event-dispatcher/releases)
 
 A [Mediator](https://en.wikipedia.org/wiki/Mediator_pattern) and [Observer](https://en.wikipedia.org/wiki/Observer_pattern) pattern event library.

--- a/src/components/framework/README.md
+++ b/src/components/framework/README.md
@@ -1,7 +1,7 @@
 # Athena Framework
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/framework.svg)](https://github.com/athena-framework/framework/releases)
 
 A web framework comprised of reusable, independent components.

--- a/src/components/image_size/README.md
+++ b/src/components/image_size/README.md
@@ -1,7 +1,7 @@
 # ImageSize
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/image-size.svg)](https://github.com/athena-framework/image-size/releases)
 
 Measures the size of various image formats.

--- a/src/components/mercure/README.md
+++ b/src/components/mercure/README.md
@@ -1,7 +1,7 @@
 # Mercure
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/mercure.svg)](https://github.com/athena-framework/mercure/releases)
 
 Allows easily pushing updates to web browsers and other HTTP clients using the Mercure protocol.

--- a/src/components/mime/README.md
+++ b/src/components/mime/README.md
@@ -1,7 +1,7 @@
 # MIME
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/mime.svg)](https://github.com/athena-framework/mime/releases)
 
 Allows manipulating MIME messages.

--- a/src/components/negotiation/README.md
+++ b/src/components/negotiation/README.md
@@ -1,7 +1,7 @@
 # Negotiation
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/negotiation.svg)](https://github.com/athena-framework/negotiation/releases)
 
 Framework agnostic [content negotiation](https://tools.ietf.org/html/rfc7231#section-5.3) library based on [willdurand/Negotiation](https://github.com/willdurand/Negotiation).

--- a/src/components/routing/README.md
+++ b/src/components/routing/README.md
@@ -1,7 +1,7 @@
 # Routing
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/routing.svg)](https://github.com/athena-framework/routing/releases)
 
 HTTP based routing library/framework.

--- a/src/components/serializer/README.md
+++ b/src/components/serializer/README.md
@@ -1,7 +1,7 @@
 # Serializer
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/serializer.svg)](https://github.com/athena-framework/serializer/releases)
 
 Flexible object (de)serialization library

--- a/src/components/spec/README.md
+++ b/src/components/spec/README.md
@@ -1,7 +1,7 @@
 # Spec
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/spec.svg)](https://github.com/athena-framework/spec/releases)
 
 Common/helpful Spec compliant testing utilities

--- a/src/components/validator/README.md
+++ b/src/components/validator/README.md
@@ -1,7 +1,7 @@
 # Validator
 
 [![Common Changelog](https://common-changelog.org/badge.svg)](https://common-changelog.org)
-[![CI](https://github.com/athena-framework/athena/workflows/CI/badge.svg)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
+[![CI](https://github.com/athena-framework/athena/actions/workflows/ci.yml/badge.svg?branch=master&event=schedule)](https://github.com/athena-framework/athena/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/release/athena-framework/validator.svg)](https://github.com/athena-framework/validator/releases)
 
 Object/value validation library


### PR DESCRIPTION
## Context

By default they were using the latest CI run, including those from PRs which could be failing. This gives the false impression to viewers that things are actually failing. This PR updates the badge to use the scheduled CI job on `master` as a better indicator of CI health.

## Changelog

* Use scheduled CI on `master` for status badge

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
