### PR TITLE
Fix missing `View source` link in API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ __pycache__
 site/
 
 coverage/
+
+# Ignore `lib` symlink related to building docs
+/src/components/**/lib

--- a/src/components/clock/mkdocs.yml
+++ b/src/components/clock/mkdocs.yml
@@ -8,9 +8,9 @@ nav:
   - Introduction: README.md
   - Back to Manual: project://.
   - API:
-    - Aliases: aliases.md
-    - Top Level: top_level.md
-    - '*'
+      - Aliases: aliases.md
+      - Top Level: top_level.md
+      - '*'
 
 plugins:
   - search
@@ -26,7 +26,7 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena-clock/src/athena-clock.cr
-            - ../../../lib/athena-clock/src/spec.cr
+            - ./lib/athena-clock/src/athena-clock.cr
+            - ./lib/athena-clock/src/spec.cr
           source_locations:
             lib/athena-clock: https://github.com/athena-framework/clock/blob/v{shard_version}/{file}#L{line}

--- a/src/components/console/mkdocs.yml
+++ b/src/components/console/mkdocs.yml
@@ -8,9 +8,9 @@ nav:
   - Introduction: README.md
   - Back to Manual: project://.
   - API:
-    - Aliases: aliases.md
-    - Top Level: top_level.md
-    - '*'
+      - Aliases: aliases.md
+      - Top Level: top_level.md
+      - '*'
 
 plugins:
   - search
@@ -26,7 +26,7 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena-console/src/athena-console.cr
-            - ../../../lib/athena-console/src/spec.cr
+            - ./lib/athena-console/src/athena-console.cr
+            - ./lib/athena-console/src/spec.cr
           source_locations:
             lib/athena-console: https://github.com/athena-framework/console/blob/v{shard_version}/{file}#L{line}

--- a/src/components/contracts/mkdocs.yml
+++ b/src/components/contracts/mkdocs.yml
@@ -24,6 +24,6 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena-contracts/src/athena-contracts.cr
+            - ./lib/athena-contracts/src/athena-contracts.cr
           source_locations:
             lib/athena-contracts: https://github.com/athena-framework/contracts/blob/v{shard_version}/{file}#L{line}

--- a/src/components/dependency_injection/mkdocs.yml
+++ b/src/components/dependency_injection/mkdocs.yml
@@ -8,9 +8,9 @@ nav:
   - Introduction: README.md
   - Back to Manual: project://.
   - API:
-    - Aliases: aliases.md
-    - Top Level: top_level.md
-    - '*'
+      - Aliases: aliases.md
+      - Top Level: top_level.md
+      - '*'
 
 plugins:
   - search
@@ -26,6 +26,6 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena-dependency_injection/src/athena-dependency_injection.cr
+            - ./lib/athena-dependency_injection/src/athena-dependency_injection.cr
           source_locations:
             lib/athena-dependency_injection: https://github.com/athena-framework/dependency-injection/blob/v{shard_version}/{file}#L{line}

--- a/src/components/dotenv/mkdocs.yml
+++ b/src/components/dotenv/mkdocs.yml
@@ -8,8 +8,8 @@ nav:
   - Introduction: README.md
   - Back to Manual: project://.
   - API:
-    - Top Level: top_level.md
-    - '*'
+      - Top Level: top_level.md
+      - '*'
 
 plugins:
   - search
@@ -25,6 +25,6 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena-dotenv/src/athena-dotenv.cr
+            - ./lib/athena-dotenv/src/athena-dotenv.cr
           source_locations:
             lib/athena-dotenv: https://github.com/athena-framework/dotenv/blob/v{shard_version}/{file}#L{line}

--- a/src/components/event_dispatcher/mkdocs.yml
+++ b/src/components/event_dispatcher/mkdocs.yml
@@ -8,9 +8,9 @@ nav:
   - Introduction: README.md
   - Back to Manual: project://.
   - API:
-    - Aliases: aliases.md
-    - Top Level: top_level.md
-    - '*'
+      - Aliases: aliases.md
+      - Top Level: top_level.md
+      - '*'
 
 plugins:
   - search
@@ -26,7 +26,7 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena-event_dispatcher/src/athena-event_dispatcher.cr
-            - ../../../lib/athena-event_dispatcher/src/spec.cr
+            - ./lib/athena-event_dispatcher/src/athena-event_dispatcher.cr
+            - ./lib/athena-event_dispatcher/src/spec.cr
           source_locations:
             lib/athena-event_dispatcher: https://github.com/athena-framework/event-dispatcher/blob/v{shard_version}/{file}#L{line}

--- a/src/components/framework/mkdocs.yml
+++ b/src/components/framework/mkdocs.yml
@@ -7,9 +7,9 @@ repo_url: https://github.com/athena-framework/framework
 nav:
   - Back to Manual: project://.
   - API:
-    - Aliases: aliases.md
-    - Top Level: index.md
-    - '*'
+      - Aliases: aliases.md
+      - Top Level: index.md
+      - '*'
 
 plugins:
   - search
@@ -25,7 +25,7 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena/src/athena.cr
-            - ../../../lib/athena/src/spec.cr
+            - ./lib/athena/src/athena.cr
+            - ./lib/athena/src/spec.cr
           source_locations:
             lib/athena: https://github.com/athena-framework/framework/blob/v{shard_version}/{file}#L{line}

--- a/src/components/image_size/mkdocs.yml
+++ b/src/components/image_size/mkdocs.yml
@@ -8,9 +8,9 @@ nav:
   - Introduction: README.md
   - Back to Manual: project://.
   - API:
-    - Aliases: aliases.md
-    - Top Level: top_level.md
-    - '*'
+      - Aliases: aliases.md
+      - Top Level: top_level.md
+      - '*'
 
 plugins:
   - search
@@ -26,6 +26,6 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena-image_size/src/athena-image_size.cr
+            - ./lib/athena-image_size/src/athena-image_size.cr
           source_locations:
             lib/athena-image_size: https://github.com/athena-framework/image-size/blob/v{shard_version}/{file}#L{line}

--- a/src/components/mercure/mkdocs.yml
+++ b/src/components/mercure/mkdocs.yml
@@ -8,9 +8,9 @@ nav:
   - Introduction: README.md
   - Back to Manual: project://.
   - API:
-    - Aliases: aliases.md
-    - Top Level: top_level.md
-    - '*'
+      - Aliases: aliases.md
+      - Top Level: top_level.md
+      - '*'
 
 plugins:
   - search
@@ -26,7 +26,7 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena-mercure/src/athena-mercure.cr
-            - ../../../lib/athena-mercure/src/spec.cr
+            - ./lib/athena-mercure/src/athena-mercure.cr
+            - ./lib/athena-mercure/src/spec.cr
           source_locations:
             lib/athena-mercure: https://github.com/athena-framework/mercure/blob/v{shard_version}/{file}#L{line}

--- a/src/components/mime/mkdocs.yml
+++ b/src/components/mime/mkdocs.yml
@@ -8,9 +8,9 @@ nav:
   - Introduction: README.md
   - Back to Manual: project://.
   - API:
-    - Aliases: aliases.md
-    - Top Level: top_level.md
-    - '*'
+      - Aliases: aliases.md
+      - Top Level: top_level.md
+      - '*'
 
 plugins:
   - search
@@ -26,6 +26,6 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena-mime/src/athena-mime.cr
+            - ./lib/athena-mime/src/athena-mime.cr
           source_locations:
             lib/athena-mime: https://github.com/athena-framework/mime/blob/v{shard_version}/{file}#L{line}

--- a/src/components/negotiation/mkdocs.yml
+++ b/src/components/negotiation/mkdocs.yml
@@ -8,9 +8,9 @@ nav:
   - Introduction: README.md
   - Back to Manual: project://.
   - API:
-    - Aliases: aliases.md
-    - Top Level: top_level.md
-    - '*'
+      - Aliases: aliases.md
+      - Top Level: top_level.md
+      - '*'
 
 plugins:
   - search
@@ -26,6 +26,6 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena-negotiation/src/athena-negotiation.cr
+            - ./lib/athena-negotiation/src/athena-negotiation.cr
           source_locations:
             lib/athena-negotiation: https://github.com/athena-framework/negotiation/blob/v{shard_version}/{file}#L{line}

--- a/src/components/routing/mkdocs.yml
+++ b/src/components/routing/mkdocs.yml
@@ -8,9 +8,9 @@ nav:
   - Introduction: README.md
   - Back to Manual: project://.
   - API:
-    - Aliases: aliases.md
-    - Top Level: top_level.md
-    - '*'
+      - Aliases: aliases.md
+      - Top Level: top_level.md
+      - '*'
 
 plugins:
   - search
@@ -26,6 +26,6 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena-routing/src/athena-routing.cr
+            - ./lib/athena-routing/src/athena-routing.cr
           source_locations:
             lib/athena-routing: https://github.com/athena-framework/routing/blob/v{shard_version}/{file}#L{line}

--- a/src/components/serializer/mkdocs.yml
+++ b/src/components/serializer/mkdocs.yml
@@ -8,9 +8,9 @@ nav:
   - Introduction: README.md
   - Back to Manual: project://.
   - API:
-    - Aliases: aliases.md
-    - Top Level: top_level.md
-    - '*'
+      - Aliases: aliases.md
+      - Top Level: top_level.md
+      - '*'
 
 plugins:
   - search
@@ -26,6 +26,6 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena-serializer/src/athena-serializer.cr
+            - ./lib/athena-serializer/src/athena-serializer.cr
           source_locations:
             lib/athena-serializer: https://github.com/athena-framework/serializer/blob/v{shard_version}/{file}#L{line}

--- a/src/components/spec/mkdocs.yml
+++ b/src/components/spec/mkdocs.yml
@@ -8,9 +8,9 @@ nav:
   - Introduction: README.md
   - Back to Manual: project://.
   - API:
-    - Aliases: aliases.md
-    - Top Level: top_level.md
-    - '*'
+      - Aliases: aliases.md
+      - Top Level: top_level.md
+      - '*'
 
 plugins:
   - search
@@ -26,6 +26,6 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena-spec/src/athena-spec.cr
+            - ./lib/athena-spec/src/athena-spec.cr
           source_locations:
             lib/athena-spec: https://github.com/athena-framework/spec/blob/v{shard_version}/{file}#L{line}

--- a/src/components/validator/mkdocs.yml
+++ b/src/components/validator/mkdocs.yml
@@ -8,9 +8,9 @@ nav:
   - Introduction: README.md
   - Back to Manual: project://.
   - API:
-    - Aliases: aliases.md
-    - Top Level: top_level.md
-    - '*'
+      - Aliases: aliases.md
+      - Top Level: top_level.md
+      - '*'
 
 plugins:
   - search
@@ -26,7 +26,7 @@ plugins:
         crystal:
           crystal_docs_flags:
             - ../../../docs/index.cr
-            - ../../../lib/athena-validator/src/athena-validator.cr
-            - ../../../lib/athena-validator/src/spec.cr
+            - ./lib/athena-validator/src/athena-validator.cr
+            - ./lib/athena-validator/src/spec.cr
           source_locations:
             lib/athena-validator: https://github.com/athena-framework/validator/blob/v{shard_version}/{file}#L{line}


### PR DESCRIPTION
## Context

The MkDocs upgrade via https://github.com/athena-framework/athena/pull/471 made it so the directory in which each component runs `crystal docs ...` changed from the mono-repo root, to the component root. This required updating the path to each file to build docs for to include a `../../../` prefix. However because of https://github.com/crystal-lang/crystal/issues/15888, they were lacking location information which made the `View source` links unable to be generated.

This PR changes things to symlink the monorepo's `lib/` directory into each component directory and updates the file paths to remove the `../../../` prefix. This still feels a bit hacky, but it at least fixes the problem and overall is simpler than mucking with `CRYSTAL_PATH` while still removing the need to `shards install` each component one-by-one.

## Changelog

* Fix missing `View source` links in API docs

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
