### PR TITLE
Unlink `lib/lib` before building docs

### DIFF
--- a/justfile
+++ b/justfile
@@ -104,6 +104,7 @@ _mkdocs: _pip
     {{ PIP }} install -q -r requirements.txt
 
 _symlink_lib:
+    @ unlink lib/lib || true # If present this seems to cause problems in GH actions context
     @ for component in $(find src/components/ -maxdepth 2 -type f -name shard.yml | xargs -I{} dirname {} | xargs -I{} basename {} | sort); do \
       ln --force --verbose --symbolic "lib" "src/components/$component/lib"; \
     done


### PR DESCRIPTION
## Context

Follow up to #555. Seems to be an issue in GH Actions but not local :/

```sh
INFO    -  [project://.clock] Cleaning site directory
INFO    -  [project://.clock] Building documentation to directory: /home/runner/work/athena/athena/site/Clock
Error: Error opening file with mode 'r': '/home/runner/work/athena/athena/src/components/clock/lib/athena-clock/src/athena-clock.cr': Symbolic link loop
ERROR   -  [project://.clock] Command `crystal docs --format=json --project-name= --project-version= --source-refname=master ../../../docs/index.cr ./lib/athena-clock/src/athena-clock.cr ./lib/athena-clock/src/spec.cr` exited with status 1

Aborted with a BuildError!
```

## Changelog

* Unlink `lib/lib` before building docs

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
