### PR TITLE
Fix nightly type incompatibility with `ASR::Any`

### DIFF
--- a/src/components/serializer/src/any.cr
+++ b/src/components/serializer/src/any.cr
@@ -16,7 +16,7 @@ module Athena::Serializer::Any
 
   # ameba:disable Naming/PredicateName
   abstract def is_nil? : Bool
-  abstract def dig(index_or_key : String | Int, *keys)
+  abstract def dig(index_or_key : String | Int, *subkeys : Int | String)
 
   abstract def raw
 end


### PR DESCRIPTION
## Context

https://github.com/crystal-lang/crystal/pull/15840 added type restrictions to the `subkeys` parameter of `JSON::Any#dig`. This PR follow up to make the same change to `ASR::Any` to make things compatible. 

## Changelog

* Fix nightly type incompatibility with `JSON::Any` and `ASR::Any`

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
