### PR TITLE
Fix `watchexec` filewatching recipes in `justfile`

### DIFF
--- a/justfile
+++ b/justfile
@@ -24,12 +24,12 @@ install:
 # Runs and watches for changes to the main entrypoint file of the provided `component`
 [group('dev')]
 watch component:
-    watchexec --restart --watch=src/ --emit-events-to=none --clear -- {{ CRYSTAL }} run src/components/{{ component }}/src/{{ if component == 'framework' { 'athena' } else { 'athena-' + component } }}.cr
+    watchexec --restart --watch=src/ --emit-events-to=none --clear --no-project-ignore -- {{ CRYSTAL }} run src/components/{{ component }}/src/{{ if component == 'framework' { 'athena' } else { 'athena-' + component } }}.cr
 
 # Runs the test suite of the provided `component`, or `all` for all components, and watches for changes
 [group('dev')]
 watch-test component:
-    watchexec --restart --watch=src/ --emit-events-to=none --clear -- {{ CRYSTAL }} spec src/components/{{ component }}/
+    watchexec --restart --watch=src/ --emit-events-to=none --clear --no-project-ignore -- {{ CRYSTAL }} spec src/components/{{ component }}/
 
 # Runs the test suite of the provided `component`, defaulting to `all` components
 [group('dev')]


### PR DESCRIPTION
## Context

Follow up to #557. The new entry in `.gitignore` makes `watchexec` no longer detect the changes. I think because the `lib` link essentially resolves to the directory itself since parent `lib/` is itself a symlink to the related component dir within `src/`. This seems to be a decent workaround since all ignores are for the root and we're inherently only watching `src/` anyway.

## Changelog

* Fix `watchexec` filewatching recipes in `justfile`

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
