### PR TITLE
Schedule GitHub Action Dependabot updates for the 7th of each month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,11 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    # Updates tend to be released at the beginning of the month, but not exactly on the first.
+    # Add some delay to be able to catpure them
     schedule:
-      interval: "monthly"
+      interval: "cron"
+      cronjob: "0 0 7 * *"
     labels:
       - "kind:infrastructure"
       - "kind:enhancement"


### PR DESCRIPTION
## Context

Typos is the main action dependabot updates regularly, which tend to be released in the beginning of each month. However because `monthly` happens on the first, we miss releases that happen shortly after. E.g. https://github.com/crate-ci/typos/releases/tag/v1.35.0 which was on the 4th. This PR updates the schedule of github action updates to be the 7th of each month to be more likely to capture the releases.

## Changelog

* Schedule GitHub Action Dependabot updates for the 7th of each month

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
