### PR TITLE
Fix broken `ACON::Question` docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-  repository_dispatch:
-    types: [docs]
 
 jobs:
   docs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,7 @@
+# Intended to be triggered after one or more component(s) have had new versions tagged.
+#
+# docs - Build and deploys the prod version of the docs based on the latest tag of each component
+
 name: Release
 
 on:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,3 +1,8 @@
+# Runs on pushes to master to:
+#
+# sync - Sync changes in the merged PR to the component specific repos. Also cherry picks changes into `docs` branch and triggers a re-build if PR has the `ci:update-docs` label
+# docs - Build and deploy a development version of the docs to allow viewing docs for all un-released changes in `master`
+
 name: Sync
 
 on:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -14,7 +14,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.SYNC_TOKEN }}
       - name: Sync Repos
-        run: ./scripts/repo.sh sync
+        run: |
+          echo "UPDATE_DOCS=$([ -n "$(gh api --jq '.[0].labels | map(.name) | index("ci:update-docs")' /repos/athena-framework/athena/commits/${{ github.event.after }}/pulls)" ] && echo "1" || echo "0")" >> "$GITHUB_ENV"
+          ./scripts/repo.sh sync
         env:
           BEFORE_SHA: ${{ github.event.before }}
           AFTER_SHA: ${{ github.event.after }}

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,0 +1,22 @@
+# Changes the directory into the provided component's git directory.
+# Checks out the repo if it does not already exist.
+# Be sure to change back to previous directory when done.
+#
+# $1 - Component to check for
+# $2 - Branch to checkout (default: master)
+# $3 - URL to use if component is not already cloned
+function cdIntoComponent()
+{
+  local BRANCH=${2:-master}
+
+  if [ ! -d "../$1" ]
+  then
+      git clone --quiet "$3" "../$1" --branch "$BRANCH"
+      cd "../$1"
+  else
+      cd "../$1"
+      git checkout --quiet "$BRANCH"
+      git fetch --quiet --tags
+      git pull --quiet origin "$BRANCH"
+  fi
+}

--- a/scripts/repo.sh
+++ b/scripts/repo.sh
@@ -3,7 +3,9 @@
 
 set -e
 
-CURRENT_BRANCH="master"
+DEFAULT_BRANCH="master"
+
+. ./scripts/_common.sh
 
 # Syncs the provided component if changes were made within the provided sub directory
 #
@@ -16,7 +18,17 @@ function maybeSync()
     echo "::group::Syncing $1"
     git remote add $2 $3 || true
     git fetch $2
-    git subtree push --prefix="$1" $2 $CURRENT_BRANCH
+    git subtree push --prefix="$1" $2 $DEFAULT_BRANCH
+
+    # Sync the newly pushed commit on the component repo to the `docs` branch for this component.
+    if [[ $UPDATE_DOCS == "1" ]]; then
+      NEW_COMMIT=$(git ls-remote $3 HEAD | awk '{ print $1}')
+      cdIntoComponent $2 docs $3
+      git cherry-pick $NEW_COMMIT
+      git push
+      CD $OLDPWD
+    fi
+
     echo "::endgroup::"
   fi
 }
@@ -30,21 +42,26 @@ METHOD=$1
 
 case $METHOD in
   sync)
-    maybeSync "src/components/clock" clock https://github.com/athena-framework/clock.git
-    maybeSync "src/components/console" console https://github.com/athena-framework/console.git
-    maybeSync "src/components/contracts" contracts https://github.com/athena-framework/contracts.git
-    maybeSync "src/components/dependency_injection" dependency-injection https://github.com/athena-framework/dependency-injection.git
-    maybeSync "src/components/dotenv" dotenv https://github.com/athena-framework/dotenv.git
-    maybeSync "src/components/event_dispatcher" event-dispatcher https://github.com/athena-framework/event-dispatcher.git
-    maybeSync "src/components/image_size" image-size https://github.com/athena-framework/image-size.git
-    maybeSync "src/components/framework" framework https://github.com/athena-framework/framework.git
-    maybeSync "src/components/mercure" mercure https://github.com/athena-framework/mercure.git
-    maybeSync "src/components/mime" mime https://github.com/athena-framework/mime.git
-    maybeSync "src/components/negotiation" negotiation https://github.com/athena-framework/negotiation.git
-    maybeSync "src/components/routing" routing https://github.com/athena-framework/routing.git
-    maybeSync "src/components/serializer" serializer https://github.com/athena-framework/serializer.git
-    maybeSync "src/components/spec" spec https://github.com/athena-framework/spec.git
-    maybeSync "src/components/validator" validator https://github.com/athena-framework/validator.git
+    maybeSync "src/components/clock" clock git@github.com:athena-framework/clock.git
+    maybeSync "src/components/console" console git@github.com:athena-framework/console.git
+    maybeSync "src/components/contracts" contracts git@github.com:athena-framework/contracts.git
+    maybeSync "src/components/dependency_injection" dependency-injection git@github.com:athena-framework/dependency-injection.git
+    maybeSync "src/components/dotenv" dotenv git@github.com:athena-framework/dotenv.git
+    maybeSync "src/components/event_dispatcher" event-dispatcher git@github.com:athena-framework/event-dispatcher.git
+    maybeSync "src/components/image_size" image-size git@github.com:athena-framework/image-size.git
+    maybeSync "src/components/framework" framework git@github.com:athena-framework/framework.git
+    maybeSync "src/components/mercure" mercure git@github.com:athena-framework/mercure.git
+    maybeSync "src/components/mime" mime git@github.com:athena-framework/mime.git
+    maybeSync "src/components/negotiation" negotiation git@github.com:athena-framework/negotiation.git
+    maybeSync "src/components/routing" routing git@github.com:athena-framework/routing.git
+    maybeSync "src/components/serializer" serializer git@github.com:athena-framework/serializer.git
+    maybeSync "src/components/spec" spec git@github.com:athena-framework/spec.git
+    maybeSync "src/components/validator" validator git@github.com:athena-framework/validator.git
+
+    # Re-build the docs if we updated any `docs` branches
+    if [[ $UPDATE_DOCS == "1" ]]; then
+      gh workflow run release.yml
+    fi
 
     ;;
   subtree)

--- a/src/components/console/src/question/choice.cr
+++ b/src/components/console/src/question/choice.cr
@@ -5,6 +5,8 @@ require "./abstract_choice"
 #
 # ```
 # question = ACON::Question::Choice.new "What is your favorite color?", {"red", "blue", "green"}
+#
+# helper = self.helper ACON::Helper::Question
 # color = helper.ask input, output, question
 # ```
 #
@@ -26,6 +28,8 @@ require "./abstract_choice"
 #
 # ```
 # question = ACON::Question::Choice.new "What is your favorite color?", {"c1" => "red", "c2" => "blue", "c3" => "green"}, "c2"
+#
+# helper = self.helper ACON::Helper::Question
 # color = helper.ask input, output, question
 # ```
 #

--- a/src/components/console/src/question/confirmation.cr
+++ b/src/components/console/src/question/confirmation.cr
@@ -2,6 +2,7 @@
 #
 # ```
 # question = ACON::Question::Confirmation.new "Continue with this action?", false
+# helper = self.helper ACON::Helper::Question
 #
 # if !helper.ask input, output, question
 #   return ACON::Command::Status::SUCCESS

--- a/src/components/console/src/question/multiple_choice.cr
+++ b/src/components/console/src/question/multiple_choice.cr
@@ -5,6 +5,8 @@ require "./abstract_choice"
 #
 # ```
 # question = ACON::Question::MultipleChoice.new "What is your favorite color?", {"red", "blue", "green"}
+#
+# helper = self.helper ACON::Helper::Question
 # answer = helper.ask input, output, question
 # ```
 #

--- a/src/components/console/src/question/question.cr
+++ b/src/components/console/src/question/question.cr
@@ -8,6 +8,8 @@ require "./base"
 #
 # ```
 # question = ACON::Question(String?).new "What is your name?", nil
+#
+# helper = self.helper ACON::Helper::Question
 # name = helper.ask input, output, question
 # ```
 #
@@ -22,6 +24,8 @@ require "./base"
 # ```
 # question = ACON::Question(String?).new "What is your name?", nil
 # question.trimmable = false
+#
+# helper = self.helper ACON::Helper::Question
 # name_with_whitespace_and_newline = helper.ask input, output, question
 # ```
 #


### PR DESCRIPTION
## Context

The docs for `ACON::Question` previously used a `helper` local var which was implicitly assumed to be already defined. This PR makes it more explicit what/how `helper` actually is.

Also, assuming everything is setup correctly, this PR should allow automating the deployment of doc only PRs. Any PR with a `ci:update-docs` label will have the commit synced to each component repo cherry picked into `docs` branch of each component. Then trigger a prod build of the docs; drastically reducing the overhead of how it had to be done before.

## Changelog

* Fix broken `ACON::Question` docs

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
