### PR TITLE
`ATH::Response` improvements

### DIFF
--- a/src/components/contracts/src/common/framework/abstract_file.cr
+++ b/src/components/contracts/src/common/framework/abstract_file.cr
@@ -11,6 +11,8 @@ abstract struct Athena::Framework::AbstractFile
   # Returns the path to this file, which may be relative.
   getter path : String
 
+  private getter info : ::File::Info { ::File.info @path }
+
   # Create a new instance for the file at the provided *path*.
   # If *check_path* is `true`, then an `ATH::Exception::FileNotFound` exception is raised if the file at the provided *path* does not exist.
   def initialize(path : String | Path, check_path : Bool = true)
@@ -89,6 +91,16 @@ abstract struct Athena::Framework::AbstractFile
   # Returns the size in bytes of this file.
   def size : Int
     ::File.size @path
+  end
+
+  # Returns `true` if this file is readable by user of this process, otherwise returns `false`.
+  def readable? : Bool
+    ::File::Info.readable? @path
+  end
+
+  # Returns the time this file was last modified.
+  def modification_time : Time
+    self.info.modification_time
   end
 
   # Returns the extension of this file, or an empty string if it does not have one.

--- a/src/components/framework/spec/binary_file_response_spec.cr
+++ b/src/components/framework/spec/binary_file_response_spec.cr
@@ -19,7 +19,7 @@ struct ATH::BinaryFileResponseTest < ASPEC::TestCase
   end
 
   def test_new_with_non_ascii_filename : Nil
-    ATH::BinaryFileResponse.new("#{__DIR__}/assets/fööö.html").file_path.basename.should eq "fööö.html"
+    ATH::BinaryFileResponse.new("#{__DIR__}/assets/fööö.html").file.basename.should eq "fööö.html"
   end
 
   def test_set_content : Nil
@@ -97,7 +97,7 @@ struct ATH::BinaryFileResponseTest < ASPEC::TestCase
   end
 
   def test_delete_file_after_send : Nil
-    path = "#{__DIR__}/assets/to_delete"
+    path = "#{Dir.tempdir}/to_delete"
 
     begin
       ::File.touch path

--- a/src/components/framework/spec/binary_file_response_spec.cr
+++ b/src/components/framework/spec/binary_file_response_spec.cr
@@ -22,6 +22,22 @@ struct ATH::BinaryFileResponseTest < ASPEC::TestCase
     ATH::BinaryFileResponse.new("#{__DIR__}/assets/fööö.html").file.basename.should eq "fööö.html"
   end
 
+  def test_set_file_unreadable : Nil
+    path = Path[Dir.tempdir, "unreadable"].to_s
+
+    begin
+      ::File.write path, "", 0
+
+      ex = expect_raises ATH::Exception::File, "The file must be readable." do
+        ATH::BinaryFileResponse.new path
+      end
+
+      ex.file.should eq path
+    ensure
+      ::File.delete? path
+    end
+  end
+
   def test_set_content : Nil
     expect_raises(::Exception, "The content cannot be set on a BinaryFileResponse instance.") do
       ATH::BinaryFileResponse.new(__FILE__).content = "FOO"
@@ -97,7 +113,7 @@ struct ATH::BinaryFileResponseTest < ASPEC::TestCase
   end
 
   def test_delete_file_after_send : Nil
-    path = "#{Dir.tempdir}/to_delete"
+    path = Path[Dir.tempdir, "unreadable"]
 
     begin
       ::File.touch path

--- a/src/components/framework/spec/binary_file_response_spec.cr
+++ b/src/components/framework/spec/binary_file_response_spec.cr
@@ -23,6 +23,8 @@ struct ATH::BinaryFileResponseTest < ASPEC::TestCase
   end
 
   def test_set_file_unreadable : Nil
+    pending! "Windows does not have unreadable files" if {{ flag? :windows }}
+
     path = Path[Dir.tempdir, "unreadable"].to_s
 
     begin

--- a/src/components/framework/src/response.cr
+++ b/src/components/framework/src/response.cr
@@ -94,14 +94,16 @@ class Athena::Framework::Response
   end
 
   # Sets the response content.
-  def content=(content : String?)
+  def content=(content : String?) : self
     @content = content || ""
+
+    self
   end
 
   # Sends `self` to the client based on the provided *context*.
   #
   # How the content gets written can be customized via an `ATH::Response::Writer`.
-  def send(request : ATH::Request, response : HTTP::Server::Response) : Nil
+  def send(request : ATH::Request, response : HTTP::Server::Response) : self
     # Ensure the response is valid.
     self.prepare request
 
@@ -119,11 +121,15 @@ class Athena::Framework::Response
 
     # Close the response.
     response.close
+
+    self
   end
 
   # Sets the `HTTP::Status` of this response.
-  def status=(code : HTTP::Status | Int32) : Nil
+  def status=(code : HTTP::Status | Int32) : self
     @status = HTTP::Status.new code
+
+    self
   end
 
   # :nodoc:
@@ -131,7 +137,7 @@ class Athena::Framework::Response
   # Do any preparation to ensure the response is RFC compliant.
   #
   # ameba:disable Metrics/CyclomaticComplexity
-  def prepare(request : ATH::Request) : Nil
+  def prepare(request : ATH::Request) : self
     # Set the content length if not already manually set
     @headers["content-length"] = @content.bytesize unless @headers.has_key? "content-length"
 
@@ -168,14 +174,18 @@ class Athena::Framework::Response
       @headers["pragma"] = "no-cache"
       @headers["expires"] = "-1"
     end
+
+    self
   end
 
   # Marks `self` as "public".
   #
   # Adds the `public` `cache-control` directive and removes the `private` directive.
-  def set_public : Nil
+  def set_public : self
     @headers.add_cache_control_directive "public"
     @headers.remove_cache_control_directive "private"
+
+    self
   end
 
   # Returns the value of the `etag` header if set, otherwise `nil`.
@@ -185,9 +195,10 @@ class Athena::Framework::Response
 
   # Updates the `etag` header to the provided, optionally *weak*, *etag*.
   # Removes the header if *etag* is `nil`.
-  def set_etag(etag : String? = nil, weak : Bool = false) : Nil
+  def set_etag(etag : String? = nil, weak : Bool = false) : self
     if etag.nil?
-      return @headers.delete "etag"
+      @headers.delete "etag"
+      return self
     end
 
     unless etag.includes? '"'
@@ -195,6 +206,8 @@ class Athena::Framework::Response
     end
 
     @headers["etag"] = "#{weak ? "W/" : ""}#{etag}"
+
+    self
   end
 
   # Returns a `Time`representing the `last-modified` header if set, otherwise `nil`.
@@ -206,12 +219,15 @@ class Athena::Framework::Response
 
   # Updates the `last-modified` header to the provided *time*.
   # Removes the header if *time* is `nil`.
-  def last_modified=(time : Time? = nil) : Nil
+  def last_modified=(time : Time? = nil) : self
     if time.nil?
-      return @headers.delete "last-modified"
+      @headers.delete "last-modified"
+      return self
     end
 
     @headers["last-modified"] = HTTP.format_time time
+
+    self
   end
 
   # Returns `true` if this response is a redirect, optionally to the provided *location*.


### PR DESCRIPTION
## Context

Makes some improvements to `ATH::Response` and related subclasses now that we have `ATH::AbstractFile` added via #559.

## Changelog

* **Breaking:** Leverage `ATH::AbstractFile` within `ATH::BinaryFileResponse`
  * Constructor argument and getter `file_path` have been renamed to `file` and now returns a `ATH::AbstractFile` instance versus `String`
* Setter methods on `ATH::Response` and subclasses now return `self` to better support method chaning

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
