### PR TITLE
Explicitly require `spec_helper` from `ATH::UploadedFile` spec

### DIFF
--- a/src/components/framework/spec/uploaded_file_spec.cr
+++ b/src/components/framework/spec/uploaded_file_spec.cr
@@ -1,3 +1,5 @@
+require "./spec_helper"
+
 struct UploadedFileTest < ASPEC::TestCase
   def test_initialize_non_existent_file : Nil
     ex = expect_raises ::ATH::Exception::FileNotFound, "The file does not exist." do


### PR DESCRIPTION
## Context

Was causing some failures in nightly CI

## Changelog

* Explicitly require `spec_helper` from `ATH::UploadedFile` spec

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
