### PR TITLE
Make QP encoded string regex a bit more strict

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,11 +1,12 @@
 [default]
 extend-ignore-re = [
   "(?Rm)^.*#\\s*spellchecker:disable-line$", # All disabling specific lines
-  "[=0-9A-F \n\r]{2}", # Disable checking Quoted-Printable encoded strings
+  "=[0-9A-F \n\r]{2}", # Disable checking Quoted-Printable encoded strings
 ]
 
 [default.extend-words]
 referer = "referrer"
+ASPEC = "ASPEC"
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
## Context

Was matching things that it shouldn't have.

## Changelog

* Make QP encoded string regex a bit more strict

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
