### PR TITLE
Fix linker warning due to duplicate `pcre2-8` linkage

### DIFF
--- a/src/components/routing/src/ext/regex.cr
+++ b/src/components/routing/src/ext/regex.cr
@@ -1,4 +1,3 @@
-@[Link("pcre2-8")]
 lib LibPCRE2
   fun jit_match = pcre2_jit_match_8(code : Code*, subject : UInt8*, length : LibC::SizeT, startoffset : LibC::SizeT, options : UInt32, match_data : MatchData*, mcontext : MatchContext*) : Int
   fun get_mark = pcre2_get_mark_8(match_data : MatchData*) : UInt8*


### PR DESCRIPTION
## Context

PCRE2 is already the default for Crystal as of 1.8 and is required for the routing component. As such we don't really need to add _another_ link annotation onto the lib we monkeypatch since the stdlib does it for us. This resolves some linker warnings on mac: `ld: warning: ignoring duplicate libraries: '-lpcre2-8'`

## Changelog

* Fix linker warning due to duplicate `pcre2-8` linkage

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
