### PR TITLE
Remove top level `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,0 @@
-# Changelog
-
-## [0.1.0] - YYYY-MM-DD
-
-_Initial release._
-
-[0.1.0]: https://github.com/athena-framework/contracts/releases/tag/v0.1.0


### PR DESCRIPTION
## Context

This was mistakenly added when the `contracts` component was integrated in 38b0a5e9c1567f467539dc9eeac993df08dd599d.

## Changelog

* Remove top level `CHANGELOG.md`

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
