### PR TITLE
Use SSH auth for Athena bot user

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: webfactory/ssh-agent@v0.9.1
         with:
-          ssh-private-key: ${{ secrets.SSH_KEY }}
+          ssh-private-key: ${{ secrets.MKDOCS_INSIDERS_SSH_PRIV_KEY }}
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3
       - name: Install Crystal

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -25,6 +25,7 @@ jobs:
           echo "UPDATE_DOCS=$([ -n "$(gh api --jq '.[0].labels | map(.name) | index("kind:documentation")' /repos/athena-framework/athena/commits/${{ github.event.after }}/pulls)" ] && echo "1" || echo "0")" >> "$GITHUB_ENV"
           ./scripts/repo.sh sync
         env:
+          GH_TOKEN: ${{ github.token }}
           BEFORE_SHA: ${{ github.event.before }}
           AFTER_SHA: ${{ github.event.after }}
   docs:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -14,10 +14,12 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.ATHENA_BOT_SSH_PRIV_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.SYNC_TOKEN }}
       - name: Sync Repos
         run: |
           echo "UPDATE_DOCS=$([ -n "$(gh api --jq '.[0].labels | map(.name) | index("kind:documentation")' /repos/athena-framework/athena/commits/${{ github.event.after }}/pulls)" ] && echo "1" || echo "0")" >> "$GITHUB_ENV"
@@ -30,7 +32,7 @@ jobs:
     steps:
       - uses: webfactory/ssh-agent@v0.9.1
         with:
-          ssh-private-key: ${{ secrets.SSH_KEY }}
+          ssh-private-key: ${{ secrets.MKDOCS_INSIDERS_SSH_PRIV_KEY }}
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3
       - name: Install Crystal


### PR DESCRIPTION
## Context

After changing the git URLs to SSH based ones in #565, Pallas no longer had permission to access the repos. This PR updates the job to use SSH auth.

## Changelog

* Fix `sync.yml` workflow permission issue

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
