### PR TITLE
Deprecate usage of codecov flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
           fail_ci_if_error: true
           directory: coverage
           files: '**/cov.xml,**/macro_coverage.*.codecov.json' # There is no `unreachable.codecov.json` file when running _only_ compiled specs
-          flags: compiled
           verbose: true
       - uses: codecov/test-results-action@v1
         if: ${{ matrix.crystal == vars.COVERAGE_CHANNEL && github.event_name != 'schedule' }} # Only want to upload coverage report once in the matrix
@@ -106,7 +105,6 @@ jobs:
           fail_ci_if_error: true
           directory: coverage
           files: '**/junit.xml'
-          flags: compiled
           verbose: true
   test_unit:
     strategy:
@@ -166,7 +164,6 @@ jobs:
           fail_ci_if_error: true
           directory: coverage
           files: '**/cov.xml,**/unreachable.codecov.json'
-          flags: unit
           verbose: true
       - uses: codecov/test-results-action@v1
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.crystal == vars.COVERAGE_CHANNEL && github.event_name != 'schedule' }} # Only want to upload coverage report once in the matrix
@@ -175,5 +172,4 @@ jobs:
           fail_ci_if_error: true
           directory: coverage
           files: '**/junit.xml'
-          flags: unit
           verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 comment:
-  layout: "condensed_header, flags, components, condensed_files, condensed_footer"
+  layout: 'condensed_header, components, condensed_files, condensed_footer'
 
 coverage:
   status:
@@ -9,10 +9,6 @@ coverage:
     patch:
       default:
         target: 100% # Enforce all _new_ code is fully tested
-
-flag_management:
-  default_rules:
-    carryforward: true
 
 component_management:
   individual_components:


### PR DESCRIPTION
## Context

We're not really benefiting from them at all given there are inherently just less compiled specs than unit so it'll always report as lower.

## Changelog

* Deprecate usage of codecov flags

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
