### PR TITLE
Tweak `CHANGELOG.md` structure

### DIFF
--- a/.changes/clock/v0.2.0.md
+++ b/.changes/clock/v0.2.0.md
@@ -2,31 +2,37 @@
 
 ### Changed
 
-- **Breaking:** Remove `Athena::Clock::Interface#sleep(Number)` overload ([#449](https://github.com/athena-framework/athena/pull/449)) (George Dietrich)
+- **Breaking:** Remove `Athena::Clock::Interface#sleep(Number)` overload ([#449]) (George Dietrich)
 
 ### Fixed
 
-- Fix type error when trying to use `ACLK::Aware#now` ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
+- Fix type error when trying to use `ACLK::Aware#now` ([#498]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/clock/releases/tag/v0.2.0
+[#449]: https://github.com/athena-framework/athena/pull/449
+[#498]: https://github.com/athena-framework/athena/pull/498
 
 ## [0.1.2] - 2024-04-09
 
 ### Changed
 
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
 
 ### Fixed
 
-- Fix that `Athena::Clock::Aware` was not required by default ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Fix that `Athena::Clock::Aware` was not required by default ([#365]) (George Dietrich)
+
+[0.1.2]: https://github.com/athena-framework/clock/releases/tag/v0.1.2
+[#365]: https://github.com/athena-framework/athena/pull/365
 
 ## [0.1.1] - 2023-10-09
 
 _Administrative release, no functional changes_
 
+[0.1.1]: https://github.com/athena-framework/clock/releases/tag/v0.1.1
+
 ## [0.1.0] - 2023-09-16
 
 _Initial release._
 
-[0.2.0]: https://github.com/athena-framework/clock/releases/tag/v0.2.0
-[0.1.2]: https://github.com/athena-framework/clock/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/clock/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/clock/releases/tag/v0.1.0

--- a/.changes/console/v0.4.1.md
+++ b/.changes/console/v0.4.1.md
@@ -2,127 +2,179 @@
 
 ### Fixed
 
-- Fix incorrectly aligned block ([#519](https://github.com/athena-framework/athena/pull/519)) (Zohir Tamda)
+- Fix incorrectly aligned block ([#519]) (Zohir Tamda)
+
+[0.4.1]: https://github.com/athena-framework/console/releases/tag/v0.4.1
+[#519]: https://github.com/athena-framework/athena/pull/519
 
 ## [0.4.0] - 2025-01-26
 
 ### Changed
 
-- **Breaking:** Normalize exception types ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
+- **Breaking:** Normalize exception types ([#428]) (George Dietrich)
 
 ### Added
 
-- **Breaking:** Add `ACON::Output::Verbosity::SILENT` verbosity level ([#489](https://github.com/athena-framework/athena/pull/489)) (George Dietrich)
-- **Breaking:** Rename `ACON::Completion::Input#must_suggest_values_for?` to `#must_suggest_option_values_for?` ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.13.0` ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
-- Add `#assert_command_is_not_successful` spec expectation method ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
-- Add support for [`FORCE_COLOR`](https://force-color.org/) and improve color support logic ([#488](https://github.com/athena-framework/athena/pull/488)) (George Dietrich)
+- **Breaking:** Add `ACON::Output::Verbosity::SILENT` verbosity level ([#489]) (George Dietrich)
+- **Breaking:** Rename `ACON::Completion::Input#must_suggest_values_for?` to `#must_suggest_option_values_for?` ([#498]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.13.0` ([#498]) (George Dietrich)
+- Add `#assert_command_is_not_successful` spec expectation method ([#498]) (George Dietrich)
+- Add support for [`FORCE_COLOR`](https://force-color.org/) and improve color support logic ([#488]) (George Dietrich)
 
 ### Fixed
 
-- Fix unexpected completion value when given an array of options ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
-- Fix error when trying to set `ACON::Helper::Table::Style#padding_char` ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
+- Fix unexpected completion value when given an array of options ([#498]) (George Dietrich)
+- Fix error when trying to set `ACON::Helper::Table::Style#padding_char` ([#498]) (George Dietrich)
+
+[0.4.0]: https://github.com/athena-framework/console/releases/tag/v0.4.0
+[#428]: https://github.com/athena-framework/athena/pull/428
+[#488]: https://github.com/athena-framework/athena/pull/488
+[#489]: https://github.com/athena-framework/athena/pull/489
+[#498]: https://github.com/athena-framework/athena/pull/498
 
 ## [0.3.6] - 2024-07-31
 
 ### Changed
 
-- **Breaking:** `ACON::Application#getter` and constructor argument must now be a `String` instead of `SemanticVersion` ([#419](https://github.com/athena-framework/athena/pull/419)) (George Dietrich)
-- Changed the default `ACON::Application` version to `UNKNOWN` from `0.1.0` ([#419](https://github.com/athena-framework/athena/pull/419)) (George Dietrich)
-- List commands in a namespace when using it as the command name ([#427](https://github.com/athena-framework/athena/pull/427)) (George Dietrich)
-- Use single quotes in text descriptor to quote values in the output ([#427](https://github.com/athena-framework/athena/pull/427)) (George Dietrich)
+- **Breaking:** `ACON::Application#getter` and constructor argument must now be a `String` instead of `SemanticVersion` ([#419]) (George Dietrich)
+- Changed the default `ACON::Application` version to `UNKNOWN` from `0.1.0` ([#419]) (George Dietrich)
+- List commands in a namespace when using it as the command name ([#427]) (George Dietrich)
+- Use single quotes in text descriptor to quote values in the output ([#427]) (George Dietrich)
+
+[0.3.6]: https://github.com/athena-framework/console/releases/tag/v0.3.6
+[#419]: https://github.com/athena-framework/athena/pull/419
+[#427]: https://github.com/athena-framework/athena/pull/427
 
 ## [0.3.5] - 2024-04-09
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.11.0` ([#270](https://github.com/athena-framework/athena/pull/270)) (George Dietrich)
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.11.0` ([#270]) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
 
 ### Added
 
-- Support for Windows OS ([#270](https://github.com/athena-framework/athena/pull/270)) (George Dietrich)
+- Support for Windows OS ([#270]) (George Dietrich)
 
 ### Fixed
 
-- Fix incorrect column/width `ACON::Terminal` values on Windows ([#361](https://github.com/athena-framework/athena/pull/361)) (George Dietrich)
+- Fix incorrect column/width `ACON::Terminal` values on Windows ([#361]) (George Dietrich)
+
+[0.3.5]: https://github.com/athena-framework/console/releases/tag/v0.3.5
+[#270]: https://github.com/athena-framework/athena/pull/270
+[#365]: https://github.com/athena-framework/athena/pull/365
+[#361]: https://github.com/athena-framework/athena/pull/361
 
 ## [0.3.4] - 2023-10-10
 
 ### Added
 
-- Add support for tab completion to the `bash` shell when binary is in the `bin/` directory and referenced with `./` ([#323](https://github.com/athena-framework/athena/pull/323)) (George Dietrich)
+- Add support for tab completion to the `bash` shell when binary is in the `bin/` directory and referenced with `./` ([#323]) (George Dietrich)
+
+[0.3.4]: https://github.com/athena-framework/console/releases/tag/v0.3.4
+[#323]: https://github.com/athena-framework/athena/pull/323
 
 ## [0.3.3] - 2023-10-09
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.8.0` ([#282](https://github.com/athena-framework/athena/pull/282)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.8.0` ([#282]) (George Dietrich)
 
 ### Added
 
-- **Breaking:** Add `ACON::Helper::ProgressBar` to enable rendering progress bars ([#304](https://github.com/athena-framework/athena/pull/304)) (George Dietrich)
-- Add native shell tab completion support for `bash`, `zsh`, and `fish` for both built-in and custom commands ([#294](https://github.com/athena-framework/athena/pull/294),[#296](https://github.com/athena-framework/athena/pull/296), [#297](https://github.com/athena-framework/athena/pull/297), [#299](https://github.com/athena-framework/athena/pull/299)) (George Dietrich)
-- Add `ACON::Helper::ProgressIndicator` to enable rendering spinners ([#314](https://github.com/athena-framework/athena/pull/314)) (George Dietrich)
-- Add support for defining a max height for an `ACON::Output::Section` ([#303](https://github.com/athena-framework/athena/pull/303)) (George Dietrich)
-- Add `ACON::Helper.format_time` to format a duration as a human readable string ([#304](https://github.com/athena-framework/athena/pull/304)) (George Dietrich)
-- Add `#assert_command_is_successful` helper method to `ACON::Spec::CommandTester` and `ACON::Spec::ApplicationTester` ([#294](https://github.com/athena-framework/athena/pull/294)) (George Dietrich)
+- **Breaking:** Add `ACON::Helper::ProgressBar` to enable rendering progress bars ([#304]) (George Dietrich)
+- Add native shell tab completion support for `bash`, `zsh`, and `fish` for both built-in and custom commands ([#294], [#296], [#297], [#299]) (George Dietrich)
+- Add `ACON::Helper::ProgressIndicator` to enable rendering spinners ([#314]) (George Dietrich)
+- Add support for defining a max height for an `ACON::Output::Section` ([#303]) (George Dietrich)
+- Add `ACON::Helper.format_time` to format a duration as a human readable string ([#304]) (George Dietrich)
+- Add `#assert_command_is_successful` helper method to `ACON::Spec::CommandTester` and `ACON::Spec::ApplicationTester` ([#294]) (George Dietrich)
 
 ### Fixed
 
-- Ensure long lines with URLs are not cut when wrapped ([#314](https://github.com/athena-framework/athena/pull/314)) (George Dietrich)
-- Do not emit erroneous newline from `ACON::Style::Athena` when it's the first thing being written ([#314](https://github.com/athena-framework/athena/pull/314)) (George Dietrich)
-- Fix misalignment when word wrapping a hyperlink ([#305](https://github.com/athena-framework/athena/pull/305)) (George Dietrich)
-- Do not emit erroneous extra newlines from an `ACON::Output::Section` ([#303](https://github.com/athena-framework/athena/pull/303)) (George Dietrich)
-- Fix misalignment within a vertical table with multi-line cell ([#300](https://github.com/athena-framework/athena/pull/300)) (George Dietrich)
+- Ensure long lines with URLs are not cut when wrapped ([#314]) (George Dietrich)
+- Do not emit erroneous newline from `ACON::Style::Athena` when it's the first thing being written ([#314]) (George Dietrich)
+- Fix misalignment when word wrapping a hyperlink ([#305]) (George Dietrich)
+- Do not emit erroneous extra newlines from an `ACON::Output::Section` ([#303]) (George Dietrich)
+- Fix misalignment within a vertical table with multi-line cell ([#300]) (George Dietrich)
+
+[0.3.3]: https://github.com/athena-framework/console/releases/tag/v0.3.3
+[#282]: https://github.com/athena-framework/athena/pull/282
+[#294]: https://github.com/athena-framework/athena/pull/294
+[#296]: https://github.com/athena-framework/athena/pull/296
+[#297]: https://github.com/athena-framework/athena/pull/297
+[#299]: https://github.com/athena-framework/athena/pull/299
+[#300]: https://github.com/athena-framework/athena/pull/300
+[#303]: https://github.com/athena-framework/athena/pull/303
+[#304]: https://github.com/athena-framework/athena/pull/304
+[#305]: https://github.com/athena-framework/athena/pull/305
+[#314]: https://github.com/athena-framework/athena/pull/314
 
 ## [0.3.2] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
 
 ### Fixed
 
-- Fix formatting issue in Crystal `1.8-dev` ([#258](https://github.com/athena-framework/athena/pull/258)) (George Dietrich)
+- Fix formatting issue in Crystal `1.8-dev` ([#258]) (George Dietrich)
+
+[0.3.2]: https://github.com/athena-framework/console/releases/tag/v0.3.2
+[#261]: https://github.com/athena-framework/athena/pull/261
+[#258]: https://github.com/athena-framework/athena/pull/258
 
 ## [0.3.1] - 2023-02-04
 
 ### Added
 
-- Add better integration between `Athena::Console` and `Athena::DependencyInjection` ([#259](https://github.com/athena-framework/athena/pull/259)) (George Dietrich)
+- Add better integration between `Athena::Console` and `Athena::DependencyInjection` ([#259]) (George Dietrich)
+
+[0.3.1]: https://github.com/athena-framework/console/releases/tag/v0.3.1
+[#259]: https://github.com/athena-framework/athena/pull/259
 
 ## [0.3.0] - 2023-01-07
 
 ### Changed
 
-- **Breaking:** deprecate command default name/description class variables in favor of the new `ACONA::AsCommand` annotation ([#214](https://github.com/athena-framework/athena/pull/214)) (George Dietrich)
-- **Breaking:** refactor `ACON::Command#application=` to no longer have a `nil` default value ([#217](https://github.com/athena-framework/athena/pull/217)) (George Dietrich)
-- **Breaking:** refactor `ACON::Command#process_title=` no longer accept `nil` ([#217](https://github.com/athena-framework/athena/pull/217)) (George Dietrich)
-- **Breaking:** rename `ACON::Command#process_title=` to `ACON::Command#process_title` ([#217](https://github.com/athena-framework/athena/pull/217)) (George Dietrich)
+- **Breaking:** deprecate command default name/description class variables in favor of the new `ACONA::AsCommand` annotation ([#214]) (George Dietrich)
+- **Breaking:** refactor `ACON::Command#application=` to no longer have a `nil` default value ([#217]) (George Dietrich)
+- **Breaking:** refactor `ACON::Command#process_title=` no longer accept `nil` ([#217]) (George Dietrich)
+- **Breaking:** rename `ACON::Command#process_title=` to `ACON::Command#process_title` ([#217]) (George Dietrich)
 
 ### Added
 
-- **Breaking:** add `#table` method to `ACON::Style::Interface` ([#220](https://github.com/athena-framework/athena/pull/220)) (George Dietrich)
-- Add `ACONA::AsCommand` annotation to configure a command's name, description, aliases, and if it should be hidden ([#214](https://github.com/athena-framework/athena/pull/214)) (George Dietrich)
-- Add support for generating tables ([#220](https://github.com/athena-framework/athena/pull/220)) (George Dietrich)
+- **Breaking:** add `#table` method to `ACON::Style::Interface` ([#220]) (George Dietrich)
+- Add `ACONA::AsCommand` annotation to configure a command's name, description, aliases, and if it should be hidden ([#214]) (George Dietrich)
+- Add support for generating tables ([#220]) (George Dietrich)
 
 ### Fixed
 
-- Fix issue with using `ACON::Formatter::Output#format_and_wrap` with `nil` input and an edge case when wrapping a string with a space at the limit ([#220](https://github.com/athena-framework/athena/pull/220)) (George Dietrich)
-- Fix `ACON::Formatter::NullStyle#*_option` method using incorrect `ACON::Formatter::Mode` type restriction ([#220](https://github.com/athena-framework/athena/pull/220)) (George Dietrich)
-- Fix some flakiness when testing commands with input ([#224](https://github.com/athena-framework/athena/pull/224)) (George Dietrich)
-- Fix compiler error when trying to use `ACON::Style::Athena#error_style` ([#240](https://github.com/athena-framework/athena/pull/240)) (George Dietrich)
+- Fix issue with using `ACON::Formatter::Output#format_and_wrap` with `nil` input and an edge case when wrapping a string with a space at the limit ([#220]) (George Dietrich)
+- Fix `ACON::Formatter::NullStyle#*_option` method using incorrect `ACON::Formatter::Mode` type restriction ([#220]) (George Dietrich)
+- Fix some flakiness when testing commands with input ([#224]) (George Dietrich)
+- Fix compiler error when trying to use `ACON::Style::Athena#error_style` ([#240]) (George Dietrich)
+
+[0.3.0]: https://github.com/athena-framework/console/releases/tag/v0.3.0
+[#214]: https://github.com/athena-framework/athena/pull/214
+[#217]: https://github.com/athena-framework/athena/pull/217
+[#220]: https://github.com/athena-framework/athena/pull/220
+[#224]: https://github.com/athena-framework/athena/pull/224
+[#240]: https://github.com/athena-framework/athena/pull/240
 
 ## [0.2.1] - 2022-09-05
 
 ### Changed
 
-- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188](https://github.com/athena-framework/athena/pull/188)) (George Dietrich)
+- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188]) (George Dietrich)
 
 ### Added
 
-- Add an `ACON::Input::Interface` based on a command line string ([#186](https://github.com/athena-framework/athena/pull/186), [#187](https://github.com/athena-framework/athena/pull/187)) (George Dietrich)
+- Add an `ACON::Input::Interface` based on a command line string ([#186], [#187]) (George Dietrich)
+
+[0.2.1]: https://github.com/athena-framework/console/releases/tag/v0.2.1
+[#186]: https://github.com/athena-framework/athena/pull/186
+[#187]: https://github.com/athena-framework/athena/pull/187
+[#188]: https://github.com/athena-framework/athena/pull/188
 
 ## [0.2.0] - 2022-05-14
 
@@ -130,39 +182,38 @@ _First release a part of the monorepo._
 
 ### Changed
 
-- **Breaking:** remove `ACON::Formatter::Mode` in favor of `Colorize::Mode`. Breaking only if not using symbol autocasting. ([#170](https://github.com/athena-framework/athena/pull/170)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- **Breaking:** remove `ACON::Formatter::Mode` in favor of `Colorize::Mode`. Breaking only if not using symbol autocasting. ([#170]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Added
 
-- Add `VERSION` constant to `Athena::Console` namespace ([#166](https://github.com/athena-framework/athena/pull/166)) (George Dietrich)
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
+- Add `VERSION` constant to `Athena::Console` namespace ([#166]) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
 
 ### Fixed
 
-- Disallow multi char option shortcuts made up of diff chars ([#164](https://github.com/athena-framework/athena/pull/164)) (George Dietrich)
+- Disallow multi char option shortcuts made up of diff chars ([#164]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/console/releases/tag/v0.2.0
+[#164]: https://github.com/athena-framework/athena/pull/164
+[#166]: https://github.com/athena-framework/athena/pull/166
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#170]: https://github.com/athena-framework/athena/pull/170
+[#172]: https://github.com/athena-framework/athena/pull/172
 
 ## [0.1.1] - 2021-12-01
 
 ### Fixed
 
-- **Breaking:** fix typo in parameter name of `ACON::Command#option` method ([#3](https://github.com/athena-framework/console/pull/3)) (George Dietrich)
-- Fix recursive struct error ([#4](https://github.com/athena-framework/console/pull/4)) (George Dietrich)
+- **Breaking:** fix typo in parameter name of `ACON::Command#option` method ([#3]) (George Dietrich)
+- Fix recursive struct error ([#4]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/console/releases/tag/v0.1.1
+[#3]: https://github.com/athena-framework/console/pull/3
+[#4]: https://github.com/athena-framework/console/pull/4
 
 ## [0.1.0] - 2021-10-30
 
 _Initial release._
 
-[0.4.1]: https://github.com/athena-framework/console/releases/tag/v0.4.1
-[0.4.0]: https://github.com/athena-framework/console/releases/tag/v0.4.0
-[0.3.6]: https://github.com/athena-framework/console/releases/tag/v0.3.6
-[0.3.5]: https://github.com/athena-framework/console/releases/tag/v0.3.5
-[0.3.4]: https://github.com/athena-framework/console/releases/tag/v0.3.4
-[0.3.3]: https://github.com/athena-framework/console/releases/tag/v0.3.3
-[0.3.2]: https://github.com/athena-framework/console/releases/tag/v0.3.2
-[0.3.1]: https://github.com/athena-framework/console/releases/tag/v0.3.1
-[0.3.0]: https://github.com/athena-framework/console/releases/tag/v0.3.0
-[0.2.1]: https://github.com/athena-framework/console/releases/tag/v0.2.1
-[0.2.0]: https://github.com/athena-framework/console/releases/tag/v0.2.0
-[0.1.1]: https://github.com/athena-framework/console/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/console/releases/tag/v0.1.0

--- a/.changes/dependency_injection/v0.4.3.md
+++ b/.changes/dependency_injection/v0.4.3.md
@@ -2,66 +2,106 @@
 
 ### Changed
 
-- **Breaking:** prevent auto registering of already registered services ([#520](https://github.com/athena-framework/athena/pull/520)) (George Dietrich)
+- **Breaking:** prevent auto registering of already registered services ([#520]) (George Dietrich)
 
 ### Fixed
 
-- Ensure all array values have proper `#of` type ([#508](https://github.com/athena-framework/athena/pull/508)) (George Dietrich)
+- Ensure all array values have proper `#of` type ([#508]) (George Dietrich)
+
+[0.4.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.3
+[#508]: https://github.com/athena-framework/athena/pull/508
+[#520]: https://github.com/athena-framework/athena/pull/520
 
 ## [0.4.2] - 2025-01-26
 
 _Administrative release, no functional changes_
 
+[0.4.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.2
+
 ## [0.4.1] - 2024-07-31
 
 ### Changed
 
-- **Breaking:** single implementation aliases are now explicit ([#408](https://github.com/athena-framework/athena/pull/408)) (George Dietrich)
+- **Breaking:** single implementation aliases are now explicit ([#408]) (George Dietrich)
 
 ### Fixed
 
-- Fix default/nil values related to `object_of` and `array_of` being unavailable in bundle extensions ([#432](https://github.com/athena-framework/athena/pull/432)) (George Dietrich)
+- Fix default/nil values related to `object_of` and `array_of` being unavailable in bundle extensions ([#432]) (George Dietrich)
+
+[0.4.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.1
+[#408]: https://github.com/athena-framework/athena/pull/408
+[#432]: https://github.com/athena-framework/athena/pull/432
 
 ## [0.4.0] - 2024-04-09
 
 ### Changed
 
-- **Breaking:** remove `Clock`, `Console`, and `EventDispatcher` built-in integrations ([#337](https://github.com/athena-framework/athena/pull/337)) (George Dietrich)
-- **Breaking:** major internal refactor ([#337](https://github.com/athena-framework/athena/pull/337), [#378](https://github.com/athena-framework/athena/pull/378)) (George Dietrich)
-- **Breaking:** replace `ADI.auto_configure` with [ADI::Autoconfigure](https://athenaframework.org/DependencyInjection/Autoconfigure/) ([#387](https://github.com/athena-framework/athena/pull/387)) (George Dietrich)
-- **Breaking:** replace `alias` `ADI::Register` field with [ADI::AsAlias](https://athenaframework.org/DependencyInjection/AsAlias/) ([#389](https://github.com/athena-framework/athena/pull/389)) (George Dietrich)
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- **Breaking:** remove `Clock`, `Console`, and `EventDispatcher` built-in integrations ([#337]) (George Dietrich)
+- **Breaking:** major internal refactor ([#337], [#378]) (George Dietrich)
+- **Breaking:** replace `ADI.auto_configure` with [ADI::Autoconfigure](https://athenaframework.org/DependencyInjection/Autoconfigure/) ([#387]) (George Dietrich)
+- **Breaking:** replace `alias` `ADI::Register` field with [ADI::AsAlias](https://athenaframework.org/DependencyInjection/AsAlias/) ([#389]) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
 
 ### Added
 
-- Add ability to easily extend/customize the container ([#337](https://github.com/athena-framework/athena/pull/337), [#348](https://github.com/athena-framework/athena/pull/348), [#371](https://github.com/athena-framework/athena/pull/371), [#372](https://github.com/athena-framework/athena/pull/372), [#373](https://github.com/athena-framework/athena/pull/373), [#374](https://github.com/athena-framework/athena/pull/374), [#377](https://github.com/athena-framework/athena/pull/377), [#379](https://github.com/athena-framework/athena/pull/379), [#382](https://github.com/athena-framework/athena/pull/382), [#383](https://github.com/athena-framework/athena/pull/383)) (George Dietrich)
-- Add ability to define method calls that should be made during service instantiation ([#384](https://github.com/athena-framework/athena/pull/384)) (George Dietrich)
-- Add new [ADI::AutoconfigureTag](https://athenaframework.org/DependencyInjection/AutoconfigureTag/) and [ADI::TaggedIterator](https://athenaframework.org/DependencyInjection/TaggedIterator/) to make working with tagged services easier ([#387](https://github.com/athena-framework/athena/pull/387)) (George Dietrich)
-- Add `ADI.configuration_annotation` to `Athena::DependencyInjection` from `Athena::Config` ([#392](https://github.com/athena-framework/athena/pull/392)) (George Dietrich)
+- Add ability to easily extend/customize the container ([#337], [#348], [#371], [#372], [#373], [#374], [#377], [#379], [#382], [#383]) (George Dietrich)
+- Add ability to define method calls that should be made during service instantiation ([#384]) (George Dietrich)
+- Add new [ADI::AutoconfigureTag](https://athenaframework.org/DependencyInjection/AutoconfigureTag/) and [ADI::TaggedIterator](https://athenaframework.org/DependencyInjection/TaggedIterator/) to make working with tagged services easier ([#387]) (George Dietrich)
+- Add `ADI.configuration_annotation` to `Athena::DependencyInjection` from `Athena::Config` ([#392]) (George Dietrich)
+
+[0.4.0]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.0
+[#337]: https://github.com/athena-framework/athena/pull/337
+[#348]: https://github.com/athena-framework/athena/pull/348
+[#365]: https://github.com/athena-framework/athena/pull/365
+[#371]: https://github.com/athena-framework/athena/pull/371
+[#372]: https://github.com/athena-framework/athena/pull/372
+[#373]: https://github.com/athena-framework/athena/pull/373
+[#374]: https://github.com/athena-framework/athena/pull/374
+[#377]: https://github.com/athena-framework/athena/pull/377
+[#378]: https://github.com/athena-framework/athena/pull/378
+[#379]: https://github.com/athena-framework/athena/pull/379
+[#382]: https://github.com/athena-framework/athena/pull/382
+[#383]: https://github.com/athena-framework/athena/pull/383
+[#384]: https://github.com/athena-framework/athena/pull/384
+[#387]: https://github.com/athena-framework/athena/pull/387
+[#389]: https://github.com/athena-framework/athena/pull/389
+[#392]: https://github.com/athena-framework/athena/pull/392
 
 ## [0.3.8] - 2023-12-16
 
 ### Fixed
 
-- Avoid depending directly on Crystal macro types ([#335](https://github.com/athena-framework/athena/pull/335)) (George Dietrich)
+- Avoid depending directly on Crystal macro types ([#335]) (George Dietrich)
+
+[0.3.8]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.8
+[#335]: https://github.com/athena-framework/athena/pull/335
 
 ## [0.3.7] - 2023-10-09
 
 ### Added
 
-- Add integration between `Athena::DependencyInjection` and the `Athena::Clock` component ([#318](https://github.com/athena-framework/athena/pull/318)) (George Dietrich)
+- Add integration between `Athena::DependencyInjection` and the `Athena::Clock` component ([#318]) (George Dietrich)
+
+[0.3.7]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.7
+[#318]: https://github.com/athena-framework/athena/pull/318
 
 ## [0.3.6] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
+
+[0.3.6]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.6
+[#261]: https://github.com/athena-framework/athena/pull/261
 
 ## [0.3.5] - 2023-02-04
 
 ### Added
 
-- Add better integration between `Athena::DependencyInjection` and the `Athena::Console` and `Athena::EventDispatcher` components ([#259](https://github.com/athena-framework/athena/pull/259)) (George Dietrich)
+- Add better integration between `Athena::DependencyInjection` and the `Athena::Console` and `Athena::EventDispatcher` components ([#259]) (George Dietrich)
+
+[0.3.5]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.5
+[#259]: https://github.com/athena-framework/athena/pull/259
 
 ## [0.3.4] - 2023-01-07
 
@@ -69,83 +109,120 @@ _Administrative release, no functional changes_
 
 - Refactor various internal logic (George Dietrich)
 
+[0.3.4]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.4
+
 ## [0.3.3] - 2022-05-14
 
 _First release a part of the monorepo._
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Added
 
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
+
+[0.3.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.3
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#172]: https://github.com/athena-framework/athena/pull/172
 
 ## [0.3.2] - 2021-10-30
 
 ### Changed
 
-- Unused services are now excluded from the container ([#30](https://github.com/athena-framework/dependency-injection/pull/30)) (George Dietrich)
+- Unused services are now excluded from the container ([#30]) (George Dietrich)
+
+[0.3.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.2
+[#30]: https://github.com/athena-framework/dependency-injection/pull/30
 
 ## [0.3.1] - 2021-03-28
 
 ### Fixed
 
-- Fix error with untyped parameters with default values injecting ([#28](https://github.com/athena-framework/dependency-injection/pull/28)) (George Dietrich)
+- Fix error with untyped parameters with default values injecting ([#28]) (George Dietrich)
+
+[0.3.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.1
+[#28]: https://github.com/athena-framework/dependency-injection/pull/28
 
 ## [0.3.0] - 2021-03-20
 
 ### Added
 
-- Allow injecting [configuration](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--configuration) into services ([#27](https://github.com/athena-framework/dependency-injection/pull/27)) (George Dietrich)
+- Allow injecting [configuration](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--configuration) into services ([#27]) (George Dietrich)
+
+[0.3.0]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.0
+[#27]: https://github.com/athena-framework/dependency-injection/pull/27
 
 ## [0.2.6] - 2021-03-15
 
 ### Added
 
-- Allow using the `ADI::Inject` annotation on class methods to create [factories](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--factories) ([#25](https://github.com/athena-framework/dependency-injection/pull/25)) (George Dietrich)
+- Allow using the `ADI::Inject` annotation on class methods to create [factories](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--factories) ([#25]) (George Dietrich)
+
+[0.2.6]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.6
+[#25]: https://github.com/athena-framework/dependency-injection/pull/25
 
 ## [0.2.5] - 2021-01-30
 
 ### Changed
 
-- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#23](https://github.com/athena-framework/dependency-injection/pull/23), [#24](https://github.com/athena-framework/dependency-injection/pull/24)) (George Dietrich)
+- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#23], [#24]) (George Dietrich)
+
+[0.2.5]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.5
+[#23]: https://github.com/athena-framework/dependency-injection/pull/23
+[#24]: https://github.com/athena-framework/dependency-injection/pull/24
 
 ## [0.2.4] - 2021-01-29
 
 ### Added
 
-- Add dependency on `athena-framework/config` ([#20](https://github.com/athena-framework/dependency-injection/pull/20)) (George Dietrich)
-- Add support for injecting [parameters](https://athenaframework.org/architecture/config/#parameters) into a service ([#20](https://github.com/athena-framework/dependency-injection/pull/20)) (George Dietrich)
-- Add support for [service proxies](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--service-proxies) ([#21](https://github.com/athena-framework/dependency-injection/pull/21)) (George Dietrich)
+- Add dependency on `athena-framework/config` ([#20]) (George Dietrich)
+- Add support for injecting [parameters](https://athenaframework.org/architecture/config/#parameters) into a service ([#20]) (George Dietrich)
+- Add support for [service proxies](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--service-proxies) ([#21]) (George Dietrich)
 
 ### Removed
 
-- Remove the `lazy` `ADI::Register` field. All services are lazy by default now ([#21](https://github.com/athena-framework/dependency-injection/pull/21)) (George Dietrich)
+- Remove the `lazy` `ADI::Register` field. All services are lazy by default now ([#21]) (George Dietrich)
 
 ### Fixed
 
-- Fix issue building documentation ([#22](https://github.com/athena-framework/dependency-injection/pull/22)) (George Dietrich)
+- Fix issue building documentation ([#22]) (George Dietrich)
+
+[0.2.4]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.4
+[#20]: https://github.com/athena-framework/dependency-injection/pull/20
+[#21]: https://github.com/athena-framework/dependency-injection/pull/21
+[#22]: https://github.com/athena-framework/dependency-injection/pull/22
 
 ## [0.2.3] - 2020-12-24
 
 ### Fixed
 
-- Fix error when a parameter has a default value after an array parameter ([#19](https://github.com/athena-framework/dependency-injection/pull/19)) (George Dietrich)
+- Fix error when a parameter has a default value after an array parameter ([#19]) (George Dietrich)
+
+[0.2.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.3
+[#19]: https://github.com/athena-framework/dependency-injection/pull/19
 
 ## [0.2.2] - 2020-12-03
 
 ### Changed
 
-- Update `crystal` version to allow version greater than `1.0.0` ([#18](https://github.com/athena-framework/dependency-injection/pull/18)) (George Dietrich)
+- Update `crystal` version to allow version greater than `1.0.0` ([#18]) (George Dietrich)
+
+[0.2.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.2
+[#18]: https://github.com/athena-framework/dependency-injection/pull/18
 
 ## [0.2.1] - 2020-11-14
 
 ### Added
 
-- Add a mock container instance to allow mocking services ([#15](https://github.com/athena-framework/dependency-injection/pull/15)) (George Dietrich)
-- Add ability to customize the type of a service within the container ([#15](https://github.com/athena-framework/dependency-injection/pull/15)) (George Dietrich)
-- Add support for [factory pattern](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--factories) constructors ([#16](https://github.com/athena-framework/dependency-injection/pull/16)) (George Dietrich)
+- Add a mock container instance to allow mocking services ([#15]) (George Dietrich)
+- Add ability to customize the type of a service within the container ([#15]) (George Dietrich)
+- Add support for [factory pattern](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--factories) constructors ([#16]) (George Dietrich)
+
+[0.2.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.1
+[#15]: https://github.com/athena-framework/dependency-injection/pull/15
+[#16]: https://github.com/athena-framework/dependency-injection/pull/16
 
 ## [0.2.0] - 2020-06-09
 
@@ -153,69 +230,58 @@ _Major refactor of the component._
 
 ### Added
 
-- Add concept of [aliasing services](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--aliasing-services) ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- Add concept of [binding values](https://athenaframework.org/DependencyInjection/#Athena::DependencyInjection:bind(key,value)) ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- Add concept of [auto configuration](https://athenaframework.org/DependencyInjection/#Athena::DependencyInjection:auto_configure(type,options)) ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- Add [ADI::Inject](https://athenaframework.org/DependencyInjection/Inject/) annotation ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- Add support for [generic services](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--generic-services) ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
+- Add concept of [aliasing services](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--aliasing-services) ([#10]) (George Dietrich)
+- Add concept of [binding values](https://athenaframework.org/DependencyInjection/#Athena::DependencyInjection:bind(key,value)) ([#10]) (George Dietrich)
+- Add concept of [auto configuration](https://athenaframework.org/DependencyInjection/#Athena::DependencyInjection:auto_configure(type,options)) ([#10]) (George Dietrich)
+- Add [ADI::Inject](https://athenaframework.org/DependencyInjection/Inject/) annotation ([#10]) (George Dietrich)
+- Add support for [generic services](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--generic-services) ([#10]) (George Dietrich)
 
 ### Changed
 
-- **Breaking:** manually provided arguments now need to be prefixed with a `_` ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- **Breaking:** service names are now based on the `FQN` of the type, downcase underscored by default ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- Updated [optional services](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--optional-services) to now be based on the type/default value of the parameter ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- Service dependencies are now resolved automatically, removes need to manually provide them ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
+- **Breaking:** manually provided arguments now need to be prefixed with a `_` ([#10]) (George Dietrich)
+- **Breaking:** service names are now based on the `FQN` of the type, downcase underscored by default ([#10]) (George Dietrich)
+- Updated [optional services](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--optional-services) to now be based on the type/default value of the parameter ([#10]) (George Dietrich)
+- Service dependencies are now resolved automatically, removes need to manually provide them ([#10]) (George Dietrich)
 
 ### Removed
 
-- **Breaking:** remove the `ADI::Service` module ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- **Breaking:** remove the `ADI::Injectable` module ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- **Breaking:** remove the `@?` syntax ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- **Breaking:** remove the `#get`, `#has`, `#resolve`, `#tagged`, and `#tags` methods from `ADI::ServiceContainer` ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
+- **Breaking:** remove the `ADI::Service` module ([#10]) (George Dietrich)
+- **Breaking:** remove the `ADI::Injectable` module ([#10]) (George Dietrich)
+- **Breaking:** remove the `@?` syntax ([#10]) (George Dietrich)
+- **Breaking:** remove the `#get`, `#has`, `#resolve`, `#tagged`, and `#tags` methods from `ADI::ServiceContainer` ([#10]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.0
+[#10]: https://github.com/athena-framework/dependency-injection/pull/10
 
 ## [0.1.3] - 2020-04-06
 
 ### Fixed
 
-- Fix an edge case by checking includers via `<=` ([#7](https://github.com/athena-framework/dependency-injection/pull/7)) (George Dietrich)
+- Fix an edge case by checking includers via `<=` ([#7]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.1.3
+[#7]: https://github.com/athena-framework/dependency-injection/pull/7
 
 ## [0.1.2] - 2020-02-22
 
 ### Changed
 
-- Change type resolution logic to operate at compile time instead of runtime ([#6](https://github.com/athena-framework/dependency-injection/pull/6)) (George Dietrich)
+- Change type resolution logic to operate at compile time instead of runtime ([#6]) (George Dietrich)
+
+[0.1.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.1.2
+[#6]: https://github.com/athena-framework/dependency-injection/pull/6
 
 ## [0.1.1] - 2020-02-06
 
 ### Added
 
-- Add the ability to redefine services ([#4](https://github.com/athena-framework/dependency-injection/pull/4)) (George Dietrich)
+- Add the ability to redefine services ([#4]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.1.1
+[#4]: https://github.com/athena-framework/dependency-injection/pull/4
 
 ## [0.1.0] - 2020-01-31
 
 _Initial release._
 
-[0.4.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.3
-[0.4.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.2
-[0.4.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.1
-[0.4.0]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.0
-[0.3.8]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.8
-[0.3.7]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.7
-[0.3.6]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.6
-[0.3.5]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.5
-[0.3.4]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.4
-[0.3.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.3
-[0.3.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.2
-[0.3.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.1
-[0.3.0]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.0
-[0.2.6]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.6
-[0.2.5]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.5
-[0.2.4]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.4
-[0.2.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.3
-[0.2.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.2
-[0.2.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.1
-[0.2.0]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.0
-[0.1.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.1.0

--- a/.changes/dotenv/v0.2.0.md
+++ b/.changes/dotenv/v0.2.0.md
@@ -2,38 +2,47 @@
 
 ### Changed
 
-- **Breaking:** Normalize exception types ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
+- **Breaking:** Normalize exception types ([#428]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/dotenv/releases/tag/v0.2.0
+[#428]: https://github.com/athena-framework/athena/pull/428
 
 ## [0.1.3] - 2024-07-31
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.13.0` ([#433](https://github.com/athena-framework/athena/pull/433)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.13.0` ([#433]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/dotenv/releases/tag/v0.1.3
+[#433]: https://github.com/athena-framework/athena/pull/433
 
 ## [0.1.2] - 2024-04-09
 
 ### Changed
 
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
 
 ### Added
 
-- Add helper `Athena::Dotenv.load` method to create and load `.env` files in one call ([#363](https://github.com/athena-framework/athena/pull/363)) (George Dietrich)
+- Add helper `Athena::Dotenv.load` method to create and load `.env` files in one call ([#363]) (George Dietrich)
 
 ### Fixed
 
-- Fixed error parsing ENV vars starting with `_` ([#346](https://github.com/athena-framework/athena/pull/346)) (George Dietrich)
+- Fixed error parsing ENV vars starting with `_` ([#346]) (George Dietrich)
+
+[0.1.2]: https://github.com/athena-framework/dotenv/releases/tag/v0.1.2
+[#346]: https://github.com/athena-framework/athena/pull/346
+[#363]: https://github.com/athena-framework/athena/pull/363
+[#365]: https://github.com/athena-framework/athena/pull/365
 
 ## [0.1.1] - 2023-10-09
 
 _Administrative release, no functional changes_
 
+[0.1.1]: https://github.com/athena-framework/dotenv/releases/tag/v0.1.1
+
 ## [0.1.0] - 2023-04-23
 
 _Initial release._
 
-[0.2.0]: https://github.com/athena-framework/dotenv/releases/tag/v0.2.0
-[0.1.3]: https://github.com/athena-framework/dotenv/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/dotenv/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/dotenv/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/dotenv/releases/tag/v0.1.0

--- a/.changes/event_dispatcher/v0.3.1.md
+++ b/.changes/event_dispatcher/v0.3.1.md
@@ -2,52 +2,69 @@
 
 _Administrative release, no functional changes_
 
+[0.3.1]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.3.1
+
 ## [0.3.0] - 2024-04-09
 
 ### Changed
 
-- **Breaking:** remove `AED::EventListenerInterface` ([#391](https://github.com/athena-framework/athena/pull/391)) (George Dietrich)
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- **Breaking:** remove `AED::EventListenerInterface` ([#391]) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
+
+[0.3.0]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.3.0
+[#365]: https://github.com/athena-framework/athena/pull/365
+[#391]: https://github.com/athena-framework/athena/pull/391
 
 ## [0.2.3] - 2023-10-09
 
 _Administrative release, no functional changes_
 
+[0.2.3]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.3
+
 ## [0.2.2] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
+
+[0.2.2]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.2
+[#261]: https://github.com/athena-framework/athena/pull/261
 
 ## [0.2.1] - 2023-02-04
 
 ### Added
 
-- Add better integration between `Athena::EventDispatcher` and `Athena::DependencyInjection` ([#259](https://github.com/athena-framework/athena/pull/259)) (George Dietrich)
+- Add better integration between `Athena::EventDispatcher` and `Athena::DependencyInjection` ([#259]) (George Dietrich)
+
+[0.2.1]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.1
+[#259]: https://github.com/athena-framework/athena/pull/259
 
 ## [0.2.0] - 2023-01-07
 
 ### Changed
 
-- **Breaking:** refactor how listeners are registered to use the new `AEDA::AsEventListener` annotation on the method instead of the `self.subscribed_events` class method ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** refactor and rename the majority of `AED::EventDispatcherInterface` API ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** change the representation of a listener when returned from a dispatcher to be an `AED::Callable` instance ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** refactor `AED::Event` to now be `abstract` ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
+- **Breaking:** refactor how listeners are registered to use the new `AEDA::AsEventListener` annotation on the method instead of the `self.subscribed_events` class method ([#236]) (George Dietrich)
+- **Breaking:** refactor and rename the majority of `AED::EventDispatcherInterface` API ([#236]) (George Dietrich)
+- **Breaking:** change the representation of a listener when returned from a dispatcher to be an `AED::Callable` instance ([#236]) (George Dietrich)
+- **Breaking:** refactor `AED::Event` to now be `abstract` ([#236]) (George Dietrich)
 
 ### Added
 
-- Add `AED::GenericEvent` that can be used for convenience within simple use cases ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- Add the ability to use a listener method without the `AED::EventDispatcherInterface` parameter ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
+- Add `AED::GenericEvent` that can be used for convenience within simple use cases ([#236]) (George Dietrich)
+- Add the ability to use a listener method without the `AED::EventDispatcherInterface` parameter ([#236]) (George Dietrich)
 
 ### Removed
 
-- **Breaking:** remove ability for listeners to automatically be registered with the dispatcher ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** remove the `AED::EventDispatcher.new` constructor that accepts an `Array(AED::EventListenerInterface)` ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** remove the `AED::EventListenerType` alias ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** remove the `AED::SubscribedEvents` alias ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** remove the `AED::EventListener` struct ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** remove the `AED.create_listener` method ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- Remove the requirement that listeners methods need to be called `call` ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
+- **Breaking:** remove ability for listeners to automatically be registered with the dispatcher ([#236]) (George Dietrich)
+- **Breaking:** remove the `AED::EventDispatcher.new` constructor that accepts an `Array(AED::EventListenerInterface)` ([#236]) (George Dietrich)
+- **Breaking:** remove the `AED::EventListenerType` alias ([#236]) (George Dietrich)
+- **Breaking:** remove the `AED::SubscribedEvents` alias ([#236]) (George Dietrich)
+- **Breaking:** remove the `AED::EventListener` struct ([#236]) (George Dietrich)
+- **Breaking:** remove the `AED.create_listener` method ([#236]) (George Dietrich)
+- Remove the requirement that listeners methods need to be called `call` ([#236]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.0
+[#236]: https://github.com/athena-framework/athena/pull/236
 
 ## [0.1.4] - 2022-05-14
 
@@ -55,46 +72,50 @@ _First release a part of the monorepo._
 
 ### Added
 
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Fixed
 
-- Fix the `VERSION` constant's value ([#166](https://github.com/athena-framework/athena/pull/166)) (George Dietrich)
+- Fix the `VERSION` constant's value ([#166]) (George Dietrich)
+
+[0.1.4]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.4
+[#166]: https://github.com/athena-framework/athena/pull/166
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#172]: https://github.com/athena-framework/athena/pull/172
 
 ## [0.1.3] - 2021-01-29
 
 ### Changed
 
-- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#14](https://github.com/athena-framework/event-dispatcher/pull/14)) (George Dietrich)
+- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#14]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.3
+[#14]: https://github.com/athena-framework/event-dispatcher/pull/14
 
 ## [0.1.2] - 2020-12-03
 
 ### Changed
 
-- Update `crystal` version to allow version greater than `1.0.0` ([#13](https://github.com/athena-framework/event-dispatcher/pull/13)) (George Dietrich)
+- Update `crystal` version to allow version greater than `1.0.0` ([#13]) (George Dietrich)
+
+[0.1.2]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.2
+[#13]: https://github.com/athena-framework/event-dispatcher/pull/13
 
 ## [0.1.1] - 2020-11-12
 
 ### Added
 
-- Add the [AED::Spec](https://athenaframework.org/EventDispatcher/Spec/) module to provide helpful testing utilities ([#11](https://github.com/athena-framework/event-dispatcher/pull/11)) (George Dietrich)
+- Add the [AED::Spec](https://athenaframework.org/EventDispatcher/Spec/) module to provide helpful testing utilities ([#11]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.1
+[#11]: https://github.com/athena-framework/event-dispatcher/pull/11
 
 ## [0.1.0] - 2020-01-11
 
 _Initial release._
 
-[0.3.1]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.3.1
-[0.3.0]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.3.0
-[0.2.3]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.3
-[0.2.2]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.2
-[0.2.1]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.1
-[0.2.0]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.0
-[0.1.4]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.4
-[0.1.3]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.0

--- a/.changes/framework/v0.20.1.md
+++ b/.changes/framework/v0.20.1.md
@@ -2,165 +2,242 @@
 
 ### Fixed
 
-- Fix `ATH::ViewHandler` bundle configuration values not being correctly set ([#520](https://github.com/athena-framework/athena/pull/520)) (George Dietrich)
+- Fix `ATH::ViewHandler` bundle configuration values not being correctly set ([#520]) (George Dietrich)
+
+[0.20.1]: https://github.com/athena-framework/framework/releases/tag/v0.20.1
+[#520]: https://github.com/athena-framework/athena/pull/520
 
 ## [0.20.0] - 2025-01-26
 
 ### Changed
 
-- **Breaking:** Normalize exception types ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
-- **Breaking:** The `ATHR::Interface.configuration` macro is no longer scoped to the resolver namespace ([#425](https://github.com/athena-framework/athena/pull/425)) (George Dietrich)
-- **Breaking:** Rename `ATHR::RequestBody::Extract` to `ATHA::MapRequestBody` ([#425](https://github.com/athena-framework/athena/pull/425)) (George Dietrich)
-- **Breaking:** Rename `ATHR::Time::Format` to `ATHA::MapTime` ([#425](https://github.com/athena-framework/athena/pull/425)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.14.0` ([#433](https://github.com/athena-framework/athena/pull/433)) (George Dietrich)
-- Refactor auto redirection logic to be more robust ([#436](https://github.com/athena-framework/athena/pull/436), [#480](https://github.com/athena-framework/athena/pull/480)) (George Dietrich)
-- Refactor `ATHR::RequestBody` to raise more accurate deserialization errors ([#490](https://github.com/athena-framework/athena/pull/490)) (George Dietrich)
+- **Breaking:** Normalize exception types ([#428]) (George Dietrich)
+- **Breaking:** The `ATHR::Interface.configuration` macro is no longer scoped to the resolver namespace ([#425]) (George Dietrich)
+- **Breaking:** Rename `ATHR::RequestBody::Extract` to `ATHA::MapRequestBody` ([#425]) (George Dietrich)
+- **Breaking:** Rename `ATHR::Time::Format` to `ATHA::MapTime` ([#425]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.14.0` ([#433]) (George Dietrich)
+- Refactor auto redirection logic to be more robust ([#436], [#480]) (George Dietrich)
+- Refactor `ATHR::RequestBody` to raise more accurate deserialization errors ([#490]) (George Dietrich)
 
 ### Added
 
-- Add support for [Proxies & Load Balancers](https://athenaframework.org/guides/proxies/) ([#440](https://github.com/athena-framework/athena/pull/440), [#444](https://github.com/athena-framework/athena/pull/444)) (George Dietrich)
-- Add new `trusted_host` bundle scheme property to allow setting trusted hostnames ([#474](https://github.com/athena-framework/athena/pull/474)) (George Dietrich)
-- Add support for deserializing `application/x-www-form-urlencoded` bodies via `ATHA::MapRequestBody` ([#477](https://github.com/athena-framework/athena/pull/477)) (George Dietrich)
-- Add `ATHA::MapQueryString` to map a request's query string into a DTO type ([#477](https://github.com/athena-framework/athena/pull/477)) (George Dietrich)
-- Add `ATH::Exception.from_status` helper method ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
-- Add `ATHA::MapQueryParameter` for handling query parameters ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
-- Add `#validation_groups` and `#accept_formats` annotation properties to `ATHA::MapRequestBody` ([#486](https://github.com/athena-framework/athena/pull/486)) (George Dietrich)
-- Add `#validation_groups` annotation property to `ATHA::MapQueryString` ([#486](https://github.com/athena-framework/athena/pull/486)) (George Dietrich)
-- Add `ATH::Request#port` and `ATH::Response#redirect?` methods ([#436](https://github.com/athena-framework/athena/pull/436)) (George Dietrich)
-- Add `#host`, `#scheme`, `#secure?`, and `#from_trusted_proxy?` methods to `ATH::Request` ([#440](https://github.com/athena-framework/athena/pull/440)) (George Dietrich)
-- Add `ATH::Request#content_type_format` to return the request format's name from its `content-type` header ([#477](https://github.com/athena-framework/athena/pull/477)) (George Dietrich)
-- Add `ATH::IPUtils` module ([#440](https://github.com/athena-framework/athena/pull/440)) (George Dietrich)
-- Add `.unquote`, `.split`, and `.combine` methods `ATH::HeaderUtils` ([#440](https://github.com/athena-framework/athena/pull/440)) (George Dietrich)
-- Add request matchers for headers and query parameters ([#491](https://github.com/athena-framework/athena/pull/491)) (George Dietrich)
+- Add support for [Proxies & Load Balancers](https://athenaframework.org/guides/proxies/) ([#440], [#444]) (George Dietrich)
+- Add new `trusted_host` bundle scheme property to allow setting trusted hostnames ([#474]) (George Dietrich)
+- Add support for deserializing `application/x-www-form-urlencoded` bodies via `ATHA::MapRequestBody` ([#477]) (George Dietrich)
+- Add `ATHA::MapQueryString` to map a request's query string into a DTO type ([#477]) (George Dietrich)
+- Add `ATH::Exception.from_status` helper method ([#426]) (George Dietrich)
+- Add `ATHA::MapQueryParameter` for handling query parameters ([#426]) (George Dietrich)
+- Add `#validation_groups` and `#accept_formats` annotation properties to `ATHA::MapRequestBody` ([#486]) (George Dietrich)
+- Add `#validation_groups` annotation property to `ATHA::MapQueryString` ([#486]) (George Dietrich)
+- Add `ATH::Request#port` and `ATH::Response#redirect?` methods ([#436]) (George Dietrich)
+- Add `#host`, `#scheme`, `#secure?`, and `#from_trusted_proxy?` methods to `ATH::Request` ([#440]) (George Dietrich)
+- Add `ATH::Request#content_type_format` to return the request format's name from its `content-type` header ([#477]) (George Dietrich)
+- Add `ATH::IPUtils` module ([#440]) (George Dietrich)
+- Add `.unquote`, `.split`, and `.combine` methods `ATH::HeaderUtils` ([#440]) (George Dietrich)
+- Add request matchers for headers and query parameters ([#491]) (George Dietrich)
 
 ### Removed
 
-- **Breaking:** Remove `ATHA::QueryParam` ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
-- **Breaking:** Remove `ATHA::RequestParam` ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
-- **Breaking:** Remove `ATH::Exception::InvalidParameter` ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
-- **Breaking:** Remove everything within `ATH::Params` namespace ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
-- **Breaking:** Remove `ATH::Action#params` ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
-- **Breaking:** Remove `ATH::Listeners::ParamFetcher` ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
+- **Breaking:** Remove `ATHA::QueryParam` ([#426]) (George Dietrich)
+- **Breaking:** Remove `ATHA::RequestParam` ([#426]) (George Dietrich)
+- **Breaking:** Remove `ATH::Exception::InvalidParameter` ([#426]) (George Dietrich)
+- **Breaking:** Remove everything within `ATH::Params` namespace ([#426]) (George Dietrich)
+- **Breaking:** Remove `ATH::Action#params` ([#426]) (George Dietrich)
+- **Breaking:** Remove `ATH::Listeners::ParamFetcher` ([#426]) (George Dietrich)
 
 ### Fixed
 
-- Fix query parameters being dropped when redirecting to a trailing/non-trailing slash endpoint ([#436](https://github.com/athena-framework/athena/pull/436)) (George Dietrich)
-- Fix auto redirection with non-standard ports ([#480](https://github.com/athena-framework/athena/pull/480)) (George Dietrich)
-- Fix `multipart/form-data` not being mapped to the `form` format ([#441](https://github.com/athena-framework/athena/pull/441)) (George Dietrich)
-- Fix being unable to provide the path of an `ARTA::Route` annotation on a class as a positional argument ([#482](https://github.com/athena-framework/athena/pull/482)) (George Dietrich)
-- Fix error when attempting to use `ATH::Controller#redirect_view` and `ATH::Controller#route_redirect_view` ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
-- Fix error when attempting to use `ATH::Spec::APITestCase#unlink` ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
+- Fix query parameters being dropped when redirecting to a trailing/non-trailing slash endpoint ([#436]) (George Dietrich)
+- Fix auto redirection with non-standard ports ([#480]) (George Dietrich)
+- Fix `multipart/form-data` not being mapped to the `form` format ([#441]) (George Dietrich)
+- Fix being unable to provide the path of an `ARTA::Route` annotation on a class as a positional argument ([#482]) (George Dietrich)
+- Fix error when attempting to use `ATH::Controller#redirect_view` and `ATH::Controller#route_redirect_view` ([#498]) (George Dietrich)
+- Fix error when attempting to use `ATH::Spec::APITestCase#unlink` ([#498]) (George Dietrich)
+
+[0.20.0]: https://github.com/athena-framework/framework/releases/tag/v0.20.0
+[#425]: https://github.com/athena-framework/athena/pull/425
+[#426]: https://github.com/athena-framework/athena/pull/426
+[#428]: https://github.com/athena-framework/athena/pull/428
+[#433]: https://github.com/athena-framework/athena/pull/433
+[#436]: https://github.com/athena-framework/athena/pull/436
+[#440]: https://github.com/athena-framework/athena/pull/440
+[#441]: https://github.com/athena-framework/athena/pull/441
+[#444]: https://github.com/athena-framework/athena/pull/444
+[#474]: https://github.com/athena-framework/athena/pull/474
+[#477]: https://github.com/athena-framework/athena/pull/477
+[#480]: https://github.com/athena-framework/athena/pull/480
+[#482]: https://github.com/athena-framework/athena/pull/482
+[#486]: https://github.com/athena-framework/athena/pull/486
+[#490]: https://github.com/athena-framework/athena/pull/490
+[#491]: https://github.com/athena-framework/athena/pull/491
+[#498]: https://github.com/athena-framework/athena/pull/498
 
 ## [0.19.2] - 2024-07-31
 
 ### Added
 
-- Add `ATH.run_console` as an easier entrypoint into the console application ([#413](https://github.com/athena-framework/athena/pull/413)) (George Dietrich)
-- Add support for additional boolean conversion values from request attributes ([#422](https://github.com/athena-framework/athena/pull/422)) (George Dietrich)
+- Add `ATH.run_console` as an easier entrypoint into the console application ([#413]) (George Dietrich)
+- Add support for additional boolean conversion values from request attributes ([#422]) (George Dietrich)
 
 ### Changed
 
-- **Breaking:** `ATH::RequestMatcher::Method` now requires an `Array(String)` as opposed to any `Enumerable(String)` ([#431](https://github.com/athena-framework/athena/pull/431)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.13.0` ([#433](https://github.com/athena-framework/athena/pull/433)) (George Dietrich)
-- Updates usages of `UTF-8` in response headers to `utf-8` as preferred by the RFC ([#417](https://github.com/athena-framework/athena/pull/417)) (George Dietrich)
+- **Breaking:** `ATH::RequestMatcher::Method` now requires an `Array(String)` as opposed to any `Enumerable(String)` ([#431]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.13.0` ([#433]) (George Dietrich)
+- Updates usages of `UTF-8` in response headers to `utf-8` as preferred by the RFC ([#417]) (George Dietrich)
 
 ### Fixed
 
-- Fix the content negotiation implementation not working ([#431](https://github.com/athena-framework/athena/pull/431)) (George Dietrich)
+- Fix the content negotiation implementation not working ([#431]) (George Dietrich)
+
+[0.19.2]: https://github.com/athena-framework/framework/releases/tag/v0.19.2
+[#413]: https://github.com/athena-framework/athena/pull/413
+[#417]: https://github.com/athena-framework/athena/pull/417
+[#422]: https://github.com/athena-framework/athena/pull/422
+[#431]: https://github.com/athena-framework/athena/pull/431
+[#433]: https://github.com/athena-framework/athena/pull/433
 
 ## [0.19.1] - 2024-04-27
 
 ### Fixed
 
-- Fix `framework` component docs landing on an empty page ([#399](https://github.com/athena-framework/athena/pull/399)) (George Dietrich)
-- Fix `Athena::Clock` not being aliased to the interface correctly ([#400](https://github.com/athena-framework/athena/pull/400)) (George Dietrich)
-- Fix `ATHA::View` annotation being defined in incorrect namespace ([#403](https://github.com/athena-framework/athena/pull/403)) (George Dietrich)
-- Fix `ATH::ErrorRenderer` not being aliased to the interface correctly ([#404](https://github.com/athena-framework/athena/pull/404)) (George Dietrich)
+- Fix `framework` component docs landing on an empty page ([#399]) (George Dietrich)
+- Fix `Athena::Clock` not being aliased to the interface correctly ([#400]) (George Dietrich)
+- Fix `ATHA::View` annotation being defined in incorrect namespace ([#403]) (George Dietrich)
+- Fix `ATH::ErrorRenderer` not being aliased to the interface correctly ([#404]) (George Dietrich)
+
+[0.19.1]: https://github.com/athena-framework/framework/releases/tag/v0.19.1
+[#399]: https://github.com/athena-framework/athena/pull/399
+[#400]: https://github.com/athena-framework/athena/pull/400
+[#403]: https://github.com/athena-framework/athena/pull/403
+[#404]: https://github.com/athena-framework/athena/pull/404
 
 ## [0.19.0] - 2024-04-09
 
 ### Changed
 
-- **Breaking:** change how framework features are configured ([#337](https://github.com/athena-framework/athena/pull/337), [#374](https://github.com/athena-framework/athena/pull/374), [#383](https://github.com/athena-framework/athena/pull/383)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.11.0` ([#270](https://github.com/athena-framework/athena/pull/270)) (George Dietrich)
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- **Breaking:** change how framework features are configured ([#337], [#374], [#383]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.11.0` ([#270]) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
 
 ### Added
 
-- Support for Windows OS ([#270](https://github.com/athena-framework/athena/pull/270)) (George Dietrich)
-- Add `ATH::RequestMatcher` as a generic way of matching an `ATH::Request` given a set of rules ([#338](https://github.com/athena-framework/athena/pull/338)) (George Dietrich)
-- Raise an exception if a controller's return value fails to serialize instead of just returning `nil` ([#357](https://github.com/athena-framework/athena/pull/357)) (George Dietrich)
-- Add support for new Crystal 1.12 `Process.on_terminate` method ([#394](https://github.com/athena-framework/athena/pull/394)) (George Dietrich)
+- Support for Windows OS ([#270]) (George Dietrich)
+- Add `ATH::RequestMatcher` as a generic way of matching an `ATH::Request` given a set of rules ([#338]) (George Dietrich)
+- Raise an exception if a controller's return value fails to serialize instead of just returning `nil` ([#357]) (George Dietrich)
+- Add support for new Crystal 1.12 `Process.on_terminate` method ([#394]) (George Dietrich)
 
 ### Fixed
 
-- Fix macro splat deprecation ([#330](https://github.com/athena-framework/athena/pull/330)) (George Dietrich)
-- Normalize `ATH::Request#method` to always be uppercase ([#338](https://github.com/athena-framework/athena/pull/338)) (George Dietrich)
-- Fixed not being able to use top level configuration annotations on controller action parameters ([#356](https://github.com/athena-framework/athena/pull/356)) (George Dietrich)
+- Fix macro splat deprecation ([#330]) (George Dietrich)
+- Normalize `ATH::Request#method` to always be uppercase ([#338]) (George Dietrich)
+- Fixed not being able to use top level configuration annotations on controller action parameters ([#356]) (George Dietrich)
+
+[0.19.0]: https://github.com/athena-framework/framework/releases/tag/v0.19.0
+[#270]: https://github.com/athena-framework/athena/pull/270
+[#330]: https://github.com/athena-framework/athena/pull/330
+[#337]: https://github.com/athena-framework/athena/pull/337
+[#338]: https://github.com/athena-framework/athena/pull/338
+[#356]: https://github.com/athena-framework/athena/pull/356
+[#357]: https://github.com/athena-framework/athena/pull/357
+[#365]: https://github.com/athena-framework/athena/pull/365
+[#374]: https://github.com/athena-framework/athena/pull/374
+[#383]: https://github.com/athena-framework/athena/pull/383
+[#394]: https://github.com/athena-framework/athena/pull/394
 
 ## [0.18.2] - 2023-10-09
 
 ### Changed
 
-- Change routing logic to redirect `GET` and `HEAD` requests with a trailing slash to the route without one if it exists, and vice versa ([#307](https://github.com/athena-framework/athena/pull/307)) (George Dietrich)
+- Change routing logic to redirect `GET` and `HEAD` requests with a trailing slash to the route without one if it exists, and vice versa ([#307]) (George Dietrich)
 
 ### Added
 
-- Add native tab completion support to the built-in `ATH::Commands` ([#296](https://github.com/athena-framework/athena/pull/296)) (George Dietrich)
-- Add support for defining multiple route annotations on a single controller action method ([#315](https://github.com/athena-framework/athena/pull/315)) (George Dietrich)
-- Require the new `Athena::Clock` component ([#318](https://github.com/athena-framework/athena/pull/318)) (George Dietrich)
-- Add additional `ATH::Spec::APITestCase` request helper methods ([#312](https://github.com/athena-framework/athena/pull/312), [#313](https://github.com/athena-framework/athena/pull/313)) (George Dietrich)
+- Add native tab completion support to the built-in `ATH::Commands` ([#296]) (George Dietrich)
+- Add support for defining multiple route annotations on a single controller action method ([#315]) (George Dietrich)
+- Require the new `Athena::Clock` component ([#318]) (George Dietrich)
+- Add additional `ATH::Spec::APITestCase` request helper methods ([#312], [#313]) (George Dietrich)
 
 ### Fixed
 
-- Fix incorrectly generated route paths with a controller level prefix and no action level `/` prefix ([#308](https://github.com/athena-framework/athena/pull/308)) (George Dietrich)
+- Fix incorrectly generated route paths with a controller level prefix and no action level `/` prefix ([#308]) (George Dietrich)
+
+[0.18.2]: https://github.com/athena-framework/framework/releases/tag/v0.18.2
+[#296]: https://github.com/athena-framework/athena/pull/296
+[#307]: https://github.com/athena-framework/athena/pull/307
+[#308]: https://github.com/athena-framework/athena/pull/308
+[#312]: https://github.com/athena-framework/athena/pull/312
+[#313]: https://github.com/athena-framework/athena/pull/313
+[#315]: https://github.com/athena-framework/athena/pull/315
+[#318]: https://github.com/athena-framework/athena/pull/318
 
 ## [0.18.1] - 2023-05-29
 
 ### Added
 
-- Add support for serializing arbitrarily nested controller action return types ([#273](https://github.com/athena-framework/athena/pull/273)) (George Dietrich)
-- Allow using constants for controller action's `path` ([#279](https://github.com/athena-framework/athena/pull/279)) (George Dietrich)
+- Add support for serializing arbitrarily nested controller action return types ([#273]) (George Dietrich)
+- Allow using constants for controller action's `path` ([#279]) (George Dietrich)
 
 ### Fixed
 
-- Fix incorrect `content-length` header value when returning multi-byte strings ([#288](https://github.com/athena-framework/athena/pull/288)) (George Dietrich)
+- Fix incorrect `content-length` header value when returning multi-byte strings ([#288]) (George Dietrich)
+
+[0.18.1]: https://github.com/athena-framework/framework/releases/tag/v0.18.1
+[#273]: https://github.com/athena-framework/athena/pull/273
+[#279]: https://github.com/athena-framework/athena/pull/279
+[#288]: https://github.com/athena-framework/athena/pull/288
 
 ## [0.18.0] - 2023-02-20
 
 ### Changed
 
-- **Breaking:** upgrade [Athena::EventDispatcher](https://athenaframework.org/EventDispatcher/) to [0.2.x](https://github.com/athena-framework/event-dispatcher/blob/master/CHANGELOG.md#020---2023-01-07) ([#205](https://github.com/athena-framework/athena/pull/205)) (George Dietrich)
-- **Breaking:** deprecate the `ATH::ParamConverter` concept in favor of [Value Resolvers](https://athenaframework.org/Framework/Controller/ValueResolvers/Interface) ([#243](https://github.com/athena-framework/athena/pull/243)) (George Dietrich)
-- **Breaking:** rename various types/methods to better adhere to https://github.com/crystal-lang/crystal/issues/10374 ([#243](https://github.com/athena-framework/athena/pull/243)) (George Dietrich)
-- **Breaking:** Change `ATH::Spec::AbstractBrowser` to be a `class` ([#249](https://github.com/athena-framework/athena/pull/249)) (George Dietrich)
-- **Breaking:** upgrade [Athena::Validator](https://athenaframework.org/Validator/) to [0.3.x](https://github.com/athena-framework/validator/blob/master/CHANGELOG.md#030---2023-01-07) ([#250](https://github.com/athena-framework/athena/pull/250)) (George Dietrich)
-- Improve service `ATH::Controller`s to not need the `public: true` `ADI::Register` field ([#213](https://github.com/athena-framework/athena/pull/213)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.6.0` ([#205](https://github.com/athena-framework/athena/pull/205)) (George Dietrich)
+- **Breaking:** upgrade [Athena::EventDispatcher](https://athenaframework.org/EventDispatcher/) to [0.2.x](https://github.com/athena-framework/event-dispatcher/blob/master/CHANGELOG.md#020---2023-01-07) ([#205]) (George Dietrich)
+- **Breaking:** deprecate the `ATH::ParamConverter` concept in favor of [Value Resolvers](https://athenaframework.org/Framework/Controller/ValueResolvers/Interface) ([#243]) (George Dietrich)
+- **Breaking:** rename various types/methods to better adhere to https://github.com/crystal-lang/crystal/issues/10374 ([#243]) (George Dietrich)
+- **Breaking:** Change `ATH::Spec::AbstractBrowser` to be a `class` ([#249]) (George Dietrich)
+- **Breaking:** upgrade [Athena::Validator](https://athenaframework.org/Validator/) to [0.3.x](https://github.com/athena-framework/validator/blob/master/CHANGELOG.md#030---2023-01-07) ([#250]) (George Dietrich)
+- Improve service `ATH::Controller`s to not need the `public: true` `ADI::Register` field ([#213]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.6.0` ([#205]) (George Dietrich)
 
 ### Added
 
-- Add trace logging to `ATH::Listeners::CORS` to aid in debugging ([#265](https://github.com/athena-framework/athena/pull/265)) (George Dietrich)
-- Introduce new `framework.debug` parameter that is `true` if the binary was _not_ built with the `--release` flag ([#249](https://github.com/athena-framework/athena/pull/249)) (George Dietrich)
-- Add built-in [HTTP Expectation](https://athenaframework.org/Framework/Spec/Expectations/HTTP) methods to `ATH::Spec::WebTestCase` ([#249](https://github.com/athena-framework/athena/pull/249)) (George Dietrich)
-- Add `#response` and `#request` methods to `ATH::Spec::AbstractBrowser` types ([#249](https://github.com/athena-framework/athena/pull/249)) (George Dietrich)
-- Add [ATHR](https://athenaframework.org/Framework/aliases/#ATHR) alias to make using value resolver annotations easier ([#243](https://github.com/athena-framework/athena/pull/243)) (George Dietrich)
-- Add [ATH::Commands::Commands::DebugEventDispatcher](https://athenaframework.org/Framework/Commands/DebugEventDispatcher) framework CLI command to aid in debugging the event dispatcher ([#241](https://github.com/athena-framework/athena/pull/241)) (George Dietrich)
-- Add [ATH::Commands::Commands::DebugRouter](https://athenaframework.org/Framework/Commands/DebugRouter) and [ATH::Commands::Commands::DebugRouterMatch](https://athenaframework.org/Framework/Commands/DebugRouterMatch) framework CLI commands to aid in debugging the router ([#224](https://github.com/athena-framework/athena/pull/224)) (George Dietrich)
-- Add integration for the [Athena::Console](https://athenaframework.org/Console/) component ([#218](https://github.com/athena-framework/athena/pull/218)) (George Dietrich)
+- Add trace logging to `ATH::Listeners::CORS` to aid in debugging ([#265]) (George Dietrich)
+- Introduce new `framework.debug` parameter that is `true` if the binary was _not_ built with the `--release` flag ([#249]) (George Dietrich)
+- Add built-in [HTTP Expectation](https://athenaframework.org/Framework/Spec/Expectations/HTTP) methods to `ATH::Spec::WebTestCase` ([#249]) (George Dietrich)
+- Add `#response` and `#request` methods to `ATH::Spec::AbstractBrowser` types ([#249]) (George Dietrich)
+- Add [ATHR](https://athenaframework.org/Framework/aliases/#ATHR) alias to make using value resolver annotations easier ([#243]) (George Dietrich)
+- Add [ATH::Commands::Commands::DebugEventDispatcher](https://athenaframework.org/Framework/Commands/DebugEventDispatcher) framework CLI command to aid in debugging the event dispatcher ([#241]) (George Dietrich)
+- Add [ATH::Commands::Commands::DebugRouter](https://athenaframework.org/Framework/Commands/DebugRouter) and [ATH::Commands::Commands::DebugRouterMatch](https://athenaframework.org/Framework/Commands/DebugRouterMatch) framework CLI commands to aid in debugging the router ([#224]) (George Dietrich)
+- Add integration for the [Athena::Console](https://athenaframework.org/Console/) component ([#218]) (George Dietrich)
 
 ### Fixed
 
-- Correctly populate `content-length` based on the response content's size ([#267](https://github.com/athena-framework/athena/pull/267)) (George Dietrich)
-- Prevent wildcard CORS `expose_headers` value when `allow_credentials` is `true` ([#264](https://github.com/athena-framework/athena/pull/264)) (George Dietrich)
-- Correctly handle `JSON::Serializable` values within `Hash`/`NamedTuple` controller action return types ([#253](https://github.com/athena-framework/athena/pull/253)) (George Dietrich)
-- Fix [ATH::ParameterBag#get?](https://athenaframework.org/Framework/ParameterBag/#Athena::Framework::ParameterBag#get?(name,_type)) not returning `nil` if it could not convert the value to the desired type ([#243](https://github.com/athena-framework/athena/pull/243)) (George Dietrich)
+- Correctly populate `content-length` based on the response content's size ([#267]) (George Dietrich)
+- Prevent wildcard CORS `expose_headers` value when `allow_credentials` is `true` ([#264]) (George Dietrich)
+- Correctly handle `JSON::Serializable` values within `Hash`/`NamedTuple` controller action return types ([#253]) (George Dietrich)
+- Fix [ATH::ParameterBag#get?](https://athenaframework.org/Framework/ParameterBag/#Athena::Framework::ParameterBag#get?(name,_type)) not returning `nil` if it could not convert the value to the desired type ([#243]) (George Dietrich)
+
+[0.18.0]: https://github.com/athena-framework/framework/releases/tag/v0.18.0
+[#205]: https://github.com/athena-framework/athena/pull/205
+[#213]: https://github.com/athena-framework/athena/pull/213
+[#218]: https://github.com/athena-framework/athena/pull/218
+[#224]: https://github.com/athena-framework/athena/pull/224
+[#241]: https://github.com/athena-framework/athena/pull/241
+[#243]: https://github.com/athena-framework/athena/pull/243
+[#249]: https://github.com/athena-framework/athena/pull/249
+[#250]: https://github.com/athena-framework/athena/pull/250
+[#253]: https://github.com/athena-framework/athena/pull/253
+[#264]: https://github.com/athena-framework/athena/pull/264
+[#265]: https://github.com/athena-framework/athena/pull/265
+[#267]: https://github.com/athena-framework/athena/pull/267
 
 ## [0.17.1] - 2022-09-05
 
 ### Changed
 
-- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188](https://github.com/athena-framework/athena/pull/188)) (George Dietrich)
+- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188]) (George Dietrich)
+
+[0.17.1]: https://github.com/athena-framework/framework/releases/tag/v0.17.1
+[#188]: https://github.com/athena-framework/athena/pull/188
 
 ## [0.17.0] - 2022-05-14
 
@@ -168,26 +245,38 @@ _Checkout [this](https://forum.crystal-lang.org/t/athena-0-17-0/4624) forum thre
 
 ### Added
 
-- Add `pcre2` library dependency to `shard.yml` ([#159](https://github.com/athena-framework/athena/pull/159)) (George Dietrich)
-- Add [ATH::Arguments::Resolvers::Enum](https://athenaframework.org/Framework/Arguments/Resolvers/Enum/) to allow resolving `Enum` members directly to controller actions ([#173](https://github.com/athena-framework/athena/pull/173)) (George Dietrich)
-- Add [ATH::Arguments::Resolvers::UUID](https://athenaframework.org/Framework/Arguments/Resolvers/UUID/) to allow resolving `UUID`s directly to controller actions by ([#176](https://github.com/athena-framework/athena/pull/176)) (George Dietrich)
-- Add [ATH::ParameterBag#has(name, type)](https://athenaframework.org/Framework/ParameterBag/#Athena::Framework::ParameterBag#has?(name,type)) that checks if a parameter with the provided name exists, and that is of the provided type ([#176](https://github.com/athena-framework/athena/pull/176)) (George Dietrich)
-- Add [ATH::Arguments::Resolvers::DefaultValue](https://athenaframework.org/Framework/Arguments/Resolvers/DefaultValue/) to allow resolving an action parameter's default value if no other value was provided ([#177](https://github.com/athena-framework/athena/pull/177)) (George Dietrich)
+- Add `pcre2` library dependency to `shard.yml` ([#159]) (George Dietrich)
+- Add [ATH::Arguments::Resolvers::Enum](https://athenaframework.org/Framework/Arguments/Resolvers/Enum/) to allow resolving `Enum` members directly to controller actions ([#173]) (George Dietrich)
+- Add [ATH::Arguments::Resolvers::UUID](https://athenaframework.org/Framework/Arguments/Resolvers/UUID/) to allow resolving `UUID`s directly to controller actions by ([#176]) (George Dietrich)
+- Add [ATH::ParameterBag#has(name, type)](https://athenaframework.org/Framework/ParameterBag/#Athena::Framework::ParameterBag#has?(name,type)) that checks if a parameter with the provided name exists, and that is of the provided type ([#176]) (George Dietrich)
+- Add [ATH::Arguments::Resolvers::DefaultValue](https://athenaframework.org/Framework/Arguments/Resolvers/DefaultValue/) to allow resolving an action parameter's default value if no other value was provided ([#177]) (George Dietrich)
 
 ### Changed
 
-- **Breaking:** rename `ATH::Arguments::Resolvers::ArgumentValueResolverInterface` to `ATH::Arguments::Resolvers::Interface` ([#176](https://github.com/athena-framework/athena/pull/176)) (George Dietrich)
-- **Breaking:** bump `athena-framework/serializer` to `~> 0.3.0` ([#181](https://github.com/athena-framework/athena/pull/181)) (George Dietrich)
-- **Breaking:** bump `athena-framework/validator` to `~> 0.2.0` ([#181](https://github.com/athena-framework/athena/pull/181)) (George Dietrich)
-- Expose the default value of an [ATH::Arguments::ArgumentMetadata](https://athenaframework.org/Framework/Arguments/ArgumentMetadata/) ([#176](https://github.com/athena-framework/athena/pull/176)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- **Breaking:** rename `ATH::Arguments::Resolvers::ArgumentValueResolverInterface` to `ATH::Arguments::Resolvers::Interface` ([#176]) (George Dietrich)
+- **Breaking:** bump `athena-framework/serializer` to `~> 0.3.0` ([#181]) (George Dietrich)
+- **Breaking:** bump `athena-framework/validator` to `~> 0.2.0` ([#181]) (George Dietrich)
+- Expose the default value of an [ATH::Arguments::ArgumentMetadata](https://athenaframework.org/Framework/Arguments/ArgumentMetadata/) ([#176]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Fixed
 
-- Fix error when two controller share a common action name ([#146](https://github.com/athena-framework/athena/pull/146)) (George Dietrich)
-- Fix release badge to use correct repo ([#161](https://github.com/athena-framework/athena/pull/161)) (George Dietrich)
-- Fix query/request param docs to use new error responses ([#167](https://github.com/athena-framework/athena/pull/167)) (George Dietrich)
-- Fix incorrect `Athena::Framework` `Log` name ([#175](https://github.com/athena-framework/athena/pull/175)) (George Dietrich)
+- Fix error when two controller share a common action name ([#146]) (George Dietrich)
+- Fix release badge to use correct repo ([#161]) (George Dietrich)
+- Fix query/request param docs to use new error responses ([#167]) (George Dietrich)
+- Fix incorrect `Athena::Framework` `Log` name ([#175]) (George Dietrich)
+
+[0.17.0]: https://github.com/athena-framework/framework/releases/tag/v0.17.0
+[#146]: https://github.com/athena-framework/athena/pull/146
+[#159]: https://github.com/athena-framework/athena/pull/159
+[#161]: https://github.com/athena-framework/athena/pull/161
+[#167]: https://github.com/athena-framework/athena/pull/167
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#173]: https://github.com/athena-framework/athena/pull/173
+[#175]: https://github.com/athena-framework/athena/pull/175
+[#176]: https://github.com/athena-framework/athena/pull/176
+[#177]: https://github.com/athena-framework/athena/pull/177
+[#181]: https://github.com/athena-framework/athena/pull/181
 
 ## [0.16.0] - 2022-01-22
 
@@ -195,27 +284,37 @@ _First release in the [athena-framework/framework](https://github.com/athena-fra
 
 ### Added
 
-- Add dependency on `athena-framework/routing` ([#141](https://github.com/athena-framework/athena/pull/141)) (George Dietrich)
-- Allow prepending [HTTP::Handlers](https://crystal-lang.org/api/HTTP/Handler.html) to the Athena server ([#133](https://github.com/athena-framework/athena/pull/133)) (George Dietrich)
-- Add common HTTP methods (get, post, put, delete) to [ATH::Spec::APITestCase](https://athenaframework.org//Framework/Spec/APITestCase/#Athena::Framework::Spec::APITestCase-methods) ([#134](https://github.com/athena-framework/athena/pull/134)) (George Dietrich)
-- Add overload of [ATH::Spec::APITestCase#request](https://athenaframework.org/Framework/Spec/APITestCase/#Athena::Framework::Spec::APITestCase#request(method,path,body,headers)) that accepts an [ATH::Request](https://athenaframework.org/Framework/Request/) or [HTTP::Request](https://crystal-lang.org/api/HTTP/Request.html) ([#134](https://github.com/athena-framework/athena/pull/134)) (George Dietrich)
-- Allow running an HTTPS server via passing an [OpenSSL::SSL::Context::Server](https://crystal-lang.org/api/OpenSSL/SSL/Context/Server.html) to `ATH.run` ([#135](https://github.com/athena-framework/athena/pull/135), [#136](https://github.com/athena-framework/athena/pull/136)) (George Dietrich)
-- Add [ATH::ParameterBag#set(hash)](https://athenaframework.org/Framework/ParameterBag/#Athena::Framework::ParameterBag#set(name,value,type)) that allows setting a hash of key/value pairs ([#141](https://github.com/athena-framework/athena/pull/141)) (George Dietrich)
+- Add dependency on `athena-framework/routing` ([#141]) (George Dietrich)
+- Allow prepending [HTTP::Handlers](https://crystal-lang.org/api/HTTP/Handler.html) to the Athena server ([#133]) (George Dietrich)
+- Add common HTTP methods (get, post, put, delete) to [ATH::Spec::APITestCase](https://athenaframework.org//Framework/Spec/APITestCase/#Athena::Framework::Spec::APITestCase-methods) ([#134]) (George Dietrich)
+- Add overload of [ATH::Spec::APITestCase#request](https://athenaframework.org/Framework/Spec/APITestCase/#Athena::Framework::Spec::APITestCase#request(method,path,body,headers)) that accepts an [ATH::Request](https://athenaframework.org/Framework/Request/) or [HTTP::Request](https://crystal-lang.org/api/HTTP/Request.html) ([#134]) (George Dietrich)
+- Allow running an HTTPS server via passing an [OpenSSL::SSL::Context::Server](https://crystal-lang.org/api/OpenSSL/SSL/Context/Server.html) to `ATH.run` ([#135], [#136]) (George Dietrich)
+- Add [ATH::ParameterBag#set(hash)](https://athenaframework.org/Framework/ParameterBag/#Athena::Framework::ParameterBag#set(name,value,type)) that allows setting a hash of key/value pairs ([#141]) (George Dietrich)
 
 ### Changed
 
-- **Breaking:** integrate the [Athena::Routing](https://athenaframework.org/Routing/) component ([#141](https://github.com/athena-framework/athena/pull/141)) (George Dietrich)
+- **Breaking:** integrate the [Athena::Routing](https://athenaframework.org/Routing/) component ([#141]) (George Dietrich)
 
 ### Removed
 
-- **Breaking:** remove dependency on [amberframework/amber-router](https://github.com/amberframework/amber-router) ([#141](https://github.com/athena-framework/athena/pull/141)) (George Dietrich)
+- **Breaking:** remove dependency on [amberframework/amber-router](https://github.com/amberframework/amber-router) ([#141]) (George Dietrich)
+
+[0.16.0]: https://github.com/athena-framework/framework/releases/tag/v0.16.0
+[#133]: https://github.com/athena-framework/athena/pull/133
+[#134]: https://github.com/athena-framework/athena/pull/134
+[#135]: https://github.com/athena-framework/athena/pull/135
+[#136]: https://github.com/athena-framework/athena/pull/136
+[#141]: https://github.com/athena-framework/athena/pull/141
 
 ## [0.15.1] - 2021-12-13
 
 ### Changed
 
-- Include error list in `ATH::Exception::InvalidParameter` ([#124](https://github.com/athena-framework/athena/pull/124)) (George Dietrich)
-- Set the base path of parameter errors to the name of the parameter ([#124](https://github.com/athena-framework/athena/pull/124)) (George Dietrich)
+- Include error list in `ATH::Exception::InvalidParameter` ([#124]) (George Dietrich)
+- Set the base path of parameter errors to the name of the parameter ([#124]) (George Dietrich)
+
+[0.15.1]: https://github.com/athena-framework/athena/releases/tag/v0.15.1
+[#124]: https://github.com/athena-framework/athena/pull/124
 
 ## [0.15.0] - 2021-10-30
 
@@ -223,31 +322,24 @@ _Last release in the [athena-framework/athena](https://github.com/athena-framewo
 
 ### Added
 
-- Expose the raw [HTTP::Request](https://crystal-lang.org/api/HTTP/Request.html) method from an `ATH::Request` ([#115](https://github.com/athena-framework/athena/pull/115)) (George Dietrich)
-- Add built in [ATH::RequestBodyConverter](https://athenaframework.org/Framework/RequestBodyConverter) param converter ([#116](https://github.com/athena-framework/athena/pull/116)) (George Dietrich)
-- Add `VERSION` constant to `Athena::Framework` namespace ([#120](https://github.com/athena-framework/athena/pull/120)) (George Dietrich)
+- Expose the raw [HTTP::Request](https://crystal-lang.org/api/HTTP/Request.html) method from an `ATH::Request` ([#115]) (George Dietrich)
+- Add built in [ATH::RequestBodyConverter](https://athenaframework.org/Framework/RequestBodyConverter) param converter ([#116]) (George Dietrich)
+- Add `VERSION` constant to `Athena::Framework` namespace ([#120]) (George Dietrich)
 
 ### Changed
 
-- **Breaking:** rename base param converter type to `ATH::ParamConverter` and make it a class ([#116](https://github.com/athena-framework/athena/pull/116)) (George Dietrich)
-- **Breaking:** rename the component from `Athena::Routing` to `Athena::Framework` ([#120](https://github.com/athena-framework/athena/pull/120)) (George Dietrich)
+- **Breaking:** rename base param converter type to `ATH::ParamConverter` and make it a class ([#116]) (George Dietrich)
+- **Breaking:** rename the component from `Athena::Routing` to `Athena::Framework` ([#120]) (George Dietrich)
 
 ### Fixed
 
-- Fix incorrect parameter type restriction on `ATH::ParameterBag#set` ([#116](https://github.com/athena-framework/athena/pull/116)) (George Dietrich)
-- Fix incorrect ivar type on `AVD::Exception::Exceptions::ValidationFailed#violations` ([#116](https://github.com/athena-framework/athena/pull/116)) (George Dietrich)
-- Correctly reject requests with whitespace when converting numeric inputs ([#117](https://github.com/athena-framework/athena/pull/117)) (George Dietrich)
+- Fix incorrect parameter type restriction on `ATH::ParameterBag#set` ([#116]) (George Dietrich)
+- Fix incorrect ivar type on `AVD::Exception::Exceptions::ValidationFailed#violations` ([#116]) (George Dietrich)
+- Correctly reject requests with whitespace when converting numeric inputs ([#117]) (George Dietrich)
 
-[0.20.1]: https://github.com/athena-framework/framework/releases/tag/v0.20.1
-[0.20.0]: https://github.com/athena-framework/framework/releases/tag/v0.20.0
-[0.19.2]: https://github.com/athena-framework/framework/releases/tag/v0.19.2
-[0.19.1]: https://github.com/athena-framework/framework/releases/tag/v0.19.1
-[0.19.0]: https://github.com/athena-framework/framework/releases/tag/v0.19.0
-[0.18.2]: https://github.com/athena-framework/framework/releases/tag/v0.18.2
-[0.18.1]: https://github.com/athena-framework/framework/releases/tag/v0.18.1
-[0.18.0]: https://github.com/athena-framework/framework/releases/tag/v0.18.0
-[0.17.1]: https://github.com/athena-framework/framework/releases/tag/v0.17.1
-[0.17.0]: https://github.com/athena-framework/framework/releases/tag/v0.17.0
-[0.16.0]: https://github.com/athena-framework/framework/releases/tag/v0.16.0
-[0.15.1]: https://github.com/athena-framework/athena/releases/tag/v0.15.1
 [0.15.0]: https://github.com/athena-framework/athena/releases/tag/v0.15.0
+[#115]: https://github.com/athena-framework/athena/pull/115
+[#116]: https://github.com/athena-framework/athena/pull/116
+[#117]: https://github.com/athena-framework/athena/pull/117
+[#120]: https://github.com/athena-framework/athena/pull/120
+

--- a/.changes/image_size/v0.1.4.md
+++ b/.changes/image_size/v0.1.4.md
@@ -2,15 +2,22 @@
 
 _Administrative release, no functional changes_
 
+[0.1.4]: https://github.com/athena-framework/image-size/releases/tag/v0.1.4
+
 ## [0.1.3] - 2024-04-09
 
 ### Changed
 
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/image-size/releases/tag/v0.1.3
+[#365]: https://github.com/athena-framework/athena/pull/365
 
 ## [0.1.2] - 2023-10-09
 
 _Administrative release, no functional changes_
+
+[0.1.2]: https://github.com/athena-framework/image-size/releases/tag/v0.1.2
 
 ## [0.1.1] - 2022-05-14
 
@@ -18,22 +25,23 @@ _First release a part of the monorepo._
 
 ### Added
 
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Fixed
 
-- Fix incorrect `description` key in `shard.yml` ([#171](https://github.com/athena-framework/athena/pull/171)) (George Dietrich)
+- Fix incorrect `description` key in `shard.yml` ([#171]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/image-size/releases/tag/v0.1.1
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#171]: https://github.com/athena-framework/athena/pull/171
+[#172]: https://github.com/athena-framework/athena/pull/172
 
 ## [0.1.0] - 2022-02-21
 
 _Initial release._
 
-[0.1.4]: https://github.com/athena-framework/image-size/releases/tag/v0.1.4
-[0.1.3]: https://github.com/athena-framework/image-size/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/image-size/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/image-size/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/image-size/releases/tag/v0.1.0

--- a/.changes/mime/v0.2.0.md
+++ b/.changes/mime/v0.2.0.md
@@ -2,11 +2,13 @@
 
 ### Added
 
-- **Breaking:** Add `AMIME::Types` to more robustly handles MIME type/file extension/guessing ([#534](https://github.com/athena-framework/athena/pull/534)) (George Dietrich)
+- **Breaking:** Add `AMIME::Types` to more robustly handles MIME type/file extension/guessing ([#534]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/mime/releases/tag/v0.2.0
+[#534]: https://github.com/athena-framework/athena/pull/534
 
 ## [0.1.0] - 2025-01-26
 
 _Initial release._
 
-[0.2.0]: https://github.com/athena-framework/mime/releases/tag/v0.2.0
 [0.1.0]: https://github.com/athena-framework/mime/releases/tag/v0.1.0

--- a/.changes/negotiation/v0.2.0.md
+++ b/.changes/negotiation/v0.2.0.md
@@ -2,25 +2,37 @@
 
 ### Changed
 
-- **Breaking:** Normalize exception types ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
-- Use lowercase `utf-8` within header values ([#417](https://github.com/athena-framework/athena/pull/417)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.13.0` ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
+- **Breaking:** Normalize exception types ([#428]) (George Dietrich)
+- Use lowercase `utf-8` within header values ([#417]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.13.0` ([#428]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/negotiation/releases/tag/v0.2.0
+[#417]: https://github.com/athena-framework/athena/pull/417
+[#428]: https://github.com/athena-framework/athena/pull/428
 
 ## [0.1.5] - 2024-04-09
 
 ### Changed
 
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
+
+[0.1.5]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.5
+[#365]: https://github.com/athena-framework/athena/pull/365
 
 ## [0.1.4] - 2023-10-09
 
 _Administrative release, no functional changes_
 
+[0.1.4]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.4
+
 ## [0.1.3] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.3
+[#261]: https://github.com/athena-framework/athena/pull/261
 
 ## [0.1.2] - 2022-05-14
 
@@ -28,31 +40,34 @@ _First release a part of the monorepo._
 
 ### Added
 
-- Add `VERSION` constant to `Athena::Negotiation` namespace ([#166](https://github.com/athena-framework/athena/pull/166)) (George Dietrich)
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
+- Add `VERSION` constant to `Athena::Negotiation` namespace ([#166]) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Fixed
 
-- Correct the shard version in `README.md` ([#6](https://github.com/athena-framework/negotiation/pull/6)) (syeopite)
+- Correct the shard version in `README.md` ([#6]) (syeopite)
+
+[0.1.2]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.2
+[#6]: https://github.com/athena-framework/negotiation/pull/6
+[#166]: https://github.com/athena-framework/athena/pull/166
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#172]: https://github.com/athena-framework/athena/pull/172
 
 ## [0.1.1] - 2021-02-04
 
 ### Changed
 
-- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#4](https://github.com/athena-framework/negotiation/pull/4)) (George Dietrich)
+- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#4]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.1
+[#4]: https://github.com/athena-framework/negotiation/pull/4
 
 ## [0.1.0] - 2020-12-24
 
 _Initial release._
 
-[0.2.0]: https://github.com/athena-framework/negotiation/releases/tag/v0.2.0
-[0.1.5]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.5
-[0.1.4]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.4
-[0.1.3]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.0

--- a/.changes/routing/v0.1.10.md
+++ b/.changes/routing/v0.1.10.md
@@ -2,97 +2,137 @@
 
 ### Changed
 
-- Allow having multiple independent compiled route collections ([#468](https://github.com/athena-framework/athena/pull/468)) (George Dietrich)
-- Log unhandled `ART::RoutingHandler` exceptions ([#470](https://github.com/athena-framework/athena/pull/470)) (George Dietrich)
+- Allow having multiple independent compiled route collections ([#468]) (George Dietrich)
+- Log unhandled `ART::RoutingHandler` exceptions ([#470]) (George Dietrich)
 
 ### Fixed
 
-- Make `ART::RequestContext.from_uri` more robust ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
+- Make `ART::RequestContext.from_uri` more robust ([#498]) (George Dietrich)
+
+[0.1.10]: https://github.com/athena-framework/routing/releases/tag/v0.1.10
+[#468]: https://github.com/athena-framework/athena/pull/468
+[#470]: https://github.com/athena-framework/athena/pull/470
+[#498]: https://github.com/athena-framework/athena/pull/498
 
 ## [0.1.9] - 2024-04-09
 
 ### Changed
 
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
 
 ### Added
 
-- **Breaking:** add kwargs overload to `ART::Generator::Interface#generate` ([#375](https://github.com/athena-framework/athena/pull/375)) (George Dietrich)
+- **Breaking:** add kwargs overload to `ART::Generator::Interface#generate` ([#375]) (George Dietrich)
 
 ### Fixed
 
-- Fix compatibility with PCRE2 10.43 ([#362](https://github.com/athena-framework/athena/pull/362)) (George Dietrich)
-- Fix error when PCRE2 JIT mode is unavailable ([#381](https://github.com/athena-framework/athena/pull/381)) (George Dietrich)
+- Fix compatibility with PCRE2 10.43 ([#362]) (George Dietrich)
+- Fix error when PCRE2 JIT mode is unavailable ([#381]) (George Dietrich)
+
+[0.1.9]: https://github.com/athena-framework/routing/releases/tag/v0.1.9
+[#362]: https://github.com/athena-framework/athena/pull/362
+[#365]: https://github.com/athena-framework/athena/pull/365
+[#375]: https://github.com/athena-framework/athena/pull/375
+[#381]: https://github.com/athena-framework/athena/pull/381
 
 ## [0.1.8] - 2023-10-09
 
 ### Added
 
-- Internal support for redirecting within an `ART::Matcher::*` ([#307](https://github.com/athena-framework/athena/pull/307)) (George Dietrich)
+- Internal support for redirecting within an `ART::Matcher::*` ([#307]) (George Dietrich)
+
+[0.1.8]: https://github.com/athena-framework/routing/releases/tag/v0.1.8
+[#307]: https://github.com/athena-framework/athena/pull/307
 
 ## [0.1.7] - 2023-05-29
 
 ### Changed
 
-- **Breaking:** Update minimum `crystal` version to `~> 1.8.0`. Drop support for `PCRE1`. ([#281](https://github.com/athena-framework/athena/pull/281)) (George Dietrich)
+- **Breaking:** Update minimum `crystal` version to `~> 1.8.0`. Drop support for `PCRE1`. ([#281]) (George Dietrich)
+
+[0.1.7]: https://github.com/athena-framework/routing/releases/tag/v0.1.7
+[#281]: https://github.com/athena-framework/athena/pull/281
 
 ## [0.1.6] - 2023-03-26
 
 ### Fixed
 
-- Fix compatibility with Crystal `1.8.0-dev` ([#272](https://github.com/athena-framework/athena/pull/272)) (George Dietrich)
+- Fix compatibility with Crystal `1.8.0-dev` ([#272]) (George Dietrich)
+
+[0.1.6]: https://github.com/athena-framework/routing/releases/tag/v0.1.6
+[#272]: https://github.com/athena-framework/athena/pull/272
 
 ## [0.1.5] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
 
 ### Added
 
-- Add additional `ART::Requirement` constants ([#257](https://github.com/athena-framework/athena/pull/257)) (George Dietrich)
+- Add additional `ART::Requirement` constants ([#257]) (George Dietrich)
 
 ### Fixed
 
-- Fix formatting issue in Crystal `1.8-dev` ([#258](https://github.com/athena-framework/athena/pull/258)) (George Dietrich)
+- Fix formatting issue in Crystal `1.8-dev` ([#258]) (George Dietrich)
+
+[0.1.5]: https://github.com/athena-framework/routing/releases/tag/v0.1.5
+[#257]: https://github.com/athena-framework/athena/pull/257
+[#258]: https://github.com/athena-framework/athena/pull/258
+[#261]: https://github.com/athena-framework/athena/pull/261
 
 ## [0.1.4] - 2023-01-07
 
 ### Changed
 
-- Change route compilation to be eager ([#207](https://github.com/athena-framework/athena/pull/207)) (George Dietrich)
+- Change route compilation to be eager ([#207]) (George Dietrich)
 
 ### Added
 
-- Add ability to bubble up exceptions from `ART::RoutingHandler` ([#206](https://github.com/athena-framework/athena/pull/206)) (George Dietrich)
-- Add `ART::Matcher::TraceableURLMatcher` to help with debugging route matches ([#224](https://github.com/athena-framework/athena/pull/224)) (George Dietrich)
-- Add `ART::Route#has_scheme?` ([#224](https://github.com/athena-framework/athena/pull/224)) (George Dietrich)
+- Add ability to bubble up exceptions from `ART::RoutingHandler` ([#206]) (George Dietrich)
+- Add `ART::Matcher::TraceableURLMatcher` to help with debugging route matches ([#224]) (George Dietrich)
+- Add `ART::Route#has_scheme?` ([#224]) (George Dietrich)
+
+[0.1.4]: https://github.com/athena-framework/routing/releases/tag/v0.1.4
+[#207]: https://github.com/athena-framework/athena/pull/207
+[#206]: https://github.com/athena-framework/athena/pull/206
+[#224]: https://github.com/athena-framework/athena/pull/224
 
 ## [0.1.3] - 2022-09-05
 
 ### Changed
 
-- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188](https://github.com/athena-framework/athena/pull/188)) (George Dietrich)
+- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188]) (George Dietrich)
 
 ### Added
 
-- Add an `HTTP::Handler` to add basic routing support to a `HTTP::Server` ([#189](https://github.com/athena-framework/athena/pull/189)) (George Dietrich)
+- Add an `HTTP::Handler` to add basic routing support to a `HTTP::Server` ([#189]) (George Dietrich)
 
 ### Fixed
 
-- Fixed slash characters being double escaped in generated URL query params ([#180](https://github.com/athena-framework/athena/pull/180)) (George Dietrich)
+- Fixed slash characters being double escaped in generated URL query params ([#180]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/routing/releases/tag/v0.1.3
+[#180]: https://github.com/athena-framework/athena/pull/180
+[#188]: https://github.com/athena-framework/athena/pull/188
+[#189]: https://github.com/athena-framework/athena/pull/189
 
 ## [0.1.2] - 2022-05-14
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Added
 
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
-- Add common route requirement constants to the [ART::Requirement](https://athenaframework.org/Routing/Requirement/) namespace ([#173](https://github.com/athena-framework/athena/pull/173)) (George Dietrich)
-- Add [ART::Requirement::Enum](https://athenaframework.org/Routing/Requirement/Enum/) to make creating [Enum](https://crystal-lang.org/api/Enum.html) based route requirements easier ([#173](https://github.com/athena-framework/athena/pull/173)) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
+- Add common route requirement constants to the [ART::Requirement](https://athenaframework.org/Routing/Requirement/) namespace ([#173]) (George Dietrich)
+- Add [ART::Requirement::Enum](https://athenaframework.org/Routing/Requirement/Enum/) to make creating [Enum](https://crystal-lang.org/api/Enum.html) based route requirements easier ([#173]) (George Dietrich)
+
+[0.1.2]: https://github.com/athena-framework/routing/releases/tag/v0.1.2
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#172]: https://github.com/athena-framework/athena/pull/172
+[#173]: https://github.com/athena-framework/athena/pull/173
 
 ## [0.1.1] - 2022-02-05
 
@@ -100,20 +140,13 @@ _First release a part of the monorepo._
 
 ### Fixed
 
-- Fix erroneous mutating of matched route data ([#144](https://github.com/athena-framework/athena/pull/144)) (George Dietrich)
+- Fix erroneous mutating of matched route data ([#144]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/routing/releases/tag/v0.1.1
+[#144]: https://github.com/athena-framework/athena/pull/144
 
 ## [0.1.0] - 2022-01-10
 
 _Initial release._
 
-[0.1.10]: https://github.com/athena-framework/routing/releases/tag/v0.1.10
-[0.1.9]: https://github.com/athena-framework/routing/releases/tag/v0.1.9
-[0.1.8]: https://github.com/athena-framework/routing/releases/tag/v0.1.8
-[0.1.7]: https://github.com/athena-framework/routing/releases/tag/v0.1.7
-[0.1.6]: https://github.com/athena-framework/routing/releases/tag/v0.1.6
-[0.1.5]: https://github.com/athena-framework/routing/releases/tag/v0.1.5
-[0.1.4]: https://github.com/athena-framework/routing/releases/tag/v0.1.4
-[0.1.3]: https://github.com/athena-framework/routing/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/routing/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/routing/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/routing/releases/tag/v0.1.0

--- a/.changes/serializer/v0.4.1.md
+++ b/.changes/serializer/v0.4.1.md
@@ -2,49 +2,73 @@
 
 ### Fixed
 
-- Fix serialization of value when its type is different type than the ivar ([#514](https://github.com/athena-framework/athena/pull/514)) (George Dietrich)
+- Fix serialization of value when its type is different type than the ivar ([#514]) (George Dietrich)
+
+[0.4.1]: https://github.com/athena-framework/serializer/releases/tag/v0.4.1
+[#514]: https://github.com/athena-framework/athena/pull/514
 
 ## [0.4.0] - 2025-01-26
 
 ### Changed
 
-- **Breaking:** Normalize exception types ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.13.0` ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
+- **Breaking:** Normalize exception types ([#428]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.13.0` ([#428]) (George Dietrich)
+
+[0.4.0]: https://github.com/athena-framework/serializer/releases/tag/v0.4.0
+[#428]: https://github.com/athena-framework/athena/pull/428
 
 ## [0.3.6] - 2024-04-27
 
 ### Fixed
 
-- Fix misnamed modules being defined in incorrect namespace ([#402](https://github.com/athena-framework/athena/pull/402)) (George Dietrich)
+- Fix misnamed modules being defined in incorrect namespace ([#402]) (George Dietrich)
+
+[0.3.6]: https://github.com/athena-framework/serializer/releases/tag/v0.3.6
+[#402]: https://github.com/athena-framework/athena/pull/402
 
 ## [0.3.5] - 2024-04-09
 
 ### Changed
 
-- Change `Config` dependency to `DependencyInjection` for the custom annotation feature ([#392](https://github.com/athena-framework/athena/pull/392)) (George Dietrich)
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Change `Config` dependency to `DependencyInjection` for the custom annotation feature ([#392]) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
+
+[0.3.5]: https://github.com/athena-framework/serializer/releases/tag/v0.3.5
+[#392]: https://github.com/athena-framework/athena/pull/392
+[#365]: https://github.com/athena-framework/athena/pull/365
 
 ## [0.3.4] - 2023-10-09
 
 _Administrative release, no functional changes_
 
+[0.3.4]: https://github.com/athena-framework/serializer/releases/tag/v0.3.4
+
 ## [0.3.3] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
+
+[0.3.3]: https://github.com/athena-framework/serializer/releases/tag/v0.3.3
+[#261]: https://github.com/athena-framework/athena/pull/261
 
 ## [0.3.2] - 2023-01-07
 
 ### Fixed
 
-- Fix deserializing `JSON::Any` and `YAML::Any` ([#215](https://github.com/athena-framework/athena/pull/215)) (George Dietrich)
+- Fix deserializing `JSON::Any` and `YAML::Any` ([#215]) (George Dietrich)
+
+[0.3.2]: https://github.com/athena-framework/serializer/releases/tag/v0.3.2
+[#215]: https://github.com/athena-framework/athena/pull/215
 
 ## [0.3.1] - 2022-09-05
 
 ### Changed
 
-- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188](https://github.com/athena-framework/athena/pull/188)) (George Dietrich)
+- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188]) (George Dietrich)
+
+[0.3.1]: https://github.com/athena-framework/serializer/releases/tag/v0.3.1
+[#188]: https://github.com/athena-framework/athena/pull/188
 
 ## [0.3.0] - 2022-05-14
 
@@ -52,136 +76,162 @@ _First release a part of the monorepo._
 
 ### Added
 
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
 
 ### Changed
 
-- **Breaking:** change serialization of [Enums](https://crystal-lang.org/api/Enum.html) to underscored strings by default ([#173](https://github.com/athena-framework/athena/pull/173)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- **Breaking:** change serialization of [Enums](https://crystal-lang.org/api/Enum.html) to underscored strings by default ([#173]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Fixed
 
-- Fix compiler error when trying to deserialize a `Hash` ([#165](https://github.com/athena-framework/athena/pull/165)) (George Dietrich)
+- Fix compiler error when trying to deserialize a `Hash` ([#165]) (George Dietrich)
+
+[0.3.0]: https://github.com/athena-framework/serializer/releases/tag/v0.3.0
+[#165]: https://github.com/athena-framework/athena/pull/165
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#172]: https://github.com/athena-framework/athena/pull/172
+[#173]: https://github.com/athena-framework/athena/pull/173
 
 ## [0.2.10] - 2021-11-12
 
 ### Fixed
 
-- Fix issue with empty YAML input ([#22](https://github.com/athena-framework/serializer/pull/22)) (George Dietrich)
+- Fix issue with empty YAML input ([#22]) (George Dietrich)
+
+[0.2.10]: https://github.com/athena-framework/serializer/releases/tag/v0.2.10
+[#22]: https://github.com/athena-framework/serializer/pull/22
 
 ## [0.2.9] - 2021-10-30
 
 ### Added
 
-- Add `VERSION` constant to `Athena::Serializer` namespace ([#20](https://github.com/athena-framework/serializer/pull/20)) (George Dietrich)
+- Add `VERSION` constant to `Athena::Serializer` namespace ([#20]) (George Dietrich)
 
 ### Fixed
 
-- Fix broken type link ([#19](https://github.com/athena-framework/serializer/pull/19)) (George Dietrich)
+- Fix broken type link ([#19]) (George Dietrich)
+
+[0.2.9]: https://github.com/athena-framework/serializer/releases/tag/v0.2.9
+[#19]: https://github.com/athena-framework/serializer/pull/19
+[#20]: https://github.com/athena-framework/serializer/pull/20
 
 ## [0.2.8] - 2021-05-17
 
 ### Fixed
 
-- Fixes incorrect `nil` check in macro logic ([#17](https://github.com/athena-framework/serializer/pull/17)) (George Dietrich)
+- Fixes incorrect `nil` check in macro logic ([#17]) (George Dietrich)
+
+[0.2.8]: https://github.com/athena-framework/serializer/releases/tag/v0.2.8
+[#17]: https://github.com/athena-framework/serializer/pull/17
 
 ## [0.2.7] - 2021-04-09
 
 ### Added
 
-- Add some more specialized exception types ([#16](https://github.com/athena-framework/serializer/pull/16)) (George Dietrich)
+- Add some more specialized exception types ([#16]) (George Dietrich)
+
+[0.2.7]: https://github.com/athena-framework/serializer/releases/tag/v0.2.7
+[#16]: https://github.com/athena-framework/serializer/pull/16
 
 ## [0.2.6] - 2021-03-16
 
 ### Added
 
-- Expose a setter for `ASR::Context#version=` ([#15](https://github.com/athena-framework/serializer/pull/15)) (George Dietrich)
+- Expose a setter for `ASR::Context#version=` ([#15]) (George Dietrich)
 
 ### Changed
 
-- Change `athena-framework/config` version constraint to `>= 2.0.0` ([#15](https://github.com/athena-framework/serializer/pull/15)) (George Dietrich)
+- Change `athena-framework/config` version constraint to `>= 2.0.0` ([#15]) (George Dietrich)
+
+[0.2.6]: https://github.com/athena-framework/serializer/releases/tag/v0.2.6
+[#15]: https://github.com/athena-framework/serializer/pull/15
 
 ## [0.2.5] - 2021-01-29
 
 ### Changed
 
-- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#14](https://github.com/athena-framework/serializer/pull/14)) (George Dietrich)
+- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#14]) (George Dietrich)
+
+[0.2.5]: https://github.com/athena-framework/serializer/releases/tag/v0.2.5
+[#14]: https://github.com/athena-framework/serializer/pull/14
 
 ## [0.2.4] - 2021-01-29
 
 ### Changed
 
-- Bump min `athena-framework/config` version to `~> 2.0.0` ([#13](https://github.com/athena-framework/serializer/pull/13)) (George Dietrich)
+- Bump min `athena-framework/config` version to `~> 2.0.0` ([#13]) (George Dietrich)
+
+[0.2.4]: https://github.com/athena-framework/serializer/releases/tag/v0.2.4
+[#13]: https://github.com/athena-framework/serializer/pull/13
 
 ## [0.2.3] - 2021-01-20
 
 ### Fixed
 
-- Fix since/until and group annotations not working for virtual properties ([#12](https://github.com/athena-framework/serializer/pull/12)) (George Dietrich)
+- Fix since/until and group annotations not working for virtual properties ([#12]) (George Dietrich)
+
+[0.2.3]: https://github.com/athena-framework/serializer/releases/tag/v0.2.3
+[#12]: https://github.com/athena-framework/serializer/pull/12
 
 ## [0.2.2] - 2020-12-03
 
 ### Changed
 
-- Update `crystal` version to allow version greater than `1.0.0` ([#11](https://github.com/athena-framework/serializer/pull/11)) (George Dietrich)
+- Update `crystal` version to allow version greater than `1.0.0` ([#11]) (George Dietrich)
+
+[0.2.2]: https://github.com/athena-framework/serializer/releases/tag/v0.2.2
+[#11]: https://github.com/athena-framework/serializer/pull/11
 
 ## [0.2.1] - 2020-11-08
 
 ### Added
 
-- Add deserialization support to `ASRA::Name` ([#9](https://github.com/athena-framework/serializer/pull/9)) (Joakim Repomaa)
+- Add deserialization support to `ASRA::Name` ([#9]) (Joakim Repomaa)
+
+[0.2.1]: https://github.com/athena-framework/serializer/releases/tag/v0.2.1
+[#9]: https://github.com/athena-framework/serializer/pull/9
 
 ## [0.2.0] - 2020-07-08
 
 ### Added
 
-- Add dependency on `athena-framework/config` ([#8](https://github.com/athena-framework/serializer/pull/8)) (George Dietrich)
-- Add ability to use custom annotations within [exclusion strategies](https://athenaframework.org/Serializer/ExclusionStrategies/ExclusionStrategyInterface/#Athena::Serializer::ExclusionStrategies::ExclusionStrategyInterface--annotation-configurations) ([#8](https://github.com/athena-framework/serializer/pull/8)) (George Dietrich)
-- Add [ASR::Context#direction](https://athenaframework.org/Serializer/Context/#Athena::Serializer::Context#direction) to represent which direction the context object represents ([#8](https://github.com/athena-framework/serializer/pull/8)) (George Dietrich)
+- Add dependency on `athena-framework/config` ([#8]) (George Dietrich)
+- Add ability to use custom annotations within [exclusion strategies](https://athenaframework.org/Serializer/ExclusionStrategies/ExclusionStrategyInterface/#Athena::Serializer::ExclusionStrategies::ExclusionStrategyInterface--annotation-configurations) ([#8]) (George Dietrich)
+- Add [ASR::Context#direction](https://athenaframework.org/Serializer/Context/#Athena::Serializer::Context#direction) to represent which direction the context object represents ([#8]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/serializer/releases/tag/v0.2.0
+[#8]: https://github.com/athena-framework/serializer/pull/8
 
 ## [0.1.3] - 2020-07-08
 
 ### Fixed
 
-- Fix overflow error when deserializing `Int64` values ([#7](https://github.com/athena-framework/serializer/pull/7)) (George Dietrich)
+- Fix overflow error when deserializing `Int64` values ([#7]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/serializer/releases/tag/v0.1.3
+[#7]: https://github.com/athena-framework/serializer/pull/7
 
 ## [0.1.2] - 2020-07-05
 
 ### Added
 
-- Add improved documentation to various types ([#6](https://github.com/athena-framework/serializer/pull/6)) (George Dietrich)
+- Add improved documentation to various types ([#6]) (George Dietrich)
+
+[0.1.2]: https://github.com/athena-framework/serializer/releases/tag/v0.1.2
+[#6]: https://github.com/athena-framework/serializer/pull/6
 
 ## [0.1.1] - 2020-06-27
 
 ### Added
 
-- Add [naming strategies](https://athenaframework.org/Serializer/Annotations/Name/#Athena::Serializer::Annotations::Name--naming-strategies) to `ASRA::Name` ([#5](https://github.com/athena-framework/serializer/pull/5)) (George Dietrich)
+- Add [naming strategies](https://athenaframework.org/Serializer/Annotations/Name/#Athena::Serializer::Annotations::Name--naming-strategies) to `ASRA::Name` ([#5]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/serializer/releases/tag/v0.1.1
+[#5]: https://github.com/athena-framework/serializer/pull/5
 
 ## [0.1.0] - 2020-06-23
 
 _Initial release._
 
-[0.4.1]: https://github.com/athena-framework/serializer/releases/tag/v0.4.1
-[0.4.0]: https://github.com/athena-framework/serializer/releases/tag/v0.4.0
-[0.3.6]: https://github.com/athena-framework/serializer/releases/tag/v0.3.6
-[0.3.5]: https://github.com/athena-framework/serializer/releases/tag/v0.3.5
-[0.3.4]: https://github.com/athena-framework/serializer/releases/tag/v0.3.4
-[0.3.3]: https://github.com/athena-framework/serializer/releases/tag/v0.3.3
-[0.3.2]: https://github.com/athena-framework/serializer/releases/tag/v0.3.2
-[0.3.1]: https://github.com/athena-framework/serializer/releases/tag/v0.3.1
-[0.3.0]: https://github.com/athena-framework/serializer/releases/tag/v0.3.0
-[0.2.10]: https://github.com/athena-framework/serializer/releases/tag/v0.2.10
-[0.2.9]: https://github.com/athena-framework/serializer/releases/tag/v0.2.9
-[0.2.8]: https://github.com/athena-framework/serializer/releases/tag/v0.2.8
-[0.2.7]: https://github.com/athena-framework/serializer/releases/tag/v0.2.7
-[0.2.6]: https://github.com/athena-framework/serializer/releases/tag/v0.2.6
-[0.2.5]: https://github.com/athena-framework/serializer/releases/tag/v0.2.5
-[0.2.4]: https://github.com/athena-framework/serializer/releases/tag/v0.2.4
-[0.2.3]: https://github.com/athena-framework/serializer/releases/tag/v0.2.3
-[0.2.2]: https://github.com/athena-framework/serializer/releases/tag/v0.2.2
-[0.2.1]: https://github.com/athena-framework/serializer/releases/tag/v0.2.1
-[0.2.0]: https://github.com/athena-framework/serializer/releases/tag/v0.2.0
-[0.1.3]: https://github.com/athena-framework/serializer/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/serializer/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/serializer/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/serializer/releases/tag/v0.1.0

--- a/.changes/spec/v0.4.0.md
+++ b/.changes/spec/v0.4.0.md
@@ -2,79 +2,116 @@
 
 ### Added
 
-- Add ability to generate macro code coverage reports for `ASPEC::Methods.assert_compile_time_error` usages ([#551](https://github.com/athena-framework/athena/pull/551)) (George Dietrich)
+- Add ability to generate macro code coverage reports for `ASPEC::Methods.assert_compile_time_error` usages ([#551]) (George Dietrich)
 
 ### Removed
 
-- **Breaking:** Remove `ASPEC::Methods.assert_error` and `ASPEC::Methods.assert_success` methods ([#551](https://github.com/athena-framework/athena/pull/551)) (George Dietrich)
+- **Breaking:** Remove `ASPEC::Methods.assert_error` and `ASPEC::Methods.assert_success` methods ([#551]) (George Dietrich)
+
+[0.4.0]: https://github.com/athena-framework/spec/releases/tag/v0.4.0
+[#551]: https://github.com/athena-framework/athena/pull/551
 
 ## [0.3.11] - 2025-05-19
 
 ### Fixed
 
-- Fix duplicate test case runs with abstract generic parent test case ([#538](https://github.com/athena-framework/athena/pull/538)) (George Dietrich)
+- Fix duplicate test case runs with abstract generic parent test case ([#538]) (George Dietrich)
+
+[0.3.11]: https://github.com/athena-framework/spec/releases/tag/v0.3.11
+[#538]: https://github.com/athena-framework/athena/pull/538
 
 ## [0.3.10] - 2025-02-08
 
 ### Changed
 
-- **Breaking:** prevent defining `ASPEC::TestCase#initialize` methods that accepts arguments/blocks ([#516](https://github.com/athena-framework/athena/pull/516)) (George Dietrich)
+- **Breaking:** prevent defining `ASPEC::TestCase#initialize` methods that accepts arguments/blocks ([#516]) (George Dietrich)
+
+[0.3.10]: https://github.com/athena-framework/spec/releases/tag/v0.3.10
+[#516]: https://github.com/athena-framework/athena/pull/516
 
 ## [0.3.9] - 2025-01-26
 
 _Administrative release, no functional changes_
 
+[0.3.9]: https://github.com/athena-framework/spec/releases/tag/v0.3.9
+
 ## [0.3.8] - 2024-07-31
 
 ### Added
 
-- Add support for using the `CRYSTAL` ENV var to customize binary used for `ASPEC::Methods.assert_error` and `ASPEC::Methods.assert_success` ([#424](https://github.com/athena-framework/athena/pull/424)) (George Dietrich)
+- Add support for using the `CRYSTAL` ENV var to customize binary used for `ASPEC::Methods.assert_error` and `ASPEC::Methods.assert_success` ([#424]) (George Dietrich)
+
+[0.3.8]: https://github.com/athena-framework/spec/releases/tag/v0.3.8
+[#424]: https://github.com/athena-framework/athena/pull/424
 
 ## [0.3.7] - 2024-04-09
 
 ### Changed
 
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
+
+[0.3.7]: https://github.com/athena-framework/spec/releases/tag/v0.3.7
+[#365]: https://github.com/athena-framework/athena/pull/365
 
 ## [0.3.6] - 2023-10-09
 
 _Administrative release, no functional changes_
 
+[0.3.6]: https://github.com/athena-framework/spec/releases/tag/v0.3.6
+
 ## [0.3.5] - 2023-04-26
 
 ### Fixed
 
-- Ensure `#before_all` runs exactly once, and before `#initialize` ([#285](https://github.com/athena-framework/athena/pull/285)) (George Dietrich)
+- Ensure `#before_all` runs exactly once, and before `#initialize` ([#285]) (George Dietrich)
+
+[0.3.5]: https://github.com/athena-framework/spec/releases/tag/v0.3.5
+[#285]: https://github.com/athena-framework/athena/pull/285
 
 ## [0.3.4] - 2023-03-19
 
 ### Fixed
 
-- Fix exceptions not being counted as errors when raised within the `initialize` method of a test case ([#276](https://github.com/athena-framework/athena/pull/276)) (George Dietrich)
-- Fix a documentation typo in the `TestWith` example ([#269](https://github.com/athena-framework/athena/pull/269)) (George Dietrich)
+- Fix exceptions not being counted as errors when raised within the `initialize` method of a test case ([#276]) (George Dietrich)
+- Fix a documentation typo in the `TestWith` example ([#269]) (George Dietrich)
+
+[0.3.4]: https://github.com/athena-framework/spec/releases/tag/v0.3.4
+[#269]: https://github.com/athena-framework/athena/pull/269
+[#276]: https://github.com/athena-framework/athena/pull/276
 
 ## [0.3.3] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
+
+[0.3.3]: https://github.com/athena-framework/spec/releases/tag/v0.3.3
+[#261]: https://github.com/athena-framework/athena/pull/261
 
 ## [0.3.2] - 2023-01-16
 
 ### Added
 
-- Add `ASPEC::TestCase::TestWith` that works similar to the `ASPEC::TestCase::DataProvider` but without needing to create a dedicated method ([#254](https://github.com/athena-framework/athena/pull/254)) (George Dietrich)
+- Add `ASPEC::TestCase::TestWith` that works similar to the `ASPEC::TestCase::DataProvider` but without needing to create a dedicated method ([#254]) (George Dietrich)
+
+[0.3.2]: https://github.com/athena-framework/spec/releases/tag/v0.3.2
+[#254]: https://github.com/athena-framework/athena/pull/254
 
 ## [0.3.1] - 2023-01-07
 
 ### Changed
 
-- Update the docs to clarify the component needs to be manually installed ([#247](https://github.com/athena-framework/athena/pull/247)) (George Dietrich)
+- Update the docs to clarify the component needs to be manually installed ([#247]) (George Dietrich)
 
 ### Added
 
-- Add support for *codegen* for the `ASPEC.assert_error` and `ASPEC.assert_success` methods ([#219](https://github.com/athena-framework/athena/pull/219)) (George Dietrich)
-- Add ability to skip running all examples within a test case via the `ASPEC::TestCase::Skip` annotation ([#248](https://github.com/athena-framework/athena/pull/248)) (George Dietrich)
+- Add support for *codegen* for the `ASPEC.assert_error` and `ASPEC.assert_success` methods ([#219]) (George Dietrich)
+- Add ability to skip running all examples within a test case via the `ASPEC::TestCase::Skip` annotation ([#248]) (George Dietrich)
+
+[0.3.1]: https://github.com/athena-framework/spec/releases/tag/v0.3.1
+[#219]: https://github.com/athena-framework/athena/pull/219
+[#247]: https://github.com/athena-framework/athena/pull/247
+[#248]: https://github.com/athena-framework/athena/pull/248
 
 ## [0.3.0] - 2022-05-14
 
@@ -82,80 +119,88 @@ _First release a part of the monorepo._
 
 ### Changed
 
-- **Breaking:** change the `assert_error` to no longer be file based. Code should now be provided as a HEREDOC argument to the method ([#173](https://github.com/athena-framework/athena/pull/173)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- **Breaking:** change the `assert_error` to no longer be file based. Code should now be provided as a HEREDOC argument to the method ([#173]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Added
 
-- Add `VERSION` constant to `Athena::Spec` namespace ([#166](https://github.com/athena-framework/athena/pull/166)) (George Dietrich)
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
-- Add [ASPEC::Methods.assert_success](https://athenaframework.org/Spec/Methods/#Athena::Spec::Methods#assert_success(code,*,line,file)) ([#173](https://github.com/athena-framework/athena/pull/173)) (George Dietrich)
+- Add `VERSION` constant to `Athena::Spec` namespace ([#166]) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
+- Add [ASPEC::Methods.assert_success](https://athenaframework.org/Spec/Methods/#Athena::Spec::Methods#assert_success(code,*,line,file)) ([#173]) (George Dietrich)
+
+[0.3.0]: https://github.com/athena-framework/spec/releases/tag/v0.3.0
+[#166]: https://github.com/athena-framework/athena/pull/166
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#172]: https://github.com/athena-framework/athena/pull/172
+[#173]: https://github.com/athena-framework/athena/pull/173
 
 ## [0.2.6] - 2021-11-03
 
 ### Fixed
 
-- Fix `test` helper macro generating invalid method names by replacing all non alphanumeric chars with `_`  ([#12](https://github.com/athena-framework/spec/pull/12)) (George Dietrich)
+- Fix `test` helper macro generating invalid method names by replacing all non alphanumeric chars with `_`  ([#12]) (George Dietrich)
+
+[0.2.6]: https://github.com/athena-framework/spec/releases/tag/v0.2.6
+[#12]: https://github.com/athena-framework/spec/pull/12
 
 ## [0.2.5] - 2021-11-03
 
 ### Fixed
 
-- Fix `test` helper macro not actually calling `yield`  ([#11](https://github.com/athena-framework/spec/pull/11)) (George Dietrich)
+- Fix `test` helper macro not actually calling `yield`  ([#11]) (George Dietrich)
+
+[0.2.5]: https://github.com/athena-framework/spec/releases/tag/v0.2.5
+[#11]: https://github.com/athena-framework/spec/pull/11
 
 ## [0.2.4] - 2021-01-29
 
 ### Changed
 
-- Finish migration to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#9](https://github.com/athena-framework/spec/pull/9)) (George Dietrich)
+- Finish migration to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#9]) (George Dietrich)
+
+[0.2.4]: https://github.com/athena-framework/spec/releases/tag/v0.2.4
+[#9]: https://github.com/athena-framework/spec/pull/9
 
 ## [0.2.3] - 2020-12-03
 
 ### Changed
 
-- Update `crystal` version to allow version greater than `1.0.0` ([#7](https://github.com/athena-framework/spec/pull/7)) (George Dietrich
+- Update `crystal` version to allow version greater than `1.0.0` ([#7]) (George Dietrich)
+
+[0.2.3]: https://github.com/athena-framework/spec/releases/tag/v0.2.3
+[#7]: https://github.com/athena-framework/spec/pull/7
 
 ## [0.2.2] - 2020-10-02
 
 ### Added
 
-- Add support for data providers defined in parent types ([#6](https://github.com/athena-framework/spec/pull/6)) (George Dietrich)
+- Add support for data providers defined in parent types ([#6]) (George Dietrich)
+
+[0.2.2]: https://github.com/athena-framework/spec/releases/tag/v0.2.2
+[#6]: https://github.com/athena-framework/spec/pull/6
 
 ## [0.2.1] - 2020-09-25
 
 ### Changed
 
-- Changed data provider generated `it` blocks have proper file names and line numbers ([#4](https://github.com/athena-framework/spec/pull/4)) (George Dietrich)
+- Changed data provider generated `it` blocks have proper file names and line numbers ([#4]) (George Dietrich)
+
+[0.2.1]: https://github.com/athena-framework/spec/releases/tag/v0.2.1
+[#4]: https://github.com/athena-framework/spec/pull/4
 
 ## [0.2.0] - 2020-08-08
 
 ### Changed
 
-- **Breaking:** require [data providers](https://athenaframework.org/Spec/TestCase/DataProvider/) methods to declare a return type of `Hash`, `NamedTuple`, `Tuple`, or `Array` ([#3](https://github.com/athena-framework/spec/pull/3)) (George Dietrich)
-- Changed data provider generated `it` blocks to include the key/index ([#2](https://github.com/athena-framework/spec/pull/2)) (George Dietrich)
+- **Breaking:** require [data providers](https://athenaframework.org/Spec/TestCase/DataProvider/) methods to declare a return type of `Hash`, `NamedTuple`, `Tuple`, or `Array` ([#3]) (George Dietrich)
+- Changed data provider generated `it` blocks to include the key/index ([#2]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/spec/releases/tag/v0.2.0
+[#2]: https://github.com/athena-framework/spec/pull/2
+[#3]: https://github.com/athena-framework/spec/pull/3
 
 ## [0.1.0] - 2020-08-06
 
 _Initial release._
 
-[0.4.0]: https://github.com/athena-framework/spec/releases/tag/v0.4.0
-[0.3.11]: https://github.com/athena-framework/spec/releases/tag/v0.3.11
-[0.3.10]: https://github.com/athena-framework/spec/releases/tag/v0.3.10
-[0.3.9]: https://github.com/athena-framework/spec/releases/tag/v0.3.9
-[0.3.8]: https://github.com/athena-framework/spec/releases/tag/v0.3.8
-[0.3.7]: https://github.com/athena-framework/spec/releases/tag/v0.3.7
-[0.3.6]: https://github.com/athena-framework/spec/releases/tag/v0.3.6
-[0.3.5]: https://github.com/athena-framework/spec/releases/tag/v0.3.5
-[0.3.4]: https://github.com/athena-framework/spec/releases/tag/v0.3.4
-[0.3.3]: https://github.com/athena-framework/spec/releases/tag/v0.3.3
-[0.3.2]: https://github.com/athena-framework/spec/releases/tag/v0.3.2
-[0.3.1]: https://github.com/athena-framework/spec/releases/tag/v0.3.1
-[0.3.0]: https://github.com/athena-framework/spec/releases/tag/v0.3.0
-[0.2.6]: https://github.com/athena-framework/spec/releases/tag/v0.2.6
-[0.2.5]: https://github.com/athena-framework/spec/releases/tag/v0.2.5
-[0.2.4]: https://github.com/athena-framework/spec/releases/tag/v0.2.4
-[0.2.3]: https://github.com/athena-framework/spec/releases/tag/v0.2.3
-[0.2.2]: https://github.com/athena-framework/spec/releases/tag/v0.2.2
-[0.2.1]: https://github.com/athena-framework/spec/releases/tag/v0.2.1
-[0.2.0]: https://github.com/athena-framework/spec/releases/tag/v0.2.0
 [0.1.0]: https://github.com/athena-framework/spec/releases/tag/v0.1.0

--- a/.changes/unreleased/console-Added-20250809-214752.yaml
+++ b/.changes/unreleased/console-Added-20250809-214752.yaml
@@ -3,6 +3,6 @@ kind: Added
 body: Add ability to customize the finished state of an `ACON::Helper::ProgressIndicator`
 time: 2025-08-09T21:47:52.992293702-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "535"
     Username: blacksmoke16

--- a/.changes/unreleased/console-Added-20250809-214818.yaml
+++ b/.changes/unreleased/console-Added-20250809-214818.yaml
@@ -3,6 +3,6 @@ kind: Added
 body: Add `markdown` `ACON::Helper::Table` style
 time: 2025-08-09T21:48:18.942747454-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "536"
     Username: blacksmoke16

--- a/.changes/unreleased/console-Added-20250809-214910.yaml
+++ b/.changes/unreleased/console-Added-20250809-214910.yaml
@@ -3,6 +3,6 @@ kind: Added
 body: Add support for nested style tags
 time: 2025-08-09T21:49:10.173060036-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "568"
     Username: blacksmoke16

--- a/.changes/unreleased/console-Fixed-20250809-214835.yaml
+++ b/.changes/unreleased/console-Fixed-20250809-214835.yaml
@@ -3,6 +3,6 @@ kind: Fixed
 body: Fix `ACON::Helper::ProgressBar` messing up output in console section with EOL
 time: 2025-08-09T21:48:35.925419418-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "537"
     Username: blacksmoke16

--- a/.changes/unreleased/dependency_injection-Changed-20250809-214717.yaml
+++ b/.changes/unreleased/dependency_injection-Changed-20250809-214717.yaml
@@ -3,7 +3,7 @@ kind: Changed
 body: Relax DI argument validation for string parameters
 time: 2025-08-09T21:47:17.3893784-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     Breaking: "No"
     PR: "548"
     Username: blacksmoke16

--- a/.changes/unreleased/event_dispatcher-Changed-20250809-213926.yaml
+++ b/.changes/unreleased/event_dispatcher-Changed-20250809-213926.yaml
@@ -3,7 +3,7 @@ kind: Changed
 body: Changed interface of `AED::EventDispatcherInterface#dispatch` to accept an `ACTR::EventDispatcher::Event` vs `AED::Event`
 time: 2025-08-09T21:39:26.328000927-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     Breaking: "Yes"
     PR: "544"
     Username: blacksmoke16

--- a/.changes/unreleased/event_dispatcher-Removed-20250809-213941.yaml
+++ b/.changes/unreleased/event_dispatcher-Removed-20250809-213941.yaml
@@ -3,6 +3,6 @@ kind: Removed
 body: Removed `AED::StoppableEvent` in favor of `ACTR::EventDispatcher::StoppableEvent`
 time: 2025-08-09T21:39:41.264472483-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "544"
     Username: blacksmoke16

--- a/.changes/unreleased/framework-Added-20250809-214012.yaml
+++ b/.changes/unreleased/framework-Added-20250809-214012.yaml
@@ -3,6 +3,6 @@ kind: Added
 body: Add support for Athena Contract component types
 time: 2025-08-09T21:40:12.061583694-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "544"
     Username: blacksmoke16

--- a/.changes/unreleased/framework-Added-20250809-214228.yaml
+++ b/.changes/unreleased/framework-Added-20250809-214228.yaml
@@ -3,6 +3,6 @@ kind: Added
 body: Add native file upload support
 time: 2025-08-09T21:42:28.072151926-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "559"
     Username: blacksmoke16

--- a/.changes/unreleased/framework-Changed-20250809-212756.yaml
+++ b/.changes/unreleased/framework-Changed-20250809-212756.yaml
@@ -3,7 +3,7 @@ kind: Changed
 body: Leverage `mime` component within `ATH::BinaryFileResponse`
 time: 2025-08-09T21:27:56.063317654-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     Breaking: "No"
     PR: "545"
     Username: blacksmoke16

--- a/.changes/unreleased/framework-Changed-20250809-214042.yaml
+++ b/.changes/unreleased/framework-Changed-20250809-214042.yaml
@@ -3,7 +3,7 @@ kind: Changed
 body: Leverage `mime` component within `ATH::BinaryFileResponse`
 time: 2025-08-09T21:40:42.572763984-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     Breaking: "No"
     PR: "545"
     Username: blacksmoke16

--- a/.changes/unreleased/framework-Changed-20250809-214300.yaml
+++ b/.changes/unreleased/framework-Changed-20250809-214300.yaml
@@ -3,7 +3,7 @@ kind: Changed
 body: Leverage `ATH::AbstractFile` within `ATH::BinaryFileResponse`
 time: 2025-08-09T21:43:00.830116982-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     Breaking: "Yes"
     PR: "563"
     Username: blacksmoke16

--- a/.changes/unreleased/framework-Changed-20250809-214316.yaml
+++ b/.changes/unreleased/framework-Changed-20250809-214316.yaml
@@ -3,7 +3,7 @@ kind: Changed
 body: Setter methods on `ATH::Response` and subclasses now return `self` to better support method chaning
 time: 2025-08-09T21:43:16.723607449-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     Breaking: "No"
     PR: "563"
     Username: blacksmoke16

--- a/.changes/unreleased/framework-Fixed-20250809-213839.yaml
+++ b/.changes/unreleased/framework-Fixed-20250809-213839.yaml
@@ -3,6 +3,6 @@ kind: Fixed
 body: Correctly apply `emit_nil` value from `ATHA::View`
 time: 2025-08-09T21:38:39.223990639-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "526"
     Username: blacksmoke16

--- a/.changes/unreleased/mime-Added-20250809-214414.yaml
+++ b/.changes/unreleased/mime-Added-20250809-214414.yaml
@@ -3,6 +3,6 @@ kind: Added
 body: Add fallback MIME types guesser based on stdlib `MIME` module
 time: 2025-08-09T21:44:14.743021535-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "546"
     Username: blacksmoke16

--- a/.changes/unreleased/routing-Fixed-20250809-213734.yaml
+++ b/.changes/unreleased/routing-Fixed-20250809-213734.yaml
@@ -3,6 +3,6 @@ kind: Fixed
 body: Fix linker warning due to duplicate `pcre2-8` linkage
 time: 2025-08-09T21:37:34.402441048-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "560"
     Username: blacksmoke16

--- a/.changes/unreleased/serializer-Fixed-20250809-213627.yaml
+++ b/.changes/unreleased/serializer-Fixed-20250809-213627.yaml
@@ -3,6 +3,6 @@ kind: Fixed
 body: Fix nightly type incompatibility with `ASR::Any`
 time: 2025-08-09T21:36:27.416169819-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "562"
     Username: blacksmoke16

--- a/.changes/unreleased/spec-Added-20250809-213446.yaml
+++ b/.changes/unreleased/spec-Added-20250809-213446.yaml
@@ -3,6 +3,6 @@ kind: Added
 body: Add support for generating macro code coverage reports for `.assert_error` and `.assert_compiles` methods
 time: 2025-08-09T21:34:46.151641968-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "551"
     Username: blacksmoke16

--- a/.changes/unreleased/spec-Removed-20250809-213045.yaml
+++ b/.changes/unreleased/spec-Removed-20250809-213045.yaml
@@ -3,7 +3,7 @@ kind: Removed
 body: Remove `codegen` parameter from `ASPEC::Methods.assert_error` and `ASPEC::Methods.assert_success`
 time: 2025-08-09T21:30:45.130915281-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     Breaking: "Yes"
     PR: "551"
     Username: blacksmoke16

--- a/.changes/unreleased/spec-Removed-20250809-213131.yaml
+++ b/.changes/unreleased/spec-Removed-20250809-213131.yaml
@@ -3,6 +3,6 @@ kind: Removed
 body: Remove `ASPEC::Methods.assert_error` in favor of `ASPEC::Methods.assert_compile_time_error` and `ASPEC::Methods.assert_runtime_error`
 time: 2025-08-09T21:31:31.491298844-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "551"
     Username: blacksmoke16

--- a/.changes/unreleased/spec-Removed-20250809-213145.yaml
+++ b/.changes/unreleased/spec-Removed-20250809-213145.yaml
@@ -3,6 +3,6 @@ kind: Removed
 body: Remove `ASPEC::Methods.assert_success` in favor of `ASPEC::Methods.assert_compiles` and `ASPEC::Methods.assert_executes`
 time: 2025-08-09T21:31:45.95512596-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "551"
     Username: blacksmoke16

--- a/.changes/unreleased/validator-Added-20250809-212939.yaml
+++ b/.changes/unreleased/validator-Added-20250809-212939.yaml
@@ -3,6 +3,6 @@ kind: Added
 body: Add support for `ATH::UploadedFile` to `AVD::Constraints::File` and `AVD::Constraints::Image`
 time: 2025-08-09T21:29:39.48850957-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "559"
     Username: blacksmoke16

--- a/.changes/unreleased/validator-Changed-20250809-212737.yaml
+++ b/.changes/unreleased/validator-Changed-20250809-212737.yaml
@@ -3,7 +3,7 @@ kind: Changed
 body: Leverage `mime` component for more robust `AVD::Constraints::File` MIME type validation
 time: 2025-08-09T21:27:37.400564323-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     Breaking: "No"
     PR: "545"
     Username: blacksmoke16

--- a/.changes/unreleased/validator-Fixed-20250808-184758.yaml
+++ b/.changes/unreleased/validator-Fixed-20250808-184758.yaml
@@ -3,6 +3,6 @@ kind: Fixed
 body: Fix equality between `AVD::Constraint` instances
 time: 2025-08-08T18:47:58.935424839-04:00
 custom:
-    Author: George Dierich
+    Author: George Dietrich
     PR: "540"
     Username: blacksmoke16

--- a/.changes/validator/v0.4.0.md
+++ b/.changes/validator/v0.4.0.md
@@ -2,107 +2,150 @@
 
 ### Changed
 
-- **Breaking:** Normalize exception types ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
+- **Breaking:** Normalize exception types ([#428]) (George Dietrich)
 
 ### Added
 
-- **Breaking:** Add and make `require_tld: true` the default for `AVD::Constraints::URL` ([#492](https://github.com/athena-framework/athena/pull/492)) (George Dietrich)
-- Add example usages to `AVD::Constraints::*` docs ([#483](https://github.com/athena-framework/athena/pull/483), [#493](https://github.com/athena-framework/athena/pull/493)) (Zohir Tamda, George Dietrich)
+- **Breaking:** Add and make `require_tld: true` the default for `AVD::Constraints::URL` ([#492]) (George Dietrich)
+- Add example usages to `AVD::Constraints::*` docs ([#483], [#493]) (Zohir Tamda, George Dietrich)
+
+[0.4.0]: https://github.com/athena-framework/validator/releases/tag/v0.4.0
+[#428]: https://github.com/athena-framework/athena/pull/428
+[#483]: https://github.com/athena-framework/athena/pull/483
+[#492]: https://github.com/athena-framework/athena/pull/492
+[#493]: https://github.com/athena-framework/athena/pull/493
 
 ## [0.3.4] - 2024-07-31
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.13.0` ([#433](https://github.com/athena-framework/athena/pull/433)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.13.0` ([#433]) (George Dietrich)
+
+[0.3.4]: https://github.com/athena-framework/validator/releases/tag/v0.3.4
+[#433]: https://github.com/athena-framework/athena/pull/433
 
 ## [0.3.3] - 2024-04-09
 
 ### Changed
 
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
+
+[0.3.3]: https://github.com/athena-framework/validator/releases/tag/v0.3.3
+[#365]: https://github.com/athena-framework/athena/pull/365
 
 ## [0.3.2] - 2023-10-09
 
 ### Fixed
 
-- Fix compiler error when using a composite constraint with a single member and no `of AVD::Constraint` ([#292](https://github.com/athena-framework/athena/pull/292)) (George Dietrich)
+- Fix compiler error when using a composite constraint with a single member and no `of AVD::Constraint` ([#292]) (George Dietrich)
+
+[0.3.2]: https://github.com/athena-framework/validator/releases/tag/v0.3.2
+[#292]: https://github.com/athena-framework/athena/pull/292
 
 ## [0.3.1] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
 
 ### Fixed
 
-- Fix issue when using `AVD::Metadata::GetterMetadata` with methods that have parameters ([#252](https://github.com/athena-framework/athena/pull/252)) (George Dietrich)
+- Fix issue when using `AVD::Metadata::GetterMetadata` with methods that have parameters ([#252]) (George Dietrich)
+
+[0.3.1]: https://github.com/athena-framework/validator/releases/tag/v0.3.1
+[#252]: https://github.com/athena-framework/athena/pull/252
+[#261]: https://github.com/athena-framework/athena/pull/261
 
 ## [0.3.0] - 2023-01-07
 
 ### Changed
 
-- **Breaking:** update default `AVD::Constraints::Email::Mode` to be `:html5` ([#230](https://github.com/athena-framework/athena/pull/230)) (George Dietrich)
-- Refactor `AVD::Constraints::IP` to use new dedicated `Socket::IPAddress` methods ([#205](https://github.com/athena-framework/athena/pull/205)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.6` ([#205](https://github.com/athena-framework/athena/pull/205)) (George Dietrich)
+- **Breaking:** update default `AVD::Constraints::Email::Mode` to be `:html5` ([#230]) (George Dietrich)
+- Refactor `AVD::Constraints::IP` to use new dedicated `Socket::IPAddress` methods ([#205]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.6` ([#205]) (George Dietrich)
 
 ### Added
 
-- Add `AVD::Constraints::Collection` ([#229](https://github.com/athena-framework/athena/pull/229)) (George Dietrich)
-- Add `AVD::Constraints::Existence`, `AVD::Constraints::Required`, and `AVD::Constraints::Optional` for use with the collection constraint ([#229](https://github.com/athena-framework/athena/pull/229)) (George Dietrich)
-- Add `AVD::Spec::ConstraintValidatorTestCase#expect_validate_value_at` to more easily handle validation of nested constraints ([#229](https://github.com/athena-framework/athena/pull/229)) (George Dietrich)
-- Add `AVD::Constraints::Email::Mode::HTML5_ALLOW_NO_TLD` that allows matching `HTML` input field validation exactly ([#231](https://github.com/athena-framework/athena/pull/231)) (George Dietrich)
+- Add `AVD::Constraints::Collection` ([#229]) (George Dietrich)
+- Add `AVD::Constraints::Existence`, `AVD::Constraints::Required`, and `AVD::Constraints::Optional` for use with the collection constraint ([#229]) (George Dietrich)
+- Add `AVD::Spec::ConstraintValidatorTestCase#expect_validate_value_at` to more easily handle validation of nested constraints ([#229]) (George Dietrich)
+- Add `AVD::Constraints::Email::Mode::HTML5_ALLOW_NO_TLD` that allows matching `HTML` input field validation exactly ([#231]) (George Dietrich)
 
 ### Removed
 
-- **Breaking:** remove `AVD::Constraints::Email::Mode::Loose` ([#230](https://github.com/athena-framework/athena/pull/230)) (George Dietrich)
+- **Breaking:** remove `AVD::Constraints::Email::Mode::Loose` ([#230]) (George Dietrich)
 
 ### Fixed
 
-- **Breaking:** fix spelling of `AVD::Constraints::ISSN#require_hyphen` parameter ([#222](https://github.com/athena-framework/athena/pull/222)) (George Dietrich)
-- Fix property path display issue with `Enumerable` objects ([#229](https://github.com/athena-framework/athena/pull/229)) (George Dietrich)
-- Fix `AVD::Constraints::Valid` constraints incorrectly being allowed within `AVD::Constraints::Composite` ([#229](https://github.com/athena-framework/athena/pull/229)) (George Dietrich)
+- **Breaking:** fix spelling of `AVD::Constraints::ISSN#require_hyphen` parameter ([#222]) (George Dietrich)
+- Fix property path display issue with `Enumerable` objects ([#229]) (George Dietrich)
+- Fix `AVD::Constraints::Valid` constraints incorrectly being allowed within `AVD::Constraints::Composite` ([#229]) (George Dietrich)
+
+[0.3.0]: https://github.com/athena-framework/validator/releases/tag/v0.3.0
+[#205]: https://github.com/athena-framework/athena/pull/205
+[#222]: https://github.com/athena-framework/athena/pull/222
+[#229]: https://github.com/athena-framework/athena/pull/229
+[#230]: https://github.com/athena-framework/athena/pull/230
+[#231]: https://github.com/athena-framework/athena/pull/231
 
 ## [0.2.1] - 2022-09-05
 
 ### Added
 
-- Add support for exclusive end support to `AVD::Constraints::Range` ([#184](https://github.com/athena-framework/athena/pull/184)) (George Dietrich)
+- Add support for exclusive end support to `AVD::Constraints::Range` ([#184]) (George Dietrich)
 
 ### Changed
 
-- Include allowed MIME types within `AVD::Constraints::Image` if they were customized ([#183](https://github.com/athena-framework/athena/pull/183)) (George Dietrich)
-- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188](https://github.com/athena-framework/athena/pull/188)) (George Dietrich)
+- Include allowed MIME types within `AVD::Constraints::Image` if they were customized ([#183]) (George Dietrich)
+- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188]) (George Dietrich)
 
 ### Fixed
 
-- Fix some file size factorization edge cases in `AVD::Constraints::File` ([#182](https://github.com/athena-framework/athena/pull/182)) (George Dietrich)
-- Fix duplicating constraints due to Crystal generics bug ([#192](https://github.com/athena-framework/athena/pull/192)) (George Dietrich)
+- Fix some file size factorization edge cases in `AVD::Constraints::File` ([#182]) (George Dietrich)
+- Fix duplicating constraints due to Crystal generics bug ([#192]) (George Dietrich)
+
+[0.2.1]: https://github.com/athena-framework/validator/releases/tag/v0.2.1
+[#182]: https://github.com/athena-framework/athena/pull/182
+[#183]: https://github.com/athena-framework/athena/pull/183
+[#184]: https://github.com/athena-framework/athena/pull/184
+[#188]: https://github.com/athena-framework/athena/pull/188
+[#192]: https://github.com/athena-framework/athena/pull/192
 
 ## [0.2.0] - 2022-05-14
 
 ### Added
 
-- Add the [AVD::Constraints::File](https://athenaframework.org/Validator/Constraints/File/) constraint ([#153](https://github.com/athena-framework/athena/pull/153)) (George Dietrich)
-- Allow `AVD::Spec::MockValidator` to dynamically configure returned violations ([#155](https://github.com/athena-framework/athena/pull/155), [#157](https://github.com/athena-framework/athena/pull/157)) (George Dietrich)
-- Add the [AVD::Constraints::Image](https://athenaframework.org/Validator/Constraints/Image/) constraint ([#153](https://github.com/athena-framework/athena/pull/153)) (George Dietrich)
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
+- Add the [AVD::Constraints::File](https://athenaframework.org/Validator/Constraints/File/) constraint ([#153]) (George Dietrich)
+- Allow `AVD::Spec::MockValidator` to dynamically configure returned violations ([#155], [#157]) (George Dietrich)
+- Add the [AVD::Constraints::Image](https://athenaframework.org/Validator/Constraints/Image/) constraint ([#153]) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
 
 ### Changed
 
-- **Breaking:** make `AVD::ConstraintValidator` classes ([#154](https://github.com/athena-framework/athena/pull/154)) (George Dietrich)
-- **Breaking:** `AVD::ExecutionContext` is no longer a generic type ([#156](https://github.com/athena-framework/athena/pull/156)) (George Dietrich)
-- Update `assert_violation` to use a clearer failure message if no violations were found ([#153](https://github.com/athena-framework/athena/pull/153)) (George Dietrich)
-- Update `AVD::Constraints::ISIN` to use the validator off the context versus an ivar ([#155](https://github.com/athena-framework/athena/pull/155)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- **Breaking:** make `AVD::ConstraintValidator` classes ([#154]) (George Dietrich)
+- **Breaking:** `AVD::ExecutionContext` is no longer a generic type ([#156]) (George Dietrich)
+- Update `assert_violation` to use a clearer failure message if no violations were found ([#153]) (George Dietrich)
+- Update `AVD::Constraints::ISIN` to use the validator off the context versus an ivar ([#155]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Removed
 
-- **Breaking:** removed `AVD::Spec::MockValidator#violations=` ([#155](https://github.com/athena-framework/athena/pull/155)) (George Dietrich)
+- **Breaking:** removed `AVD::Spec::MockValidator#violations=` ([#155]) (George Dietrich)
 
 ### Fixed
 
-- Fix `AVD::Violation::ConstraintViolation` not comparing correctly ([#153](https://github.com/athena-framework/athena/pull/153)) (George Dietrich)
-- Ensure only `Indexable` types can be used with `AVD::Constraints::Unique` ([#168](https://github.com/athena-framework/athena/pull/168)) (George Dietrich)
+- Fix `AVD::Violation::ConstraintViolation` not comparing correctly ([#153]) (George Dietrich)
+- Ensure only `Indexable` types can be used with `AVD::Constraints::Unique` ([#168]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/validator/releases/tag/v0.2.0
+[#153]: https://github.com/athena-framework/athena/pull/153
+[#154]: https://github.com/athena-framework/athena/pull/154
+[#155]: https://github.com/athena-framework/athena/pull/155
+[#156]: https://github.com/athena-framework/athena/pull/156
+[#157]: https://github.com/athena-framework/athena/pull/157
+[#168]: https://github.com/athena-framework/athena/pull/168
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#172]: https://github.com/athena-framework/athena/pull/172
 
 ## [0.1.7] - 2021-12-27
 
@@ -110,70 +153,79 @@ _First release a part of the monorepo._
 
 ### Fixed
 
-- Fix callback constraint methods being incorrectly added as getters ([#132](https://github.com/athena-framework/athena/pull/132)) (George Dietrich)
+- Fix callback constraint methods being incorrectly added as getters ([#132]) (George Dietrich)
+
+[0.1.7]: https://github.com/athena-framework/validator/releases/tag/v0.1.7
+[#132]: https://github.com/athena-framework/athena/pull/132
 
 ## [0.1.6] - 2021-12-13
 
 ### Fixed
 
-- Fix `AVD::Validatable` not working when included into parent types ([#16](https://github.com/athena-framework/validator/pull/16)) (George Dietrich)
+- Fix `AVD::Validatable` not working when included into parent types ([#16]) (George Dietrich)
+
+[0.1.6]: https://github.com/athena-framework/validator/releases/tag/v0.1.6
+[#16]: https://github.com/athena-framework/validator/pull/16
 
 ## [0.1.5] - 2021-10-30
 
 ### Added
 
-- Add `VERSION` constant to `Athena::Validator` namespace ([#12](https://github.com/athena-framework/validator/pull/12)) (George Dietrich)
+- Add `VERSION` constant to `Athena::Validator` namespace ([#12]) (George Dietrich)
 
 ### Fixed
 
-- Fix incorrect type restriction on validator factory ([#12](https://github.com/athena-framework/validator/pull/12)) (George Dietrich)
-- Fix incorrect link within the docs ([#14](https://github.com/athena-framework/validator/pull/14)) (George Dietrich)
+- Fix incorrect type restriction on validator factory ([#12]) (George Dietrich)
+- Fix incorrect link within the docs ([#14]) (George Dietrich)
+
+[0.1.5]: https://github.com/athena-framework/validator/releases/tag/v0.1.5
+[#12]: https://github.com/athena-framework/validator/pull/12
+[#14]: https://github.com/athena-framework/validator/pull/14
 
 ## [0.1.4] - 2021-01-30
 
 ### Changed
 
-- Finish migration to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#10](https://github.com/athena-framework/validator/pull/10), [#11](https://github.com/athena-framework/validator/pull/11)) (George Dietrich)
+- Finish migration to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#10], [#11]) (George Dietrich)
+
+[0.1.4]: https://github.com/athena-framework/validator/releases/tag/v0.1.4
+[#10]: https://github.com/athena-framework/validator/pull/10
+[#11]: https://github.com/athena-framework/validator/pull/11
 
 ## [0.1.3] - 2020-12-07
 
 ### Changed
 
-- Update `crystal` version to allow version greater than `1.0.0` ([#9](https://github.com/athena-framework/validator/pull/9)) (George Dietrich
+- Update `crystal` version to allow version greater than `1.0.0` ([#9]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/validator/releases/tag/v0.1.3
+[#9]: https://github.com/athena-framework/validator/pull/9
 
 ## [0.1.2] - 2020-11-25
 
 ### Added
 
-- Add the [AVD::Constraints::Choice](https://athenaframework.org/Validator/Constraints/Choice/) constraint ([#7](https://github.com/athena-framework/validator/pull/7)) (George Dietrich)
+- Add the [AVD::Constraints::Choice](https://athenaframework.org/Validator/Constraints/Choice/) constraint ([#7]) (George Dietrich)
 
 ### Changed
 
-- Allow setting violations directly on mock validators ([#7](https://github.com/athena-framework/validator/pull/7)) (George Dietrich)
+- Allow setting violations directly on mock validators ([#7]) (George Dietrich)
+
+[0.1.2]: https://github.com/athena-framework/validator/releases/tag/v0.1.2
+[#7]: https://github.com/athena-framework/validator/pull/7
 
 ## [0.1.1] - 2020-11-08
 
 ### Fixed
 
-- Fix compiler error due to less strict `abstract def` implementations ([#6](https://github.com/athena-framework/validator/pull/6)) (George Dietrich)
+- Fix compiler error due to less strict `abstract def` implementations ([#6]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/validator/releases/tag/v0.1.1
+[#6]: https://github.com/athena-framework/validator/pull/6
 
 ## [0.1.0] - 2020-10-17
 
 _Initial release._
 
-[0.4.0]: https://github.com/athena-framework/validator/releases/tag/v0.4.0
-[0.3.4]: https://github.com/athena-framework/validator/releases/tag/v0.3.4
-[0.3.3]: https://github.com/athena-framework/validator/releases/tag/v0.3.3
-[0.3.2]: https://github.com/athena-framework/validator/releases/tag/v0.3.2
-[0.3.1]: https://github.com/athena-framework/validator/releases/tag/v0.3.1
-[0.3.0]: https://github.com/athena-framework/validator/releases/tag/v0.3.0
-[0.2.1]: https://github.com/athena-framework/validator/releases/tag/v0.2.1
-[0.2.0]: https://github.com/athena-framework/validator/releases/tag/v0.2.0
-[0.1.7]: https://github.com/athena-framework/validator/releases/tag/v0.1.7
-[0.1.6]: https://github.com/athena-framework/validator/releases/tag/v0.1.6
-[0.1.5]: https://github.com/athena-framework/validator/releases/tag/v0.1.5
-[0.1.4]: https://github.com/athena-framework/validator/releases/tag/v0.1.4
-[0.1.3]: https://github.com/athena-framework/validator/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/validator/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/validator/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/validator/releases/tag/v0.1.0
+

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -7,10 +7,10 @@ versionFormat: '## [{{.VersionNoPrefix}}] - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: '- {{.Body}} ([#{{.Custom.PR}}]) ({{.Custom.Author}})'
 footerFormat: |
+  [{{.VersionNoPrefix}}]: https://github.com/athena-framework/{{ kebabcase (index .Changes 0).Project }}/releases/tag/{{.Version}}
   {{- range (customs .Changes "PR" | uniq) }}
   [#{{.}}]: https://github.com/athena-framework/athena/pull/{{.}}
   {{- end}}
-  [{{.VersionNoPrefix}}]: https://github.com/athena-framework/{{ kebabcase (index .Changes 0).Project }}/releases/tag/{{.Version}}
 projectsVersionSeparator: '/'
 projects:
   - label: Clock

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -10,6 +10,7 @@ footerFormat: |
   {{- range (customs .Changes "PR" | uniq) }}
   [#{{.}}]: https://github.com/athena-framework/athena/pull/{{.}}
   {{- end}}
+  [{{.VersionNoPrefix}}]: https://github.com/athena-framework/{{ kebabcase (index .Changes 0).Project }}/releases/tag/{{.Version}}
 projectsVersionSeparator: '/'
 projects:
   - label: Clock

--- a/src/components/clock/CHANGELOG.md
+++ b/src/components/clock/CHANGELOG.md
@@ -4,31 +4,37 @@
 
 ### Changed
 
-- **Breaking:** Remove `Athena::Clock::Interface#sleep(Number)` overload ([#449](https://github.com/athena-framework/athena/pull/449)) (George Dietrich)
+- **Breaking:** Remove `Athena::Clock::Interface#sleep(Number)` overload ([#449]) (George Dietrich)
 
 ### Fixed
 
-- Fix type error when trying to use `ACLK::Aware#now` ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
+- Fix type error when trying to use `ACLK::Aware#now` ([#498]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/clock/releases/tag/v0.2.0
+[#449]: https://github.com/athena-framework/athena/pull/449
+[#498]: https://github.com/athena-framework/athena/pull/498
 
 ## [0.1.2] - 2024-04-09
 
 ### Changed
 
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
 
 ### Fixed
 
-- Fix that `Athena::Clock::Aware` was not required by default ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Fix that `Athena::Clock::Aware` was not required by default ([#365]) (George Dietrich)
+
+[0.1.2]: https://github.com/athena-framework/clock/releases/tag/v0.1.2
+[#365]: https://github.com/athena-framework/athena/pull/365
 
 ## [0.1.1] - 2023-10-09
 
 _Administrative release, no functional changes_
 
+[0.1.1]: https://github.com/athena-framework/clock/releases/tag/v0.1.1
+
 ## [0.1.0] - 2023-09-16
 
 _Initial release._
 
-[0.2.0]: https://github.com/athena-framework/clock/releases/tag/v0.2.0
-[0.1.2]: https://github.com/athena-framework/clock/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/clock/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/clock/releases/tag/v0.1.0

--- a/src/components/console/CHANGELOG.md
+++ b/src/components/console/CHANGELOG.md
@@ -4,127 +4,179 @@
 
 ### Fixed
 
-- Fix incorrectly aligned block ([#519](https://github.com/athena-framework/athena/pull/519)) (Zohir Tamda)
+- Fix incorrectly aligned block ([#519]) (Zohir Tamda)
+
+[0.4.1]: https://github.com/athena-framework/console/releases/tag/v0.4.1
+[#519]: https://github.com/athena-framework/athena/pull/519
 
 ## [0.4.0] - 2025-01-26
 
 ### Changed
 
-- **Breaking:** Normalize exception types ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
+- **Breaking:** Normalize exception types ([#428]) (George Dietrich)
 
 ### Added
 
-- **Breaking:** Add `ACON::Output::Verbosity::SILENT` verbosity level ([#489](https://github.com/athena-framework/athena/pull/489)) (George Dietrich)
-- **Breaking:** Rename `ACON::Completion::Input#must_suggest_values_for?` to `#must_suggest_option_values_for?` ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.13.0` ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
-- Add `#assert_command_is_not_successful` spec expectation method ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
-- Add support for [`FORCE_COLOR`](https://force-color.org/) and improve color support logic ([#488](https://github.com/athena-framework/athena/pull/488)) (George Dietrich)
+- **Breaking:** Add `ACON::Output::Verbosity::SILENT` verbosity level ([#489]) (George Dietrich)
+- **Breaking:** Rename `ACON::Completion::Input#must_suggest_values_for?` to `#must_suggest_option_values_for?` ([#498]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.13.0` ([#498]) (George Dietrich)
+- Add `#assert_command_is_not_successful` spec expectation method ([#498]) (George Dietrich)
+- Add support for [`FORCE_COLOR`](https://force-color.org/) and improve color support logic ([#488]) (George Dietrich)
 
 ### Fixed
 
-- Fix unexpected completion value when given an array of options ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
-- Fix error when trying to set `ACON::Helper::Table::Style#padding_char` ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
+- Fix unexpected completion value when given an array of options ([#498]) (George Dietrich)
+- Fix error when trying to set `ACON::Helper::Table::Style#padding_char` ([#498]) (George Dietrich)
+
+[0.4.0]: https://github.com/athena-framework/console/releases/tag/v0.4.0
+[#428]: https://github.com/athena-framework/athena/pull/428
+[#488]: https://github.com/athena-framework/athena/pull/488
+[#489]: https://github.com/athena-framework/athena/pull/489
+[#498]: https://github.com/athena-framework/athena/pull/498
 
 ## [0.3.6] - 2024-07-31
 
 ### Changed
 
-- **Breaking:** `ACON::Application#getter` and constructor argument must now be a `String` instead of `SemanticVersion` ([#419](https://github.com/athena-framework/athena/pull/419)) (George Dietrich)
-- Changed the default `ACON::Application` version to `UNKNOWN` from `0.1.0` ([#419](https://github.com/athena-framework/athena/pull/419)) (George Dietrich)
-- List commands in a namespace when using it as the command name ([#427](https://github.com/athena-framework/athena/pull/427)) (George Dietrich)
-- Use single quotes in text descriptor to quote values in the output ([#427](https://github.com/athena-framework/athena/pull/427)) (George Dietrich)
+- **Breaking:** `ACON::Application#getter` and constructor argument must now be a `String` instead of `SemanticVersion` ([#419]) (George Dietrich)
+- Changed the default `ACON::Application` version to `UNKNOWN` from `0.1.0` ([#419]) (George Dietrich)
+- List commands in a namespace when using it as the command name ([#427]) (George Dietrich)
+- Use single quotes in text descriptor to quote values in the output ([#427]) (George Dietrich)
+
+[0.3.6]: https://github.com/athena-framework/console/releases/tag/v0.3.6
+[#419]: https://github.com/athena-framework/athena/pull/419
+[#427]: https://github.com/athena-framework/athena/pull/427
 
 ## [0.3.5] - 2024-04-09
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.11.0` ([#270](https://github.com/athena-framework/athena/pull/270)) (George Dietrich)
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.11.0` ([#270]) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
 
 ### Added
 
-- Support for Windows OS ([#270](https://github.com/athena-framework/athena/pull/270)) (George Dietrich)
+- Support for Windows OS ([#270]) (George Dietrich)
 
 ### Fixed
 
-- Fix incorrect column/width `ACON::Terminal` values on Windows ([#361](https://github.com/athena-framework/athena/pull/361)) (George Dietrich)
+- Fix incorrect column/width `ACON::Terminal` values on Windows ([#361]) (George Dietrich)
+
+[0.3.5]: https://github.com/athena-framework/console/releases/tag/v0.3.5
+[#270]: https://github.com/athena-framework/athena/pull/270
+[#365]: https://github.com/athena-framework/athena/pull/365
+[#361]: https://github.com/athena-framework/athena/pull/361
 
 ## [0.3.4] - 2023-10-10
 
 ### Added
 
-- Add support for tab completion to the `bash` shell when binary is in the `bin/` directory and referenced with `./` ([#323](https://github.com/athena-framework/athena/pull/323)) (George Dietrich)
+- Add support for tab completion to the `bash` shell when binary is in the `bin/` directory and referenced with `./` ([#323]) (George Dietrich)
+
+[0.3.4]: https://github.com/athena-framework/console/releases/tag/v0.3.4
+[#323]: https://github.com/athena-framework/athena/pull/323
 
 ## [0.3.3] - 2023-10-09
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.8.0` ([#282](https://github.com/athena-framework/athena/pull/282)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.8.0` ([#282]) (George Dietrich)
 
 ### Added
 
-- **Breaking:** Add `ACON::Helper::ProgressBar` to enable rendering progress bars ([#304](https://github.com/athena-framework/athena/pull/304)) (George Dietrich)
-- Add native shell tab completion support for `bash`, `zsh`, and `fish` for both built-in and custom commands ([#294](https://github.com/athena-framework/athena/pull/294),[#296](https://github.com/athena-framework/athena/pull/296), [#297](https://github.com/athena-framework/athena/pull/297), [#299](https://github.com/athena-framework/athena/pull/299)) (George Dietrich)
-- Add `ACON::Helper::ProgressIndicator` to enable rendering spinners ([#314](https://github.com/athena-framework/athena/pull/314)) (George Dietrich)
-- Add support for defining a max height for an `ACON::Output::Section` ([#303](https://github.com/athena-framework/athena/pull/303)) (George Dietrich)
-- Add `ACON::Helper.format_time` to format a duration as a human readable string ([#304](https://github.com/athena-framework/athena/pull/304)) (George Dietrich)
-- Add `#assert_command_is_successful` helper method to `ACON::Spec::CommandTester` and `ACON::Spec::ApplicationTester` ([#294](https://github.com/athena-framework/athena/pull/294)) (George Dietrich)
+- **Breaking:** Add `ACON::Helper::ProgressBar` to enable rendering progress bars ([#304]) (George Dietrich)
+- Add native shell tab completion support for `bash`, `zsh`, and `fish` for both built-in and custom commands ([#294], [#296], [#297], [#299]) (George Dietrich)
+- Add `ACON::Helper::ProgressIndicator` to enable rendering spinners ([#314]) (George Dietrich)
+- Add support for defining a max height for an `ACON::Output::Section` ([#303]) (George Dietrich)
+- Add `ACON::Helper.format_time` to format a duration as a human readable string ([#304]) (George Dietrich)
+- Add `#assert_command_is_successful` helper method to `ACON::Spec::CommandTester` and `ACON::Spec::ApplicationTester` ([#294]) (George Dietrich)
 
 ### Fixed
 
-- Ensure long lines with URLs are not cut when wrapped ([#314](https://github.com/athena-framework/athena/pull/314)) (George Dietrich)
-- Do not emit erroneous newline from `ACON::Style::Athena` when it's the first thing being written ([#314](https://github.com/athena-framework/athena/pull/314)) (George Dietrich)
-- Fix misalignment when word wrapping a hyperlink ([#305](https://github.com/athena-framework/athena/pull/305)) (George Dietrich)
-- Do not emit erroneous extra newlines from an `ACON::Output::Section` ([#303](https://github.com/athena-framework/athena/pull/303)) (George Dietrich)
-- Fix misalignment within a vertical table with multi-line cell ([#300](https://github.com/athena-framework/athena/pull/300)) (George Dietrich)
+- Ensure long lines with URLs are not cut when wrapped ([#314]) (George Dietrich)
+- Do not emit erroneous newline from `ACON::Style::Athena` when it's the first thing being written ([#314]) (George Dietrich)
+- Fix misalignment when word wrapping a hyperlink ([#305]) (George Dietrich)
+- Do not emit erroneous extra newlines from an `ACON::Output::Section` ([#303]) (George Dietrich)
+- Fix misalignment within a vertical table with multi-line cell ([#300]) (George Dietrich)
+
+[0.3.3]: https://github.com/athena-framework/console/releases/tag/v0.3.3
+[#282]: https://github.com/athena-framework/athena/pull/282
+[#294]: https://github.com/athena-framework/athena/pull/294
+[#296]: https://github.com/athena-framework/athena/pull/296
+[#297]: https://github.com/athena-framework/athena/pull/297
+[#299]: https://github.com/athena-framework/athena/pull/299
+[#300]: https://github.com/athena-framework/athena/pull/300
+[#303]: https://github.com/athena-framework/athena/pull/303
+[#304]: https://github.com/athena-framework/athena/pull/304
+[#305]: https://github.com/athena-framework/athena/pull/305
+[#314]: https://github.com/athena-framework/athena/pull/314
 
 ## [0.3.2] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
 
 ### Fixed
 
-- Fix formatting issue in Crystal `1.8-dev` ([#258](https://github.com/athena-framework/athena/pull/258)) (George Dietrich)
+- Fix formatting issue in Crystal `1.8-dev` ([#258]) (George Dietrich)
+
+[0.3.2]: https://github.com/athena-framework/console/releases/tag/v0.3.2
+[#261]: https://github.com/athena-framework/athena/pull/261
+[#258]: https://github.com/athena-framework/athena/pull/258
 
 ## [0.3.1] - 2023-02-04
 
 ### Added
 
-- Add better integration between `Athena::Console` and `Athena::DependencyInjection` ([#259](https://github.com/athena-framework/athena/pull/259)) (George Dietrich)
+- Add better integration between `Athena::Console` and `Athena::DependencyInjection` ([#259]) (George Dietrich)
+
+[0.3.1]: https://github.com/athena-framework/console/releases/tag/v0.3.1
+[#259]: https://github.com/athena-framework/athena/pull/259
 
 ## [0.3.0] - 2023-01-07
 
 ### Changed
 
-- **Breaking:** deprecate command default name/description class variables in favor of the new `ACONA::AsCommand` annotation ([#214](https://github.com/athena-framework/athena/pull/214)) (George Dietrich)
-- **Breaking:** refactor `ACON::Command#application=` to no longer have a `nil` default value ([#217](https://github.com/athena-framework/athena/pull/217)) (George Dietrich)
-- **Breaking:** refactor `ACON::Command#process_title=` no longer accept `nil` ([#217](https://github.com/athena-framework/athena/pull/217)) (George Dietrich)
-- **Breaking:** rename `ACON::Command#process_title=` to `ACON::Command#process_title` ([#217](https://github.com/athena-framework/athena/pull/217)) (George Dietrich)
+- **Breaking:** deprecate command default name/description class variables in favor of the new `ACONA::AsCommand` annotation ([#214]) (George Dietrich)
+- **Breaking:** refactor `ACON::Command#application=` to no longer have a `nil` default value ([#217]) (George Dietrich)
+- **Breaking:** refactor `ACON::Command#process_title=` no longer accept `nil` ([#217]) (George Dietrich)
+- **Breaking:** rename `ACON::Command#process_title=` to `ACON::Command#process_title` ([#217]) (George Dietrich)
 
 ### Added
 
-- **Breaking:** add `#table` method to `ACON::Style::Interface` ([#220](https://github.com/athena-framework/athena/pull/220)) (George Dietrich)
-- Add `ACONA::AsCommand` annotation to configure a command's name, description, aliases, and if it should be hidden ([#214](https://github.com/athena-framework/athena/pull/214)) (George Dietrich)
-- Add support for generating tables ([#220](https://github.com/athena-framework/athena/pull/220)) (George Dietrich)
+- **Breaking:** add `#table` method to `ACON::Style::Interface` ([#220]) (George Dietrich)
+- Add `ACONA::AsCommand` annotation to configure a command's name, description, aliases, and if it should be hidden ([#214]) (George Dietrich)
+- Add support for generating tables ([#220]) (George Dietrich)
 
 ### Fixed
 
-- Fix issue with using `ACON::Formatter::Output#format_and_wrap` with `nil` input and an edge case when wrapping a string with a space at the limit ([#220](https://github.com/athena-framework/athena/pull/220)) (George Dietrich)
-- Fix `ACON::Formatter::NullStyle#*_option` method using incorrect `ACON::Formatter::Mode` type restriction ([#220](https://github.com/athena-framework/athena/pull/220)) (George Dietrich)
-- Fix some flakiness when testing commands with input ([#224](https://github.com/athena-framework/athena/pull/224)) (George Dietrich)
-- Fix compiler error when trying to use `ACON::Style::Athena#error_style` ([#240](https://github.com/athena-framework/athena/pull/240)) (George Dietrich)
+- Fix issue with using `ACON::Formatter::Output#format_and_wrap` with `nil` input and an edge case when wrapping a string with a space at the limit ([#220]) (George Dietrich)
+- Fix `ACON::Formatter::NullStyle#*_option` method using incorrect `ACON::Formatter::Mode` type restriction ([#220]) (George Dietrich)
+- Fix some flakiness when testing commands with input ([#224]) (George Dietrich)
+- Fix compiler error when trying to use `ACON::Style::Athena#error_style` ([#240]) (George Dietrich)
+
+[0.3.0]: https://github.com/athena-framework/console/releases/tag/v0.3.0
+[#214]: https://github.com/athena-framework/athena/pull/214
+[#217]: https://github.com/athena-framework/athena/pull/217
+[#220]: https://github.com/athena-framework/athena/pull/220
+[#224]: https://github.com/athena-framework/athena/pull/224
+[#240]: https://github.com/athena-framework/athena/pull/240
 
 ## [0.2.1] - 2022-09-05
 
 ### Changed
 
-- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188](https://github.com/athena-framework/athena/pull/188)) (George Dietrich)
+- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188]) (George Dietrich)
 
 ### Added
 
-- Add an `ACON::Input::Interface` based on a command line string ([#186](https://github.com/athena-framework/athena/pull/186), [#187](https://github.com/athena-framework/athena/pull/187)) (George Dietrich)
+- Add an `ACON::Input::Interface` based on a command line string ([#186], [#187]) (George Dietrich)
+
+[0.2.1]: https://github.com/athena-framework/console/releases/tag/v0.2.1
+[#186]: https://github.com/athena-framework/athena/pull/186
+[#187]: https://github.com/athena-framework/athena/pull/187
+[#188]: https://github.com/athena-framework/athena/pull/188
 
 ## [0.2.0] - 2022-05-14
 
@@ -132,39 +184,38 @@ _First release a part of the monorepo._
 
 ### Changed
 
-- **Breaking:** remove `ACON::Formatter::Mode` in favor of `Colorize::Mode`. Breaking only if not using symbol autocasting. ([#170](https://github.com/athena-framework/athena/pull/170)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- **Breaking:** remove `ACON::Formatter::Mode` in favor of `Colorize::Mode`. Breaking only if not using symbol autocasting. ([#170]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Added
 
-- Add `VERSION` constant to `Athena::Console` namespace ([#166](https://github.com/athena-framework/athena/pull/166)) (George Dietrich)
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
+- Add `VERSION` constant to `Athena::Console` namespace ([#166]) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
 
 ### Fixed
 
-- Disallow multi char option shortcuts made up of diff chars ([#164](https://github.com/athena-framework/athena/pull/164)) (George Dietrich)
+- Disallow multi char option shortcuts made up of diff chars ([#164]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/console/releases/tag/v0.2.0
+[#164]: https://github.com/athena-framework/athena/pull/164
+[#166]: https://github.com/athena-framework/athena/pull/166
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#170]: https://github.com/athena-framework/athena/pull/170
+[#172]: https://github.com/athena-framework/athena/pull/172
 
 ## [0.1.1] - 2021-12-01
 
 ### Fixed
 
-- **Breaking:** fix typo in parameter name of `ACON::Command#option` method ([#3](https://github.com/athena-framework/console/pull/3)) (George Dietrich)
-- Fix recursive struct error ([#4](https://github.com/athena-framework/console/pull/4)) (George Dietrich)
+- **Breaking:** fix typo in parameter name of `ACON::Command#option` method ([#3]) (George Dietrich)
+- Fix recursive struct error ([#4]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/console/releases/tag/v0.1.1
+[#3]: https://github.com/athena-framework/console/pull/3
+[#4]: https://github.com/athena-framework/console/pull/4
 
 ## [0.1.0] - 2021-10-30
 
 _Initial release._
 
-[0.4.1]: https://github.com/athena-framework/console/releases/tag/v0.4.1
-[0.4.0]: https://github.com/athena-framework/console/releases/tag/v0.4.0
-[0.3.6]: https://github.com/athena-framework/console/releases/tag/v0.3.6
-[0.3.5]: https://github.com/athena-framework/console/releases/tag/v0.3.5
-[0.3.4]: https://github.com/athena-framework/console/releases/tag/v0.3.4
-[0.3.3]: https://github.com/athena-framework/console/releases/tag/v0.3.3
-[0.3.2]: https://github.com/athena-framework/console/releases/tag/v0.3.2
-[0.3.1]: https://github.com/athena-framework/console/releases/tag/v0.3.1
-[0.3.0]: https://github.com/athena-framework/console/releases/tag/v0.3.0
-[0.2.1]: https://github.com/athena-framework/console/releases/tag/v0.2.1
-[0.2.0]: https://github.com/athena-framework/console/releases/tag/v0.2.0
-[0.1.1]: https://github.com/athena-framework/console/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/console/releases/tag/v0.1.0

--- a/src/components/dependency_injection/CHANGELOG.md
+++ b/src/components/dependency_injection/CHANGELOG.md
@@ -4,66 +4,106 @@
 
 ### Changed
 
-- **Breaking:** prevent auto registering of already registered services ([#520](https://github.com/athena-framework/athena/pull/520)) (George Dietrich)
+- **Breaking:** prevent auto registering of already registered services ([#520]) (George Dietrich)
 
 ### Fixed
 
-- Ensure all array values have proper `#of` type ([#508](https://github.com/athena-framework/athena/pull/508)) (George Dietrich)
+- Ensure all array values have proper `#of` type ([#508]) (George Dietrich)
+
+[0.4.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.3
+[#508]: https://github.com/athena-framework/athena/pull/508
+[#520]: https://github.com/athena-framework/athena/pull/520
 
 ## [0.4.2] - 2025-01-26
 
 _Administrative release, no functional changes_
 
+[0.4.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.2
+
 ## [0.4.1] - 2024-07-31
 
 ### Changed
 
-- **Breaking:** single implementation aliases are now explicit ([#408](https://github.com/athena-framework/athena/pull/408)) (George Dietrich)
+- **Breaking:** single implementation aliases are now explicit ([#408]) (George Dietrich)
 
 ### Fixed
 
-- Fix default/nil values related to `object_of` and `array_of` being unavailable in bundle extensions ([#432](https://github.com/athena-framework/athena/pull/432)) (George Dietrich)
+- Fix default/nil values related to `object_of` and `array_of` being unavailable in bundle extensions ([#432]) (George Dietrich)
+
+[0.4.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.1
+[#408]: https://github.com/athena-framework/athena/pull/408
+[#432]: https://github.com/athena-framework/athena/pull/432
 
 ## [0.4.0] - 2024-04-09
 
 ### Changed
 
-- **Breaking:** remove `Clock`, `Console`, and `EventDispatcher` built-in integrations ([#337](https://github.com/athena-framework/athena/pull/337)) (George Dietrich)
-- **Breaking:** major internal refactor ([#337](https://github.com/athena-framework/athena/pull/337), [#378](https://github.com/athena-framework/athena/pull/378)) (George Dietrich)
-- **Breaking:** replace `ADI.auto_configure` with [ADI::Autoconfigure](https://athenaframework.org/DependencyInjection/Autoconfigure/) ([#387](https://github.com/athena-framework/athena/pull/387)) (George Dietrich)
-- **Breaking:** replace `alias` `ADI::Register` field with [ADI::AsAlias](https://athenaframework.org/DependencyInjection/AsAlias/) ([#389](https://github.com/athena-framework/athena/pull/389)) (George Dietrich)
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- **Breaking:** remove `Clock`, `Console`, and `EventDispatcher` built-in integrations ([#337]) (George Dietrich)
+- **Breaking:** major internal refactor ([#337], [#378]) (George Dietrich)
+- **Breaking:** replace `ADI.auto_configure` with [ADI::Autoconfigure](https://athenaframework.org/DependencyInjection/Autoconfigure/) ([#387]) (George Dietrich)
+- **Breaking:** replace `alias` `ADI::Register` field with [ADI::AsAlias](https://athenaframework.org/DependencyInjection/AsAlias/) ([#389]) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
 
 ### Added
 
-- Add ability to easily extend/customize the container ([#337](https://github.com/athena-framework/athena/pull/337), [#348](https://github.com/athena-framework/athena/pull/348), [#371](https://github.com/athena-framework/athena/pull/371), [#372](https://github.com/athena-framework/athena/pull/372), [#373](https://github.com/athena-framework/athena/pull/373), [#374](https://github.com/athena-framework/athena/pull/374), [#377](https://github.com/athena-framework/athena/pull/377), [#379](https://github.com/athena-framework/athena/pull/379), [#382](https://github.com/athena-framework/athena/pull/382), [#383](https://github.com/athena-framework/athena/pull/383)) (George Dietrich)
-- Add ability to define method calls that should be made during service instantiation ([#384](https://github.com/athena-framework/athena/pull/384)) (George Dietrich)
-- Add new [ADI::AutoconfigureTag](https://athenaframework.org/DependencyInjection/AutoconfigureTag/) and [ADI::TaggedIterator](https://athenaframework.org/DependencyInjection/TaggedIterator/) to make working with tagged services easier ([#387](https://github.com/athena-framework/athena/pull/387)) (George Dietrich)
-- Add `ADI.configuration_annotation` to `Athena::DependencyInjection` from `Athena::Config` ([#392](https://github.com/athena-framework/athena/pull/392)) (George Dietrich)
+- Add ability to easily extend/customize the container ([#337], [#348], [#371], [#372], [#373], [#374], [#377], [#379], [#382], [#383]) (George Dietrich)
+- Add ability to define method calls that should be made during service instantiation ([#384]) (George Dietrich)
+- Add new [ADI::AutoconfigureTag](https://athenaframework.org/DependencyInjection/AutoconfigureTag/) and [ADI::TaggedIterator](https://athenaframework.org/DependencyInjection/TaggedIterator/) to make working with tagged services easier ([#387]) (George Dietrich)
+- Add `ADI.configuration_annotation` to `Athena::DependencyInjection` from `Athena::Config` ([#392]) (George Dietrich)
+
+[0.4.0]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.0
+[#337]: https://github.com/athena-framework/athena/pull/337
+[#348]: https://github.com/athena-framework/athena/pull/348
+[#365]: https://github.com/athena-framework/athena/pull/365
+[#371]: https://github.com/athena-framework/athena/pull/371
+[#372]: https://github.com/athena-framework/athena/pull/372
+[#373]: https://github.com/athena-framework/athena/pull/373
+[#374]: https://github.com/athena-framework/athena/pull/374
+[#377]: https://github.com/athena-framework/athena/pull/377
+[#378]: https://github.com/athena-framework/athena/pull/378
+[#379]: https://github.com/athena-framework/athena/pull/379
+[#382]: https://github.com/athena-framework/athena/pull/382
+[#383]: https://github.com/athena-framework/athena/pull/383
+[#384]: https://github.com/athena-framework/athena/pull/384
+[#387]: https://github.com/athena-framework/athena/pull/387
+[#389]: https://github.com/athena-framework/athena/pull/389
+[#392]: https://github.com/athena-framework/athena/pull/392
 
 ## [0.3.8] - 2023-12-16
 
 ### Fixed
 
-- Avoid depending directly on Crystal macro types ([#335](https://github.com/athena-framework/athena/pull/335)) (George Dietrich)
+- Avoid depending directly on Crystal macro types ([#335]) (George Dietrich)
+
+[0.3.8]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.8
+[#335]: https://github.com/athena-framework/athena/pull/335
 
 ## [0.3.7] - 2023-10-09
 
 ### Added
 
-- Add integration between `Athena::DependencyInjection` and the `Athena::Clock` component ([#318](https://github.com/athena-framework/athena/pull/318)) (George Dietrich)
+- Add integration between `Athena::DependencyInjection` and the `Athena::Clock` component ([#318]) (George Dietrich)
+
+[0.3.7]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.7
+[#318]: https://github.com/athena-framework/athena/pull/318
 
 ## [0.3.6] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
+
+[0.3.6]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.6
+[#261]: https://github.com/athena-framework/athena/pull/261
 
 ## [0.3.5] - 2023-02-04
 
 ### Added
 
-- Add better integration between `Athena::DependencyInjection` and the `Athena::Console` and `Athena::EventDispatcher` components ([#259](https://github.com/athena-framework/athena/pull/259)) (George Dietrich)
+- Add better integration between `Athena::DependencyInjection` and the `Athena::Console` and `Athena::EventDispatcher` components ([#259]) (George Dietrich)
+
+[0.3.5]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.5
+[#259]: https://github.com/athena-framework/athena/pull/259
 
 ## [0.3.4] - 2023-01-07
 
@@ -71,83 +111,120 @@ _Administrative release, no functional changes_
 
 - Refactor various internal logic (George Dietrich)
 
+[0.3.4]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.4
+
 ## [0.3.3] - 2022-05-14
 
 _First release a part of the monorepo._
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Added
 
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
+
+[0.3.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.3
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#172]: https://github.com/athena-framework/athena/pull/172
 
 ## [0.3.2] - 2021-10-30
 
 ### Changed
 
-- Unused services are now excluded from the container ([#30](https://github.com/athena-framework/dependency-injection/pull/30)) (George Dietrich)
+- Unused services are now excluded from the container ([#30]) (George Dietrich)
+
+[0.3.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.2
+[#30]: https://github.com/athena-framework/dependency-injection/pull/30
 
 ## [0.3.1] - 2021-03-28
 
 ### Fixed
 
-- Fix error with untyped parameters with default values injecting ([#28](https://github.com/athena-framework/dependency-injection/pull/28)) (George Dietrich)
+- Fix error with untyped parameters with default values injecting ([#28]) (George Dietrich)
+
+[0.3.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.1
+[#28]: https://github.com/athena-framework/dependency-injection/pull/28
 
 ## [0.3.0] - 2021-03-20
 
 ### Added
 
-- Allow injecting [configuration](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--configuration) into services ([#27](https://github.com/athena-framework/dependency-injection/pull/27)) (George Dietrich)
+- Allow injecting [configuration](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--configuration) into services ([#27]) (George Dietrich)
+
+[0.3.0]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.0
+[#27]: https://github.com/athena-framework/dependency-injection/pull/27
 
 ## [0.2.6] - 2021-03-15
 
 ### Added
 
-- Allow using the `ADI::Inject` annotation on class methods to create [factories](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--factories) ([#25](https://github.com/athena-framework/dependency-injection/pull/25)) (George Dietrich)
+- Allow using the `ADI::Inject` annotation on class methods to create [factories](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--factories) ([#25]) (George Dietrich)
+
+[0.2.6]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.6
+[#25]: https://github.com/athena-framework/dependency-injection/pull/25
 
 ## [0.2.5] - 2021-01-30
 
 ### Changed
 
-- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#23](https://github.com/athena-framework/dependency-injection/pull/23), [#24](https://github.com/athena-framework/dependency-injection/pull/24)) (George Dietrich)
+- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#23], [#24]) (George Dietrich)
+
+[0.2.5]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.5
+[#23]: https://github.com/athena-framework/dependency-injection/pull/23
+[#24]: https://github.com/athena-framework/dependency-injection/pull/24
 
 ## [0.2.4] - 2021-01-29
 
 ### Added
 
-- Add dependency on `athena-framework/config` ([#20](https://github.com/athena-framework/dependency-injection/pull/20)) (George Dietrich)
-- Add support for injecting [parameters](https://athenaframework.org/architecture/config/#parameters) into a service ([#20](https://github.com/athena-framework/dependency-injection/pull/20)) (George Dietrich)
-- Add support for [service proxies](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--service-proxies) ([#21](https://github.com/athena-framework/dependency-injection/pull/21)) (George Dietrich)
+- Add dependency on `athena-framework/config` ([#20]) (George Dietrich)
+- Add support for injecting [parameters](https://athenaframework.org/architecture/config/#parameters) into a service ([#20]) (George Dietrich)
+- Add support for [service proxies](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--service-proxies) ([#21]) (George Dietrich)
 
 ### Removed
 
-- Remove the `lazy` `ADI::Register` field. All services are lazy by default now ([#21](https://github.com/athena-framework/dependency-injection/pull/21)) (George Dietrich)
+- Remove the `lazy` `ADI::Register` field. All services are lazy by default now ([#21]) (George Dietrich)
 
 ### Fixed
 
-- Fix issue building documentation ([#22](https://github.com/athena-framework/dependency-injection/pull/22)) (George Dietrich)
+- Fix issue building documentation ([#22]) (George Dietrich)
+
+[0.2.4]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.4
+[#20]: https://github.com/athena-framework/dependency-injection/pull/20
+[#21]: https://github.com/athena-framework/dependency-injection/pull/21
+[#22]: https://github.com/athena-framework/dependency-injection/pull/22
 
 ## [0.2.3] - 2020-12-24
 
 ### Fixed
 
-- Fix error when a parameter has a default value after an array parameter ([#19](https://github.com/athena-framework/dependency-injection/pull/19)) (George Dietrich)
+- Fix error when a parameter has a default value after an array parameter ([#19]) (George Dietrich)
+
+[0.2.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.3
+[#19]: https://github.com/athena-framework/dependency-injection/pull/19
 
 ## [0.2.2] - 2020-12-03
 
 ### Changed
 
-- Update `crystal` version to allow version greater than `1.0.0` ([#18](https://github.com/athena-framework/dependency-injection/pull/18)) (George Dietrich)
+- Update `crystal` version to allow version greater than `1.0.0` ([#18]) (George Dietrich)
+
+[0.2.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.2
+[#18]: https://github.com/athena-framework/dependency-injection/pull/18
 
 ## [0.2.1] - 2020-11-14
 
 ### Added
 
-- Add a mock container instance to allow mocking services ([#15](https://github.com/athena-framework/dependency-injection/pull/15)) (George Dietrich)
-- Add ability to customize the type of a service within the container ([#15](https://github.com/athena-framework/dependency-injection/pull/15)) (George Dietrich)
-- Add support for [factory pattern](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--factories) constructors ([#16](https://github.com/athena-framework/dependency-injection/pull/16)) (George Dietrich)
+- Add a mock container instance to allow mocking services ([#15]) (George Dietrich)
+- Add ability to customize the type of a service within the container ([#15]) (George Dietrich)
+- Add support for [factory pattern](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--factories) constructors ([#16]) (George Dietrich)
+
+[0.2.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.1
+[#15]: https://github.com/athena-framework/dependency-injection/pull/15
+[#16]: https://github.com/athena-framework/dependency-injection/pull/16
 
 ## [0.2.0] - 2020-06-09
 
@@ -155,69 +232,58 @@ _Major refactor of the component._
 
 ### Added
 
-- Add concept of [aliasing services](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--aliasing-services) ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- Add concept of [binding values](https://athenaframework.org/DependencyInjection/#Athena::DependencyInjection:bind(key,value)) ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- Add concept of [auto configuration](https://athenaframework.org/DependencyInjection/#Athena::DependencyInjection:auto_configure(type,options)) ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- Add [ADI::Inject](https://athenaframework.org/DependencyInjection/Inject/) annotation ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- Add support for [generic services](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--generic-services) ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
+- Add concept of [aliasing services](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--aliasing-services) ([#10]) (George Dietrich)
+- Add concept of [binding values](https://athenaframework.org/DependencyInjection/#Athena::DependencyInjection:bind(key,value)) ([#10]) (George Dietrich)
+- Add concept of [auto configuration](https://athenaframework.org/DependencyInjection/#Athena::DependencyInjection:auto_configure(type,options)) ([#10]) (George Dietrich)
+- Add [ADI::Inject](https://athenaframework.org/DependencyInjection/Inject/) annotation ([#10]) (George Dietrich)
+- Add support for [generic services](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--generic-services) ([#10]) (George Dietrich)
 
 ### Changed
 
-- **Breaking:** manually provided arguments now need to be prefixed with a `_` ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- **Breaking:** service names are now based on the `FQN` of the type, downcase underscored by default ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- Updated [optional services](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--optional-services) to now be based on the type/default value of the parameter ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- Service dependencies are now resolved automatically, removes need to manually provide them ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
+- **Breaking:** manually provided arguments now need to be prefixed with a `_` ([#10]) (George Dietrich)
+- **Breaking:** service names are now based on the `FQN` of the type, downcase underscored by default ([#10]) (George Dietrich)
+- Updated [optional services](https://athenaframework.org/DependencyInjection/Register/#Athena::DependencyInjection::Register--optional-services) to now be based on the type/default value of the parameter ([#10]) (George Dietrich)
+- Service dependencies are now resolved automatically, removes need to manually provide them ([#10]) (George Dietrich)
 
 ### Removed
 
-- **Breaking:** remove the `ADI::Service` module ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- **Breaking:** remove the `ADI::Injectable` module ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- **Breaking:** remove the `@?` syntax ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
-- **Breaking:** remove the `#get`, `#has`, `#resolve`, `#tagged`, and `#tags` methods from `ADI::ServiceContainer` ([#10](https://github.com/athena-framework/dependency-injection/pull/10)) (George Dietrich)
+- **Breaking:** remove the `ADI::Service` module ([#10]) (George Dietrich)
+- **Breaking:** remove the `ADI::Injectable` module ([#10]) (George Dietrich)
+- **Breaking:** remove the `@?` syntax ([#10]) (George Dietrich)
+- **Breaking:** remove the `#get`, `#has`, `#resolve`, `#tagged`, and `#tags` methods from `ADI::ServiceContainer` ([#10]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.0
+[#10]: https://github.com/athena-framework/dependency-injection/pull/10
 
 ## [0.1.3] - 2020-04-06
 
 ### Fixed
 
-- Fix an edge case by checking includers via `<=` ([#7](https://github.com/athena-framework/dependency-injection/pull/7)) (George Dietrich)
+- Fix an edge case by checking includers via `<=` ([#7]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.1.3
+[#7]: https://github.com/athena-framework/dependency-injection/pull/7
 
 ## [0.1.2] - 2020-02-22
 
 ### Changed
 
-- Change type resolution logic to operate at compile time instead of runtime ([#6](https://github.com/athena-framework/dependency-injection/pull/6)) (George Dietrich)
+- Change type resolution logic to operate at compile time instead of runtime ([#6]) (George Dietrich)
+
+[0.1.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.1.2
+[#6]: https://github.com/athena-framework/dependency-injection/pull/6
 
 ## [0.1.1] - 2020-02-06
 
 ### Added
 
-- Add the ability to redefine services ([#4](https://github.com/athena-framework/dependency-injection/pull/4)) (George Dietrich)
+- Add the ability to redefine services ([#4]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.1.1
+[#4]: https://github.com/athena-framework/dependency-injection/pull/4
 
 ## [0.1.0] - 2020-01-31
 
 _Initial release._
 
-[0.4.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.3
-[0.4.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.2
-[0.4.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.1
-[0.4.0]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.4.0
-[0.3.8]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.8
-[0.3.7]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.7
-[0.3.6]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.6
-[0.3.5]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.5
-[0.3.4]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.4
-[0.3.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.3
-[0.3.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.2
-[0.3.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.1
-[0.3.0]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.3.0
-[0.2.6]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.6
-[0.2.5]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.5
-[0.2.4]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.4
-[0.2.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.3
-[0.2.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.2
-[0.2.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.1
-[0.2.0]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.2.0
-[0.1.3]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/dependency-injection/releases/tag/v0.1.0

--- a/src/components/dotenv/CHANGELOG.md
+++ b/src/components/dotenv/CHANGELOG.md
@@ -4,38 +4,47 @@
 
 ### Changed
 
-- **Breaking:** Normalize exception types ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
+- **Breaking:** Normalize exception types ([#428]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/dotenv/releases/tag/v0.2.0
+[#428]: https://github.com/athena-framework/athena/pull/428
 
 ## [0.1.3] - 2024-07-31
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.13.0` ([#433](https://github.com/athena-framework/athena/pull/433)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.13.0` ([#433]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/dotenv/releases/tag/v0.1.3
+[#433]: https://github.com/athena-framework/athena/pull/433
 
 ## [0.1.2] - 2024-04-09
 
 ### Changed
 
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
 
 ### Added
 
-- Add helper `Athena::Dotenv.load` method to create and load `.env` files in one call ([#363](https://github.com/athena-framework/athena/pull/363)) (George Dietrich)
+- Add helper `Athena::Dotenv.load` method to create and load `.env` files in one call ([#363]) (George Dietrich)
 
 ### Fixed
 
-- Fixed error parsing ENV vars starting with `_` ([#346](https://github.com/athena-framework/athena/pull/346)) (George Dietrich)
+- Fixed error parsing ENV vars starting with `_` ([#346]) (George Dietrich)
+
+[0.1.2]: https://github.com/athena-framework/dotenv/releases/tag/v0.1.2
+[#346]: https://github.com/athena-framework/athena/pull/346
+[#363]: https://github.com/athena-framework/athena/pull/363
+[#365]: https://github.com/athena-framework/athena/pull/365
 
 ## [0.1.1] - 2023-10-09
 
 _Administrative release, no functional changes_
 
+[0.1.1]: https://github.com/athena-framework/dotenv/releases/tag/v0.1.1
+
 ## [0.1.0] - 2023-04-23
 
 _Initial release._
 
-[0.2.0]: https://github.com/athena-framework/dotenv/releases/tag/v0.2.0
-[0.1.3]: https://github.com/athena-framework/dotenv/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/dotenv/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/dotenv/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/dotenv/releases/tag/v0.1.0

--- a/src/components/event_dispatcher/CHANGELOG.md
+++ b/src/components/event_dispatcher/CHANGELOG.md
@@ -4,52 +4,69 @@
 
 _Administrative release, no functional changes_
 
+[0.3.1]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.3.1
+
 ## [0.3.0] - 2024-04-09
 
 ### Changed
 
-- **Breaking:** remove `AED::EventListenerInterface` ([#391](https://github.com/athena-framework/athena/pull/391)) (George Dietrich)
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- **Breaking:** remove `AED::EventListenerInterface` ([#391]) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
+
+[0.3.0]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.3.0
+[#365]: https://github.com/athena-framework/athena/pull/365
+[#391]: https://github.com/athena-framework/athena/pull/391
 
 ## [0.2.3] - 2023-10-09
 
 _Administrative release, no functional changes_
 
+[0.2.3]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.3
+
 ## [0.2.2] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
+
+[0.2.2]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.2
+[#261]: https://github.com/athena-framework/athena/pull/261
 
 ## [0.2.1] - 2023-02-04
 
 ### Added
 
-- Add better integration between `Athena::EventDispatcher` and `Athena::DependencyInjection` ([#259](https://github.com/athena-framework/athena/pull/259)) (George Dietrich)
+- Add better integration between `Athena::EventDispatcher` and `Athena::DependencyInjection` ([#259]) (George Dietrich)
+
+[0.2.1]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.1
+[#259]: https://github.com/athena-framework/athena/pull/259
 
 ## [0.2.0] - 2023-01-07
 
 ### Changed
 
-- **Breaking:** refactor how listeners are registered to use the new `AEDA::AsEventListener` annotation on the method instead of the `self.subscribed_events` class method ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** refactor and rename the majority of `AED::EventDispatcherInterface` API ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** change the representation of a listener when returned from a dispatcher to be an `AED::Callable` instance ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** refactor `AED::Event` to now be `abstract` ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
+- **Breaking:** refactor how listeners are registered to use the new `AEDA::AsEventListener` annotation on the method instead of the `self.subscribed_events` class method ([#236]) (George Dietrich)
+- **Breaking:** refactor and rename the majority of `AED::EventDispatcherInterface` API ([#236]) (George Dietrich)
+- **Breaking:** change the representation of a listener when returned from a dispatcher to be an `AED::Callable` instance ([#236]) (George Dietrich)
+- **Breaking:** refactor `AED::Event` to now be `abstract` ([#236]) (George Dietrich)
 
 ### Added
 
-- Add `AED::GenericEvent` that can be used for convenience within simple use cases ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- Add the ability to use a listener method without the `AED::EventDispatcherInterface` parameter ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
+- Add `AED::GenericEvent` that can be used for convenience within simple use cases ([#236]) (George Dietrich)
+- Add the ability to use a listener method without the `AED::EventDispatcherInterface` parameter ([#236]) (George Dietrich)
 
 ### Removed
 
-- **Breaking:** remove ability for listeners to automatically be registered with the dispatcher ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** remove the `AED::EventDispatcher.new` constructor that accepts an `Array(AED::EventListenerInterface)` ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** remove the `AED::EventListenerType` alias ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** remove the `AED::SubscribedEvents` alias ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** remove the `AED::EventListener` struct ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- **Breaking:** remove the `AED.create_listener` method ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
-- Remove the requirement that listeners methods need to be called `call` ([#236](https://github.com/athena-framework/athena/pull/236)) (George Dietrich)
+- **Breaking:** remove ability for listeners to automatically be registered with the dispatcher ([#236]) (George Dietrich)
+- **Breaking:** remove the `AED::EventDispatcher.new` constructor that accepts an `Array(AED::EventListenerInterface)` ([#236]) (George Dietrich)
+- **Breaking:** remove the `AED::EventListenerType` alias ([#236]) (George Dietrich)
+- **Breaking:** remove the `AED::SubscribedEvents` alias ([#236]) (George Dietrich)
+- **Breaking:** remove the `AED::EventListener` struct ([#236]) (George Dietrich)
+- **Breaking:** remove the `AED.create_listener` method ([#236]) (George Dietrich)
+- Remove the requirement that listeners methods need to be called `call` ([#236]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.0
+[#236]: https://github.com/athena-framework/athena/pull/236
 
 ## [0.1.4] - 2022-05-14
 
@@ -57,46 +74,50 @@ _First release a part of the monorepo._
 
 ### Added
 
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Fixed
 
-- Fix the `VERSION` constant's value ([#166](https://github.com/athena-framework/athena/pull/166)) (George Dietrich)
+- Fix the `VERSION` constant's value ([#166]) (George Dietrich)
+
+[0.1.4]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.4
+[#166]: https://github.com/athena-framework/athena/pull/166
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#172]: https://github.com/athena-framework/athena/pull/172
 
 ## [0.1.3] - 2021-01-29
 
 ### Changed
 
-- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#14](https://github.com/athena-framework/event-dispatcher/pull/14)) (George Dietrich)
+- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#14]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.3
+[#14]: https://github.com/athena-framework/event-dispatcher/pull/14
 
 ## [0.1.2] - 2020-12-03
 
 ### Changed
 
-- Update `crystal` version to allow version greater than `1.0.0` ([#13](https://github.com/athena-framework/event-dispatcher/pull/13)) (George Dietrich)
+- Update `crystal` version to allow version greater than `1.0.0` ([#13]) (George Dietrich)
+
+[0.1.2]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.2
+[#13]: https://github.com/athena-framework/event-dispatcher/pull/13
 
 ## [0.1.1] - 2020-11-12
 
 ### Added
 
-- Add the [AED::Spec](https://athenaframework.org/EventDispatcher/Spec/) module to provide helpful testing utilities ([#11](https://github.com/athena-framework/event-dispatcher/pull/11)) (George Dietrich)
+- Add the [AED::Spec](https://athenaframework.org/EventDispatcher/Spec/) module to provide helpful testing utilities ([#11]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.1
+[#11]: https://github.com/athena-framework/event-dispatcher/pull/11
 
 ## [0.1.0] - 2020-01-11
 
 _Initial release._
 
-[0.3.1]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.3.1
-[0.3.0]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.3.0
-[0.2.3]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.3
-[0.2.2]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.2
-[0.2.1]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.1
-[0.2.0]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.2.0
-[0.1.4]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.4
-[0.1.3]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/event-dispatcher/releases/tag/v0.1.0

--- a/src/components/framework/CHANGELOG.md
+++ b/src/components/framework/CHANGELOG.md
@@ -4,165 +4,242 @@
 
 ### Fixed
 
-- Fix `ATH::ViewHandler` bundle configuration values not being correctly set ([#520](https://github.com/athena-framework/athena/pull/520)) (George Dietrich)
+- Fix `ATH::ViewHandler` bundle configuration values not being correctly set ([#520]) (George Dietrich)
+
+[0.20.1]: https://github.com/athena-framework/framework/releases/tag/v0.20.1
+[#520]: https://github.com/athena-framework/athena/pull/520
 
 ## [0.20.0] - 2025-01-26
 
 ### Changed
 
-- **Breaking:** Normalize exception types ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
-- **Breaking:** The `ATHR::Interface.configuration` macro is no longer scoped to the resolver namespace ([#425](https://github.com/athena-framework/athena/pull/425)) (George Dietrich)
-- **Breaking:** Rename `ATHR::RequestBody::Extract` to `ATHA::MapRequestBody` ([#425](https://github.com/athena-framework/athena/pull/425)) (George Dietrich)
-- **Breaking:** Rename `ATHR::Time::Format` to `ATHA::MapTime` ([#425](https://github.com/athena-framework/athena/pull/425)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.14.0` ([#433](https://github.com/athena-framework/athena/pull/433)) (George Dietrich)
-- Refactor auto redirection logic to be more robust ([#436](https://github.com/athena-framework/athena/pull/436), [#480](https://github.com/athena-framework/athena/pull/480)) (George Dietrich)
-- Refactor `ATHR::RequestBody` to raise more accurate deserialization errors ([#490](https://github.com/athena-framework/athena/pull/490)) (George Dietrich)
+- **Breaking:** Normalize exception types ([#428]) (George Dietrich)
+- **Breaking:** The `ATHR::Interface.configuration` macro is no longer scoped to the resolver namespace ([#425]) (George Dietrich)
+- **Breaking:** Rename `ATHR::RequestBody::Extract` to `ATHA::MapRequestBody` ([#425]) (George Dietrich)
+- **Breaking:** Rename `ATHR::Time::Format` to `ATHA::MapTime` ([#425]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.14.0` ([#433]) (George Dietrich)
+- Refactor auto redirection logic to be more robust ([#436], [#480]) (George Dietrich)
+- Refactor `ATHR::RequestBody` to raise more accurate deserialization errors ([#490]) (George Dietrich)
 
 ### Added
 
-- Add support for [Proxies & Load Balancers](https://athenaframework.org/guides/proxies/) ([#440](https://github.com/athena-framework/athena/pull/440), [#444](https://github.com/athena-framework/athena/pull/444)) (George Dietrich)
-- Add new `trusted_host` bundle scheme property to allow setting trusted hostnames ([#474](https://github.com/athena-framework/athena/pull/474)) (George Dietrich)
-- Add support for deserializing `application/x-www-form-urlencoded` bodies via `ATHA::MapRequestBody` ([#477](https://github.com/athena-framework/athena/pull/477)) (George Dietrich)
-- Add `ATHA::MapQueryString` to map a request's query string into a DTO type ([#477](https://github.com/athena-framework/athena/pull/477)) (George Dietrich)
-- Add `ATH::Exception.from_status` helper method ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
-- Add `ATHA::MapQueryParameter` for handling query parameters ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
-- Add `#validation_groups` and `#accept_formats` annotation properties to `ATHA::MapRequestBody` ([#486](https://github.com/athena-framework/athena/pull/486)) (George Dietrich)
-- Add `#validation_groups` annotation property to `ATHA::MapQueryString` ([#486](https://github.com/athena-framework/athena/pull/486)) (George Dietrich)
-- Add `ATH::Request#port` and `ATH::Response#redirect?` methods ([#436](https://github.com/athena-framework/athena/pull/436)) (George Dietrich)
-- Add `#host`, `#scheme`, `#secure?`, and `#from_trusted_proxy?` methods to `ATH::Request` ([#440](https://github.com/athena-framework/athena/pull/440)) (George Dietrich)
-- Add `ATH::Request#content_type_format` to return the request format's name from its `content-type` header ([#477](https://github.com/athena-framework/athena/pull/477)) (George Dietrich)
-- Add `ATH::IPUtils` module ([#440](https://github.com/athena-framework/athena/pull/440)) (George Dietrich)
-- Add `.unquote`, `.split`, and `.combine` methods `ATH::HeaderUtils` ([#440](https://github.com/athena-framework/athena/pull/440)) (George Dietrich)
-- Add request matchers for headers and query parameters ([#491](https://github.com/athena-framework/athena/pull/491)) (George Dietrich)
+- Add support for [Proxies & Load Balancers](https://athenaframework.org/guides/proxies/) ([#440], [#444]) (George Dietrich)
+- Add new `trusted_host` bundle scheme property to allow setting trusted hostnames ([#474]) (George Dietrich)
+- Add support for deserializing `application/x-www-form-urlencoded` bodies via `ATHA::MapRequestBody` ([#477]) (George Dietrich)
+- Add `ATHA::MapQueryString` to map a request's query string into a DTO type ([#477]) (George Dietrich)
+- Add `ATH::Exception.from_status` helper method ([#426]) (George Dietrich)
+- Add `ATHA::MapQueryParameter` for handling query parameters ([#426]) (George Dietrich)
+- Add `#validation_groups` and `#accept_formats` annotation properties to `ATHA::MapRequestBody` ([#486]) (George Dietrich)
+- Add `#validation_groups` annotation property to `ATHA::MapQueryString` ([#486]) (George Dietrich)
+- Add `ATH::Request#port` and `ATH::Response#redirect?` methods ([#436]) (George Dietrich)
+- Add `#host`, `#scheme`, `#secure?`, and `#from_trusted_proxy?` methods to `ATH::Request` ([#440]) (George Dietrich)
+- Add `ATH::Request#content_type_format` to return the request format's name from its `content-type` header ([#477]) (George Dietrich)
+- Add `ATH::IPUtils` module ([#440]) (George Dietrich)
+- Add `.unquote`, `.split`, and `.combine` methods `ATH::HeaderUtils` ([#440]) (George Dietrich)
+- Add request matchers for headers and query parameters ([#491]) (George Dietrich)
 
 ### Removed
 
-- **Breaking:** Remove `ATHA::QueryParam` ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
-- **Breaking:** Remove `ATHA::RequestParam` ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
-- **Breaking:** Remove `ATH::Exception::InvalidParameter` ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
-- **Breaking:** Remove everything within `ATH::Params` namespace ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
-- **Breaking:** Remove `ATH::Action#params` ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
-- **Breaking:** Remove `ATH::Listeners::ParamFetcher` ([#426](https://github.com/athena-framework/athena/pull/426)) (George Dietrich)
+- **Breaking:** Remove `ATHA::QueryParam` ([#426]) (George Dietrich)
+- **Breaking:** Remove `ATHA::RequestParam` ([#426]) (George Dietrich)
+- **Breaking:** Remove `ATH::Exception::InvalidParameter` ([#426]) (George Dietrich)
+- **Breaking:** Remove everything within `ATH::Params` namespace ([#426]) (George Dietrich)
+- **Breaking:** Remove `ATH::Action#params` ([#426]) (George Dietrich)
+- **Breaking:** Remove `ATH::Listeners::ParamFetcher` ([#426]) (George Dietrich)
 
 ### Fixed
 
-- Fix query parameters being dropped when redirecting to a trailing/non-trailing slash endpoint ([#436](https://github.com/athena-framework/athena/pull/436)) (George Dietrich)
-- Fix auto redirection with non-standard ports ([#480](https://github.com/athena-framework/athena/pull/480)) (George Dietrich)
-- Fix `multipart/form-data` not being mapped to the `form` format ([#441](https://github.com/athena-framework/athena/pull/441)) (George Dietrich)
-- Fix being unable to provide the path of an `ARTA::Route` annotation on a class as a positional argument ([#482](https://github.com/athena-framework/athena/pull/482)) (George Dietrich)
-- Fix error when attempting to use `ATH::Controller#redirect_view` and `ATH::Controller#route_redirect_view` ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
-- Fix error when attempting to use `ATH::Spec::APITestCase#unlink` ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
+- Fix query parameters being dropped when redirecting to a trailing/non-trailing slash endpoint ([#436]) (George Dietrich)
+- Fix auto redirection with non-standard ports ([#480]) (George Dietrich)
+- Fix `multipart/form-data` not being mapped to the `form` format ([#441]) (George Dietrich)
+- Fix being unable to provide the path of an `ARTA::Route` annotation on a class as a positional argument ([#482]) (George Dietrich)
+- Fix error when attempting to use `ATH::Controller#redirect_view` and `ATH::Controller#route_redirect_view` ([#498]) (George Dietrich)
+- Fix error when attempting to use `ATH::Spec::APITestCase#unlink` ([#498]) (George Dietrich)
+
+[0.20.0]: https://github.com/athena-framework/framework/releases/tag/v0.20.0
+[#425]: https://github.com/athena-framework/athena/pull/425
+[#426]: https://github.com/athena-framework/athena/pull/426
+[#428]: https://github.com/athena-framework/athena/pull/428
+[#433]: https://github.com/athena-framework/athena/pull/433
+[#436]: https://github.com/athena-framework/athena/pull/436
+[#440]: https://github.com/athena-framework/athena/pull/440
+[#441]: https://github.com/athena-framework/athena/pull/441
+[#444]: https://github.com/athena-framework/athena/pull/444
+[#474]: https://github.com/athena-framework/athena/pull/474
+[#477]: https://github.com/athena-framework/athena/pull/477
+[#480]: https://github.com/athena-framework/athena/pull/480
+[#482]: https://github.com/athena-framework/athena/pull/482
+[#486]: https://github.com/athena-framework/athena/pull/486
+[#490]: https://github.com/athena-framework/athena/pull/490
+[#491]: https://github.com/athena-framework/athena/pull/491
+[#498]: https://github.com/athena-framework/athena/pull/498
 
 ## [0.19.2] - 2024-07-31
 
 ### Added
 
-- Add `ATH.run_console` as an easier entrypoint into the console application ([#413](https://github.com/athena-framework/athena/pull/413)) (George Dietrich)
-- Add support for additional boolean conversion values from request attributes ([#422](https://github.com/athena-framework/athena/pull/422)) (George Dietrich)
+- Add `ATH.run_console` as an easier entrypoint into the console application ([#413]) (George Dietrich)
+- Add support for additional boolean conversion values from request attributes ([#422]) (George Dietrich)
 
 ### Changed
 
-- **Breaking:** `ATH::RequestMatcher::Method` now requires an `Array(String)` as opposed to any `Enumerable(String)` ([#431](https://github.com/athena-framework/athena/pull/431)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.13.0` ([#433](https://github.com/athena-framework/athena/pull/433)) (George Dietrich)
-- Updates usages of `UTF-8` in response headers to `utf-8` as preferred by the RFC ([#417](https://github.com/athena-framework/athena/pull/417)) (George Dietrich)
+- **Breaking:** `ATH::RequestMatcher::Method` now requires an `Array(String)` as opposed to any `Enumerable(String)` ([#431]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.13.0` ([#433]) (George Dietrich)
+- Updates usages of `UTF-8` in response headers to `utf-8` as preferred by the RFC ([#417]) (George Dietrich)
 
 ### Fixed
 
-- Fix the content negotiation implementation not working ([#431](https://github.com/athena-framework/athena/pull/431)) (George Dietrich)
+- Fix the content negotiation implementation not working ([#431]) (George Dietrich)
+
+[0.19.2]: https://github.com/athena-framework/framework/releases/tag/v0.19.2
+[#413]: https://github.com/athena-framework/athena/pull/413
+[#417]: https://github.com/athena-framework/athena/pull/417
+[#422]: https://github.com/athena-framework/athena/pull/422
+[#431]: https://github.com/athena-framework/athena/pull/431
+[#433]: https://github.com/athena-framework/athena/pull/433
 
 ## [0.19.1] - 2024-04-27
 
 ### Fixed
 
-- Fix `framework` component docs landing on an empty page ([#399](https://github.com/athena-framework/athena/pull/399)) (George Dietrich)
-- Fix `Athena::Clock` not being aliased to the interface correctly ([#400](https://github.com/athena-framework/athena/pull/400)) (George Dietrich)
-- Fix `ATHA::View` annotation being defined in incorrect namespace ([#403](https://github.com/athena-framework/athena/pull/403)) (George Dietrich)
-- Fix `ATH::ErrorRenderer` not being aliased to the interface correctly ([#404](https://github.com/athena-framework/athena/pull/404)) (George Dietrich)
+- Fix `framework` component docs landing on an empty page ([#399]) (George Dietrich)
+- Fix `Athena::Clock` not being aliased to the interface correctly ([#400]) (George Dietrich)
+- Fix `ATHA::View` annotation being defined in incorrect namespace ([#403]) (George Dietrich)
+- Fix `ATH::ErrorRenderer` not being aliased to the interface correctly ([#404]) (George Dietrich)
+
+[0.19.1]: https://github.com/athena-framework/framework/releases/tag/v0.19.1
+[#399]: https://github.com/athena-framework/athena/pull/399
+[#400]: https://github.com/athena-framework/athena/pull/400
+[#403]: https://github.com/athena-framework/athena/pull/403
+[#404]: https://github.com/athena-framework/athena/pull/404
 
 ## [0.19.0] - 2024-04-09
 
 ### Changed
 
-- **Breaking:** change how framework features are configured ([#337](https://github.com/athena-framework/athena/pull/337), [#374](https://github.com/athena-framework/athena/pull/374), [#383](https://github.com/athena-framework/athena/pull/383)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.11.0` ([#270](https://github.com/athena-framework/athena/pull/270)) (George Dietrich)
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- **Breaking:** change how framework features are configured ([#337], [#374], [#383]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.11.0` ([#270]) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
 
 ### Added
 
-- Support for Windows OS ([#270](https://github.com/athena-framework/athena/pull/270)) (George Dietrich)
-- Add `ATH::RequestMatcher` as a generic way of matching an `ATH::Request` given a set of rules ([#338](https://github.com/athena-framework/athena/pull/338)) (George Dietrich)
-- Raise an exception if a controller's return value fails to serialize instead of just returning `nil` ([#357](https://github.com/athena-framework/athena/pull/357)) (George Dietrich)
-- Add support for new Crystal 1.12 `Process.on_terminate` method ([#394](https://github.com/athena-framework/athena/pull/394)) (George Dietrich)
+- Support for Windows OS ([#270]) (George Dietrich)
+- Add `ATH::RequestMatcher` as a generic way of matching an `ATH::Request` given a set of rules ([#338]) (George Dietrich)
+- Raise an exception if a controller's return value fails to serialize instead of just returning `nil` ([#357]) (George Dietrich)
+- Add support for new Crystal 1.12 `Process.on_terminate` method ([#394]) (George Dietrich)
 
 ### Fixed
 
-- Fix macro splat deprecation ([#330](https://github.com/athena-framework/athena/pull/330)) (George Dietrich)
-- Normalize `ATH::Request#method` to always be uppercase ([#338](https://github.com/athena-framework/athena/pull/338)) (George Dietrich)
-- Fixed not being able to use top level configuration annotations on controller action parameters ([#356](https://github.com/athena-framework/athena/pull/356)) (George Dietrich)
+- Fix macro splat deprecation ([#330]) (George Dietrich)
+- Normalize `ATH::Request#method` to always be uppercase ([#338]) (George Dietrich)
+- Fixed not being able to use top level configuration annotations on controller action parameters ([#356]) (George Dietrich)
+
+[0.19.0]: https://github.com/athena-framework/framework/releases/tag/v0.19.0
+[#270]: https://github.com/athena-framework/athena/pull/270
+[#330]: https://github.com/athena-framework/athena/pull/330
+[#337]: https://github.com/athena-framework/athena/pull/337
+[#338]: https://github.com/athena-framework/athena/pull/338
+[#356]: https://github.com/athena-framework/athena/pull/356
+[#357]: https://github.com/athena-framework/athena/pull/357
+[#365]: https://github.com/athena-framework/athena/pull/365
+[#374]: https://github.com/athena-framework/athena/pull/374
+[#383]: https://github.com/athena-framework/athena/pull/383
+[#394]: https://github.com/athena-framework/athena/pull/394
 
 ## [0.18.2] - 2023-10-09
 
 ### Changed
 
-- Change routing logic to redirect `GET` and `HEAD` requests with a trailing slash to the route without one if it exists, and vice versa ([#307](https://github.com/athena-framework/athena/pull/307)) (George Dietrich)
+- Change routing logic to redirect `GET` and `HEAD` requests with a trailing slash to the route without one if it exists, and vice versa ([#307]) (George Dietrich)
 
 ### Added
 
-- Add native tab completion support to the built-in `ATH::Commands` ([#296](https://github.com/athena-framework/athena/pull/296)) (George Dietrich)
-- Add support for defining multiple route annotations on a single controller action method ([#315](https://github.com/athena-framework/athena/pull/315)) (George Dietrich)
-- Require the new `Athena::Clock` component ([#318](https://github.com/athena-framework/athena/pull/318)) (George Dietrich)
-- Add additional `ATH::Spec::APITestCase` request helper methods ([#312](https://github.com/athena-framework/athena/pull/312), [#313](https://github.com/athena-framework/athena/pull/313)) (George Dietrich)
+- Add native tab completion support to the built-in `ATH::Commands` ([#296]) (George Dietrich)
+- Add support for defining multiple route annotations on a single controller action method ([#315]) (George Dietrich)
+- Require the new `Athena::Clock` component ([#318]) (George Dietrich)
+- Add additional `ATH::Spec::APITestCase` request helper methods ([#312], [#313]) (George Dietrich)
 
 ### Fixed
 
-- Fix incorrectly generated route paths with a controller level prefix and no action level `/` prefix ([#308](https://github.com/athena-framework/athena/pull/308)) (George Dietrich)
+- Fix incorrectly generated route paths with a controller level prefix and no action level `/` prefix ([#308]) (George Dietrich)
+
+[0.18.2]: https://github.com/athena-framework/framework/releases/tag/v0.18.2
+[#296]: https://github.com/athena-framework/athena/pull/296
+[#307]: https://github.com/athena-framework/athena/pull/307
+[#308]: https://github.com/athena-framework/athena/pull/308
+[#312]: https://github.com/athena-framework/athena/pull/312
+[#313]: https://github.com/athena-framework/athena/pull/313
+[#315]: https://github.com/athena-framework/athena/pull/315
+[#318]: https://github.com/athena-framework/athena/pull/318
 
 ## [0.18.1] - 2023-05-29
 
 ### Added
 
-- Add support for serializing arbitrarily nested controller action return types ([#273](https://github.com/athena-framework/athena/pull/273)) (George Dietrich)
-- Allow using constants for controller action's `path` ([#279](https://github.com/athena-framework/athena/pull/279)) (George Dietrich)
+- Add support for serializing arbitrarily nested controller action return types ([#273]) (George Dietrich)
+- Allow using constants for controller action's `path` ([#279]) (George Dietrich)
 
 ### Fixed
 
-- Fix incorrect `content-length` header value when returning multi-byte strings ([#288](https://github.com/athena-framework/athena/pull/288)) (George Dietrich)
+- Fix incorrect `content-length` header value when returning multi-byte strings ([#288]) (George Dietrich)
+
+[0.18.1]: https://github.com/athena-framework/framework/releases/tag/v0.18.1
+[#273]: https://github.com/athena-framework/athena/pull/273
+[#279]: https://github.com/athena-framework/athena/pull/279
+[#288]: https://github.com/athena-framework/athena/pull/288
 
 ## [0.18.0] - 2023-02-20
 
 ### Changed
 
-- **Breaking:** upgrade [Athena::EventDispatcher](https://athenaframework.org/EventDispatcher/) to [0.2.x](https://github.com/athena-framework/event-dispatcher/blob/master/CHANGELOG.md#020---2023-01-07) ([#205](https://github.com/athena-framework/athena/pull/205)) (George Dietrich)
-- **Breaking:** deprecate the `ATH::ParamConverter` concept in favor of [Value Resolvers](https://athenaframework.org/Framework/Controller/ValueResolvers/Interface) ([#243](https://github.com/athena-framework/athena/pull/243)) (George Dietrich)
-- **Breaking:** rename various types/methods to better adhere to https://github.com/crystal-lang/crystal/issues/10374 ([#243](https://github.com/athena-framework/athena/pull/243)) (George Dietrich)
-- **Breaking:** Change `ATH::Spec::AbstractBrowser` to be a `class` ([#249](https://github.com/athena-framework/athena/pull/249)) (George Dietrich)
-- **Breaking:** upgrade [Athena::Validator](https://athenaframework.org/Validator/) to [0.3.x](https://github.com/athena-framework/validator/blob/master/CHANGELOG.md#030---2023-01-07) ([#250](https://github.com/athena-framework/athena/pull/250)) (George Dietrich)
-- Improve service `ATH::Controller`s to not need the `public: true` `ADI::Register` field ([#213](https://github.com/athena-framework/athena/pull/213)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.6.0` ([#205](https://github.com/athena-framework/athena/pull/205)) (George Dietrich)
+- **Breaking:** upgrade [Athena::EventDispatcher](https://athenaframework.org/EventDispatcher/) to [0.2.x](https://github.com/athena-framework/event-dispatcher/blob/master/CHANGELOG.md#020---2023-01-07) ([#205]) (George Dietrich)
+- **Breaking:** deprecate the `ATH::ParamConverter` concept in favor of [Value Resolvers](https://athenaframework.org/Framework/Controller/ValueResolvers/Interface) ([#243]) (George Dietrich)
+- **Breaking:** rename various types/methods to better adhere to https://github.com/crystal-lang/crystal/issues/10374 ([#243]) (George Dietrich)
+- **Breaking:** Change `ATH::Spec::AbstractBrowser` to be a `class` ([#249]) (George Dietrich)
+- **Breaking:** upgrade [Athena::Validator](https://athenaframework.org/Validator/) to [0.3.x](https://github.com/athena-framework/validator/blob/master/CHANGELOG.md#030---2023-01-07) ([#250]) (George Dietrich)
+- Improve service `ATH::Controller`s to not need the `public: true` `ADI::Register` field ([#213]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.6.0` ([#205]) (George Dietrich)
 
 ### Added
 
-- Add trace logging to `ATH::Listeners::CORS` to aid in debugging ([#265](https://github.com/athena-framework/athena/pull/265)) (George Dietrich)
-- Introduce new `framework.debug` parameter that is `true` if the binary was _not_ built with the `--release` flag ([#249](https://github.com/athena-framework/athena/pull/249)) (George Dietrich)
-- Add built-in [HTTP Expectation](https://athenaframework.org/Framework/Spec/Expectations/HTTP) methods to `ATH::Spec::WebTestCase` ([#249](https://github.com/athena-framework/athena/pull/249)) (George Dietrich)
-- Add `#response` and `#request` methods to `ATH::Spec::AbstractBrowser` types ([#249](https://github.com/athena-framework/athena/pull/249)) (George Dietrich)
-- Add [ATHR](https://athenaframework.org/Framework/aliases/#ATHR) alias to make using value resolver annotations easier ([#243](https://github.com/athena-framework/athena/pull/243)) (George Dietrich)
-- Add [ATH::Commands::Commands::DebugEventDispatcher](https://athenaframework.org/Framework/Commands/DebugEventDispatcher) framework CLI command to aid in debugging the event dispatcher ([#241](https://github.com/athena-framework/athena/pull/241)) (George Dietrich)
-- Add [ATH::Commands::Commands::DebugRouter](https://athenaframework.org/Framework/Commands/DebugRouter) and [ATH::Commands::Commands::DebugRouterMatch](https://athenaframework.org/Framework/Commands/DebugRouterMatch) framework CLI commands to aid in debugging the router ([#224](https://github.com/athena-framework/athena/pull/224)) (George Dietrich)
-- Add integration for the [Athena::Console](https://athenaframework.org/Console/) component ([#218](https://github.com/athena-framework/athena/pull/218)) (George Dietrich)
+- Add trace logging to `ATH::Listeners::CORS` to aid in debugging ([#265]) (George Dietrich)
+- Introduce new `framework.debug` parameter that is `true` if the binary was _not_ built with the `--release` flag ([#249]) (George Dietrich)
+- Add built-in [HTTP Expectation](https://athenaframework.org/Framework/Spec/Expectations/HTTP) methods to `ATH::Spec::WebTestCase` ([#249]) (George Dietrich)
+- Add `#response` and `#request` methods to `ATH::Spec::AbstractBrowser` types ([#249]) (George Dietrich)
+- Add [ATHR](https://athenaframework.org/Framework/aliases/#ATHR) alias to make using value resolver annotations easier ([#243]) (George Dietrich)
+- Add [ATH::Commands::Commands::DebugEventDispatcher](https://athenaframework.org/Framework/Commands/DebugEventDispatcher) framework CLI command to aid in debugging the event dispatcher ([#241]) (George Dietrich)
+- Add [ATH::Commands::Commands::DebugRouter](https://athenaframework.org/Framework/Commands/DebugRouter) and [ATH::Commands::Commands::DebugRouterMatch](https://athenaframework.org/Framework/Commands/DebugRouterMatch) framework CLI commands to aid in debugging the router ([#224]) (George Dietrich)
+- Add integration for the [Athena::Console](https://athenaframework.org/Console/) component ([#218]) (George Dietrich)
 
 ### Fixed
 
-- Correctly populate `content-length` based on the response content's size ([#267](https://github.com/athena-framework/athena/pull/267)) (George Dietrich)
-- Prevent wildcard CORS `expose_headers` value when `allow_credentials` is `true` ([#264](https://github.com/athena-framework/athena/pull/264)) (George Dietrich)
-- Correctly handle `JSON::Serializable` values within `Hash`/`NamedTuple` controller action return types ([#253](https://github.com/athena-framework/athena/pull/253)) (George Dietrich)
-- Fix [ATH::ParameterBag#get?](https://athenaframework.org/Framework/ParameterBag/#Athena::Framework::ParameterBag#get?(name,_type)) not returning `nil` if it could not convert the value to the desired type ([#243](https://github.com/athena-framework/athena/pull/243)) (George Dietrich)
+- Correctly populate `content-length` based on the response content's size ([#267]) (George Dietrich)
+- Prevent wildcard CORS `expose_headers` value when `allow_credentials` is `true` ([#264]) (George Dietrich)
+- Correctly handle `JSON::Serializable` values within `Hash`/`NamedTuple` controller action return types ([#253]) (George Dietrich)
+- Fix [ATH::ParameterBag#get?](https://athenaframework.org/Framework/ParameterBag/#Athena::Framework::ParameterBag#get?(name,_type)) not returning `nil` if it could not convert the value to the desired type ([#243]) (George Dietrich)
+
+[0.18.0]: https://github.com/athena-framework/framework/releases/tag/v0.18.0
+[#205]: https://github.com/athena-framework/athena/pull/205
+[#213]: https://github.com/athena-framework/athena/pull/213
+[#218]: https://github.com/athena-framework/athena/pull/218
+[#224]: https://github.com/athena-framework/athena/pull/224
+[#241]: https://github.com/athena-framework/athena/pull/241
+[#243]: https://github.com/athena-framework/athena/pull/243
+[#249]: https://github.com/athena-framework/athena/pull/249
+[#250]: https://github.com/athena-framework/athena/pull/250
+[#253]: https://github.com/athena-framework/athena/pull/253
+[#264]: https://github.com/athena-framework/athena/pull/264
+[#265]: https://github.com/athena-framework/athena/pull/265
+[#267]: https://github.com/athena-framework/athena/pull/267
 
 ## [0.17.1] - 2022-09-05
 
 ### Changed
 
-- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188](https://github.com/athena-framework/athena/pull/188)) (George Dietrich)
+- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188]) (George Dietrich)
+
+[0.17.1]: https://github.com/athena-framework/framework/releases/tag/v0.17.1
+[#188]: https://github.com/athena-framework/athena/pull/188
 
 ## [0.17.0] - 2022-05-14
 
@@ -170,26 +247,38 @@ _Checkout [this](https://forum.crystal-lang.org/t/athena-0-17-0/4624) forum thre
 
 ### Added
 
-- Add `pcre2` library dependency to `shard.yml` ([#159](https://github.com/athena-framework/athena/pull/159)) (George Dietrich)
-- Add [ATH::Arguments::Resolvers::Enum](https://athenaframework.org/Framework/Arguments/Resolvers/Enum/) to allow resolving `Enum` members directly to controller actions ([#173](https://github.com/athena-framework/athena/pull/173)) (George Dietrich)
-- Add [ATH::Arguments::Resolvers::UUID](https://athenaframework.org/Framework/Arguments/Resolvers/UUID/) to allow resolving `UUID`s directly to controller actions by ([#176](https://github.com/athena-framework/athena/pull/176)) (George Dietrich)
-- Add [ATH::ParameterBag#has(name, type)](https://athenaframework.org/Framework/ParameterBag/#Athena::Framework::ParameterBag#has?(name,type)) that checks if a parameter with the provided name exists, and that is of the provided type ([#176](https://github.com/athena-framework/athena/pull/176)) (George Dietrich)
-- Add [ATH::Arguments::Resolvers::DefaultValue](https://athenaframework.org/Framework/Arguments/Resolvers/DefaultValue/) to allow resolving an action parameter's default value if no other value was provided ([#177](https://github.com/athena-framework/athena/pull/177)) (George Dietrich)
+- Add `pcre2` library dependency to `shard.yml` ([#159]) (George Dietrich)
+- Add [ATH::Arguments::Resolvers::Enum](https://athenaframework.org/Framework/Arguments/Resolvers/Enum/) to allow resolving `Enum` members directly to controller actions ([#173]) (George Dietrich)
+- Add [ATH::Arguments::Resolvers::UUID](https://athenaframework.org/Framework/Arguments/Resolvers/UUID/) to allow resolving `UUID`s directly to controller actions by ([#176]) (George Dietrich)
+- Add [ATH::ParameterBag#has(name, type)](https://athenaframework.org/Framework/ParameterBag/#Athena::Framework::ParameterBag#has?(name,type)) that checks if a parameter with the provided name exists, and that is of the provided type ([#176]) (George Dietrich)
+- Add [ATH::Arguments::Resolvers::DefaultValue](https://athenaframework.org/Framework/Arguments/Resolvers/DefaultValue/) to allow resolving an action parameter's default value if no other value was provided ([#177]) (George Dietrich)
 
 ### Changed
 
-- **Breaking:** rename `ATH::Arguments::Resolvers::ArgumentValueResolverInterface` to `ATH::Arguments::Resolvers::Interface` ([#176](https://github.com/athena-framework/athena/pull/176)) (George Dietrich)
-- **Breaking:** bump `athena-framework/serializer` to `~> 0.3.0` ([#181](https://github.com/athena-framework/athena/pull/181)) (George Dietrich)
-- **Breaking:** bump `athena-framework/validator` to `~> 0.2.0` ([#181](https://github.com/athena-framework/athena/pull/181)) (George Dietrich)
-- Expose the default value of an [ATH::Arguments::ArgumentMetadata](https://athenaframework.org/Framework/Arguments/ArgumentMetadata/) ([#176](https://github.com/athena-framework/athena/pull/176)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- **Breaking:** rename `ATH::Arguments::Resolvers::ArgumentValueResolverInterface` to `ATH::Arguments::Resolvers::Interface` ([#176]) (George Dietrich)
+- **Breaking:** bump `athena-framework/serializer` to `~> 0.3.0` ([#181]) (George Dietrich)
+- **Breaking:** bump `athena-framework/validator` to `~> 0.2.0` ([#181]) (George Dietrich)
+- Expose the default value of an [ATH::Arguments::ArgumentMetadata](https://athenaframework.org/Framework/Arguments/ArgumentMetadata/) ([#176]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Fixed
 
-- Fix error when two controller share a common action name ([#146](https://github.com/athena-framework/athena/pull/146)) (George Dietrich)
-- Fix release badge to use correct repo ([#161](https://github.com/athena-framework/athena/pull/161)) (George Dietrich)
-- Fix query/request param docs to use new error responses ([#167](https://github.com/athena-framework/athena/pull/167)) (George Dietrich)
-- Fix incorrect `Athena::Framework` `Log` name ([#175](https://github.com/athena-framework/athena/pull/175)) (George Dietrich)
+- Fix error when two controller share a common action name ([#146]) (George Dietrich)
+- Fix release badge to use correct repo ([#161]) (George Dietrich)
+- Fix query/request param docs to use new error responses ([#167]) (George Dietrich)
+- Fix incorrect `Athena::Framework` `Log` name ([#175]) (George Dietrich)
+
+[0.17.0]: https://github.com/athena-framework/framework/releases/tag/v0.17.0
+[#146]: https://github.com/athena-framework/athena/pull/146
+[#159]: https://github.com/athena-framework/athena/pull/159
+[#161]: https://github.com/athena-framework/athena/pull/161
+[#167]: https://github.com/athena-framework/athena/pull/167
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#173]: https://github.com/athena-framework/athena/pull/173
+[#175]: https://github.com/athena-framework/athena/pull/175
+[#176]: https://github.com/athena-framework/athena/pull/176
+[#177]: https://github.com/athena-framework/athena/pull/177
+[#181]: https://github.com/athena-framework/athena/pull/181
 
 ## [0.16.0] - 2022-01-22
 
@@ -197,27 +286,37 @@ _First release in the [athena-framework/framework](https://github.com/athena-fra
 
 ### Added
 
-- Add dependency on `athena-framework/routing` ([#141](https://github.com/athena-framework/athena/pull/141)) (George Dietrich)
-- Allow prepending [HTTP::Handlers](https://crystal-lang.org/api/HTTP/Handler.html) to the Athena server ([#133](https://github.com/athena-framework/athena/pull/133)) (George Dietrich)
-- Add common HTTP methods (get, post, put, delete) to [ATH::Spec::APITestCase](https://athenaframework.org//Framework/Spec/APITestCase/#Athena::Framework::Spec::APITestCase-methods) ([#134](https://github.com/athena-framework/athena/pull/134)) (George Dietrich)
-- Add overload of [ATH::Spec::APITestCase#request](https://athenaframework.org/Framework/Spec/APITestCase/#Athena::Framework::Spec::APITestCase#request(method,path,body,headers)) that accepts an [ATH::Request](https://athenaframework.org/Framework/Request/) or [HTTP::Request](https://crystal-lang.org/api/HTTP/Request.html) ([#134](https://github.com/athena-framework/athena/pull/134)) (George Dietrich)
-- Allow running an HTTPS server via passing an [OpenSSL::SSL::Context::Server](https://crystal-lang.org/api/OpenSSL/SSL/Context/Server.html) to `ATH.run` ([#135](https://github.com/athena-framework/athena/pull/135), [#136](https://github.com/athena-framework/athena/pull/136)) (George Dietrich)
-- Add [ATH::ParameterBag#set(hash)](https://athenaframework.org/Framework/ParameterBag/#Athena::Framework::ParameterBag#set(name,value,type)) that allows setting a hash of key/value pairs ([#141](https://github.com/athena-framework/athena/pull/141)) (George Dietrich)
+- Add dependency on `athena-framework/routing` ([#141]) (George Dietrich)
+- Allow prepending [HTTP::Handlers](https://crystal-lang.org/api/HTTP/Handler.html) to the Athena server ([#133]) (George Dietrich)
+- Add common HTTP methods (get, post, put, delete) to [ATH::Spec::APITestCase](https://athenaframework.org//Framework/Spec/APITestCase/#Athena::Framework::Spec::APITestCase-methods) ([#134]) (George Dietrich)
+- Add overload of [ATH::Spec::APITestCase#request](https://athenaframework.org/Framework/Spec/APITestCase/#Athena::Framework::Spec::APITestCase#request(method,path,body,headers)) that accepts an [ATH::Request](https://athenaframework.org/Framework/Request/) or [HTTP::Request](https://crystal-lang.org/api/HTTP/Request.html) ([#134]) (George Dietrich)
+- Allow running an HTTPS server via passing an [OpenSSL::SSL::Context::Server](https://crystal-lang.org/api/OpenSSL/SSL/Context/Server.html) to `ATH.run` ([#135], [#136]) (George Dietrich)
+- Add [ATH::ParameterBag#set(hash)](https://athenaframework.org/Framework/ParameterBag/#Athena::Framework::ParameterBag#set(name,value,type)) that allows setting a hash of key/value pairs ([#141]) (George Dietrich)
 
 ### Changed
 
-- **Breaking:** integrate the [Athena::Routing](https://athenaframework.org/Routing/) component ([#141](https://github.com/athena-framework/athena/pull/141)) (George Dietrich)
+- **Breaking:** integrate the [Athena::Routing](https://athenaframework.org/Routing/) component ([#141]) (George Dietrich)
 
 ### Removed
 
-- **Breaking:** remove dependency on [amberframework/amber-router](https://github.com/amberframework/amber-router) ([#141](https://github.com/athena-framework/athena/pull/141)) (George Dietrich)
+- **Breaking:** remove dependency on [amberframework/amber-router](https://github.com/amberframework/amber-router) ([#141]) (George Dietrich)
+
+[0.16.0]: https://github.com/athena-framework/framework/releases/tag/v0.16.0
+[#133]: https://github.com/athena-framework/athena/pull/133
+[#134]: https://github.com/athena-framework/athena/pull/134
+[#135]: https://github.com/athena-framework/athena/pull/135
+[#136]: https://github.com/athena-framework/athena/pull/136
+[#141]: https://github.com/athena-framework/athena/pull/141
 
 ## [0.15.1] - 2021-12-13
 
 ### Changed
 
-- Include error list in `ATH::Exception::InvalidParameter` ([#124](https://github.com/athena-framework/athena/pull/124)) (George Dietrich)
-- Set the base path of parameter errors to the name of the parameter ([#124](https://github.com/athena-framework/athena/pull/124)) (George Dietrich)
+- Include error list in `ATH::Exception::InvalidParameter` ([#124]) (George Dietrich)
+- Set the base path of parameter errors to the name of the parameter ([#124]) (George Dietrich)
+
+[0.15.1]: https://github.com/athena-framework/athena/releases/tag/v0.15.1
+[#124]: https://github.com/athena-framework/athena/pull/124
 
 ## [0.15.0] - 2021-10-30
 
@@ -225,31 +324,24 @@ _Last release in the [athena-framework/athena](https://github.com/athena-framewo
 
 ### Added
 
-- Expose the raw [HTTP::Request](https://crystal-lang.org/api/HTTP/Request.html) method from an `ATH::Request` ([#115](https://github.com/athena-framework/athena/pull/115)) (George Dietrich)
-- Add built in [ATH::RequestBodyConverter](https://athenaframework.org/Framework/RequestBodyConverter) param converter ([#116](https://github.com/athena-framework/athena/pull/116)) (George Dietrich)
-- Add `VERSION` constant to `Athena::Framework` namespace ([#120](https://github.com/athena-framework/athena/pull/120)) (George Dietrich)
+- Expose the raw [HTTP::Request](https://crystal-lang.org/api/HTTP/Request.html) method from an `ATH::Request` ([#115]) (George Dietrich)
+- Add built in [ATH::RequestBodyConverter](https://athenaframework.org/Framework/RequestBodyConverter) param converter ([#116]) (George Dietrich)
+- Add `VERSION` constant to `Athena::Framework` namespace ([#120]) (George Dietrich)
 
 ### Changed
 
-- **Breaking:** rename base param converter type to `ATH::ParamConverter` and make it a class ([#116](https://github.com/athena-framework/athena/pull/116)) (George Dietrich)
-- **Breaking:** rename the component from `Athena::Routing` to `Athena::Framework` ([#120](https://github.com/athena-framework/athena/pull/120)) (George Dietrich)
+- **Breaking:** rename base param converter type to `ATH::ParamConverter` and make it a class ([#116]) (George Dietrich)
+- **Breaking:** rename the component from `Athena::Routing` to `Athena::Framework` ([#120]) (George Dietrich)
 
 ### Fixed
 
-- Fix incorrect parameter type restriction on `ATH::ParameterBag#set` ([#116](https://github.com/athena-framework/athena/pull/116)) (George Dietrich)
-- Fix incorrect ivar type on `AVD::Exception::Exceptions::ValidationFailed#violations` ([#116](https://github.com/athena-framework/athena/pull/116)) (George Dietrich)
-- Correctly reject requests with whitespace when converting numeric inputs ([#117](https://github.com/athena-framework/athena/pull/117)) (George Dietrich)
+- Fix incorrect parameter type restriction on `ATH::ParameterBag#set` ([#116]) (George Dietrich)
+- Fix incorrect ivar type on `AVD::Exception::Exceptions::ValidationFailed#violations` ([#116]) (George Dietrich)
+- Correctly reject requests with whitespace when converting numeric inputs ([#117]) (George Dietrich)
 
-[0.20.1]: https://github.com/athena-framework/framework/releases/tag/v0.20.1
-[0.20.0]: https://github.com/athena-framework/framework/releases/tag/v0.20.0
-[0.19.2]: https://github.com/athena-framework/framework/releases/tag/v0.19.2
-[0.19.1]: https://github.com/athena-framework/framework/releases/tag/v0.19.1
-[0.19.0]: https://github.com/athena-framework/framework/releases/tag/v0.19.0
-[0.18.2]: https://github.com/athena-framework/framework/releases/tag/v0.18.2
-[0.18.1]: https://github.com/athena-framework/framework/releases/tag/v0.18.1
-[0.18.0]: https://github.com/athena-framework/framework/releases/tag/v0.18.0
-[0.17.1]: https://github.com/athena-framework/framework/releases/tag/v0.17.1
-[0.17.0]: https://github.com/athena-framework/framework/releases/tag/v0.17.0
-[0.16.0]: https://github.com/athena-framework/framework/releases/tag/v0.16.0
-[0.15.1]: https://github.com/athena-framework/athena/releases/tag/v0.15.1
 [0.15.0]: https://github.com/athena-framework/athena/releases/tag/v0.15.0
+[#115]: https://github.com/athena-framework/athena/pull/115
+[#116]: https://github.com/athena-framework/athena/pull/116
+[#117]: https://github.com/athena-framework/athena/pull/117
+[#120]: https://github.com/athena-framework/athena/pull/120
+

--- a/src/components/image_size/CHANGELOG.md
+++ b/src/components/image_size/CHANGELOG.md
@@ -4,15 +4,22 @@
 
 _Administrative release, no functional changes_
 
+[0.1.4]: https://github.com/athena-framework/image-size/releases/tag/v0.1.4
+
 ## [0.1.3] - 2024-04-09
 
 ### Changed
 
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/image-size/releases/tag/v0.1.3
+[#365]: https://github.com/athena-framework/athena/pull/365
 
 ## [0.1.2] - 2023-10-09
 
 _Administrative release, no functional changes_
+
+[0.1.2]: https://github.com/athena-framework/image-size/releases/tag/v0.1.2
 
 ## [0.1.1] - 2022-05-14
 
@@ -20,22 +27,23 @@ _First release a part of the monorepo._
 
 ### Added
 
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Fixed
 
-- Fix incorrect `description` key in `shard.yml` ([#171](https://github.com/athena-framework/athena/pull/171)) (George Dietrich)
+- Fix incorrect `description` key in `shard.yml` ([#171]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/image-size/releases/tag/v0.1.1
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#171]: https://github.com/athena-framework/athena/pull/171
+[#172]: https://github.com/athena-framework/athena/pull/172
 
 ## [0.1.0] - 2022-02-21
 
 _Initial release._
 
-[0.1.4]: https://github.com/athena-framework/image-size/releases/tag/v0.1.4
-[0.1.3]: https://github.com/athena-framework/image-size/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/image-size/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/image-size/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/image-size/releases/tag/v0.1.0

--- a/src/components/mime/CHANGELOG.md
+++ b/src/components/mime/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Added
 
-- **Breaking:** Add `AMIME::Types` to more robustly handles MIME type/file extension/guessing ([#534](https://github.com/athena-framework/athena/pull/534)) (George Dietrich)
+- **Breaking:** Add `AMIME::Types` to more robustly handles MIME type/file extension/guessing ([#534]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/mime/releases/tag/v0.2.0
+[#534]: https://github.com/athena-framework/athena/pull/534
 
 ## [0.1.0] - 2025-01-26
 
 _Initial release._
 
-[0.2.0]: https://github.com/athena-framework/mime/releases/tag/v0.2.0
 [0.1.0]: https://github.com/athena-framework/mime/releases/tag/v0.1.0

--- a/src/components/negotiation/CHANGELOG.md
+++ b/src/components/negotiation/CHANGELOG.md
@@ -4,25 +4,37 @@
 
 ### Changed
 
-- **Breaking:** Normalize exception types ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
-- Use lowercase `utf-8` within header values ([#417](https://github.com/athena-framework/athena/pull/417)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.13.0` ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
+- **Breaking:** Normalize exception types ([#428]) (George Dietrich)
+- Use lowercase `utf-8` within header values ([#417]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.13.0` ([#428]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/negotiation/releases/tag/v0.2.0
+[#417]: https://github.com/athena-framework/athena/pull/417
+[#428]: https://github.com/athena-framework/athena/pull/428
 
 ## [0.1.5] - 2024-04-09
 
 ### Changed
 
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
+
+[0.1.5]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.5
+[#365]: https://github.com/athena-framework/athena/pull/365
 
 ## [0.1.4] - 2023-10-09
 
 _Administrative release, no functional changes_
 
+[0.1.4]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.4
+
 ## [0.1.3] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.3
+[#261]: https://github.com/athena-framework/athena/pull/261
 
 ## [0.1.2] - 2022-05-14
 
@@ -30,31 +42,34 @@ _First release a part of the monorepo._
 
 ### Added
 
-- Add `VERSION` constant to `Athena::Negotiation` namespace ([#166](https://github.com/athena-framework/athena/pull/166)) (George Dietrich)
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
+- Add `VERSION` constant to `Athena::Negotiation` namespace ([#166]) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Fixed
 
-- Correct the shard version in `README.md` ([#6](https://github.com/athena-framework/negotiation/pull/6)) (syeopite)
+- Correct the shard version in `README.md` ([#6]) (syeopite)
+
+[0.1.2]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.2
+[#6]: https://github.com/athena-framework/negotiation/pull/6
+[#166]: https://github.com/athena-framework/athena/pull/166
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#172]: https://github.com/athena-framework/athena/pull/172
 
 ## [0.1.1] - 2021-02-04
 
 ### Changed
 
-- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#4](https://github.com/athena-framework/negotiation/pull/4)) (George Dietrich)
+- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#4]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.1
+[#4]: https://github.com/athena-framework/negotiation/pull/4
 
 ## [0.1.0] - 2020-12-24
 
 _Initial release._
 
-[0.2.0]: https://github.com/athena-framework/negotiation/releases/tag/v0.2.0
-[0.1.5]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.5
-[0.1.4]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.4
-[0.1.3]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/negotiation/releases/tag/v0.1.0

--- a/src/components/routing/CHANGELOG.md
+++ b/src/components/routing/CHANGELOG.md
@@ -4,97 +4,137 @@
 
 ### Changed
 
-- Allow having multiple independent compiled route collections ([#468](https://github.com/athena-framework/athena/pull/468)) (George Dietrich)
-- Log unhandled `ART::RoutingHandler` exceptions ([#470](https://github.com/athena-framework/athena/pull/470)) (George Dietrich)
+- Allow having multiple independent compiled route collections ([#468]) (George Dietrich)
+- Log unhandled `ART::RoutingHandler` exceptions ([#470]) (George Dietrich)
 
 ### Fixed
 
-- Make `ART::RequestContext.from_uri` more robust ([#498](https://github.com/athena-framework/athena/pull/498)) (George Dietrich)
+- Make `ART::RequestContext.from_uri` more robust ([#498]) (George Dietrich)
+
+[0.1.10]: https://github.com/athena-framework/routing/releases/tag/v0.1.10
+[#468]: https://github.com/athena-framework/athena/pull/468
+[#470]: https://github.com/athena-framework/athena/pull/470
+[#498]: https://github.com/athena-framework/athena/pull/498
 
 ## [0.1.9] - 2024-04-09
 
 ### Changed
 
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
 
 ### Added
 
-- **Breaking:** add kwargs overload to `ART::Generator::Interface#generate` ([#375](https://github.com/athena-framework/athena/pull/375)) (George Dietrich)
+- **Breaking:** add kwargs overload to `ART::Generator::Interface#generate` ([#375]) (George Dietrich)
 
 ### Fixed
 
-- Fix compatibility with PCRE2 10.43 ([#362](https://github.com/athena-framework/athena/pull/362)) (George Dietrich)
-- Fix error when PCRE2 JIT mode is unavailable ([#381](https://github.com/athena-framework/athena/pull/381)) (George Dietrich)
+- Fix compatibility with PCRE2 10.43 ([#362]) (George Dietrich)
+- Fix error when PCRE2 JIT mode is unavailable ([#381]) (George Dietrich)
+
+[0.1.9]: https://github.com/athena-framework/routing/releases/tag/v0.1.9
+[#362]: https://github.com/athena-framework/athena/pull/362
+[#365]: https://github.com/athena-framework/athena/pull/365
+[#375]: https://github.com/athena-framework/athena/pull/375
+[#381]: https://github.com/athena-framework/athena/pull/381
 
 ## [0.1.8] - 2023-10-09
 
 ### Added
 
-- Internal support for redirecting within an `ART::Matcher::*` ([#307](https://github.com/athena-framework/athena/pull/307)) (George Dietrich)
+- Internal support for redirecting within an `ART::Matcher::*` ([#307]) (George Dietrich)
+
+[0.1.8]: https://github.com/athena-framework/routing/releases/tag/v0.1.8
+[#307]: https://github.com/athena-framework/athena/pull/307
 
 ## [0.1.7] - 2023-05-29
 
 ### Changed
 
-- **Breaking:** Update minimum `crystal` version to `~> 1.8.0`. Drop support for `PCRE1`. ([#281](https://github.com/athena-framework/athena/pull/281)) (George Dietrich)
+- **Breaking:** Update minimum `crystal` version to `~> 1.8.0`. Drop support for `PCRE1`. ([#281]) (George Dietrich)
+
+[0.1.7]: https://github.com/athena-framework/routing/releases/tag/v0.1.7
+[#281]: https://github.com/athena-framework/athena/pull/281
 
 ## [0.1.6] - 2023-03-26
 
 ### Fixed
 
-- Fix compatibility with Crystal `1.8.0-dev` ([#272](https://github.com/athena-framework/athena/pull/272)) (George Dietrich)
+- Fix compatibility with Crystal `1.8.0-dev` ([#272]) (George Dietrich)
+
+[0.1.6]: https://github.com/athena-framework/routing/releases/tag/v0.1.6
+[#272]: https://github.com/athena-framework/athena/pull/272
 
 ## [0.1.5] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
 
 ### Added
 
-- Add additional `ART::Requirement` constants ([#257](https://github.com/athena-framework/athena/pull/257)) (George Dietrich)
+- Add additional `ART::Requirement` constants ([#257]) (George Dietrich)
 
 ### Fixed
 
-- Fix formatting issue in Crystal `1.8-dev` ([#258](https://github.com/athena-framework/athena/pull/258)) (George Dietrich)
+- Fix formatting issue in Crystal `1.8-dev` ([#258]) (George Dietrich)
+
+[0.1.5]: https://github.com/athena-framework/routing/releases/tag/v0.1.5
+[#257]: https://github.com/athena-framework/athena/pull/257
+[#258]: https://github.com/athena-framework/athena/pull/258
+[#261]: https://github.com/athena-framework/athena/pull/261
 
 ## [0.1.4] - 2023-01-07
 
 ### Changed
 
-- Change route compilation to be eager ([#207](https://github.com/athena-framework/athena/pull/207)) (George Dietrich)
+- Change route compilation to be eager ([#207]) (George Dietrich)
 
 ### Added
 
-- Add ability to bubble up exceptions from `ART::RoutingHandler` ([#206](https://github.com/athena-framework/athena/pull/206)) (George Dietrich)
-- Add `ART::Matcher::TraceableURLMatcher` to help with debugging route matches ([#224](https://github.com/athena-framework/athena/pull/224)) (George Dietrich)
-- Add `ART::Route#has_scheme?` ([#224](https://github.com/athena-framework/athena/pull/224)) (George Dietrich)
+- Add ability to bubble up exceptions from `ART::RoutingHandler` ([#206]) (George Dietrich)
+- Add `ART::Matcher::TraceableURLMatcher` to help with debugging route matches ([#224]) (George Dietrich)
+- Add `ART::Route#has_scheme?` ([#224]) (George Dietrich)
+
+[0.1.4]: https://github.com/athena-framework/routing/releases/tag/v0.1.4
+[#207]: https://github.com/athena-framework/athena/pull/207
+[#206]: https://github.com/athena-framework/athena/pull/206
+[#224]: https://github.com/athena-framework/athena/pull/224
 
 ## [0.1.3] - 2022-09-05
 
 ### Changed
 
-- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188](https://github.com/athena-framework/athena/pull/188)) (George Dietrich)
+- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188]) (George Dietrich)
 
 ### Added
 
-- Add an `HTTP::Handler` to add basic routing support to a `HTTP::Server` ([#189](https://github.com/athena-framework/athena/pull/189)) (George Dietrich)
+- Add an `HTTP::Handler` to add basic routing support to a `HTTP::Server` ([#189]) (George Dietrich)
 
 ### Fixed
 
-- Fixed slash characters being double escaped in generated URL query params ([#180](https://github.com/athena-framework/athena/pull/180)) (George Dietrich)
+- Fixed slash characters being double escaped in generated URL query params ([#180]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/routing/releases/tag/v0.1.3
+[#180]: https://github.com/athena-framework/athena/pull/180
+[#188]: https://github.com/athena-framework/athena/pull/188
+[#189]: https://github.com/athena-framework/athena/pull/189
 
 ## [0.1.2] - 2022-05-14
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Added
 
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
-- Add common route requirement constants to the [ART::Requirement](https://athenaframework.org/Routing/Requirement/) namespace ([#173](https://github.com/athena-framework/athena/pull/173)) (George Dietrich)
-- Add [ART::Requirement::Enum](https://athenaframework.org/Routing/Requirement/Enum/) to make creating [Enum](https://crystal-lang.org/api/Enum.html) based route requirements easier ([#173](https://github.com/athena-framework/athena/pull/173)) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
+- Add common route requirement constants to the [ART::Requirement](https://athenaframework.org/Routing/Requirement/) namespace ([#173]) (George Dietrich)
+- Add [ART::Requirement::Enum](https://athenaframework.org/Routing/Requirement/Enum/) to make creating [Enum](https://crystal-lang.org/api/Enum.html) based route requirements easier ([#173]) (George Dietrich)
+
+[0.1.2]: https://github.com/athena-framework/routing/releases/tag/v0.1.2
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#172]: https://github.com/athena-framework/athena/pull/172
+[#173]: https://github.com/athena-framework/athena/pull/173
 
 ## [0.1.1] - 2022-02-05
 
@@ -102,20 +142,13 @@ _First release a part of the monorepo._
 
 ### Fixed
 
-- Fix erroneous mutating of matched route data ([#144](https://github.com/athena-framework/athena/pull/144)) (George Dietrich)
+- Fix erroneous mutating of matched route data ([#144]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/routing/releases/tag/v0.1.1
+[#144]: https://github.com/athena-framework/athena/pull/144
 
 ## [0.1.0] - 2022-01-10
 
 _Initial release._
 
-[0.1.10]: https://github.com/athena-framework/routing/releases/tag/v0.1.10
-[0.1.9]: https://github.com/athena-framework/routing/releases/tag/v0.1.9
-[0.1.8]: https://github.com/athena-framework/routing/releases/tag/v0.1.8
-[0.1.7]: https://github.com/athena-framework/routing/releases/tag/v0.1.7
-[0.1.6]: https://github.com/athena-framework/routing/releases/tag/v0.1.6
-[0.1.5]: https://github.com/athena-framework/routing/releases/tag/v0.1.5
-[0.1.4]: https://github.com/athena-framework/routing/releases/tag/v0.1.4
-[0.1.3]: https://github.com/athena-framework/routing/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/routing/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/routing/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/routing/releases/tag/v0.1.0

--- a/src/components/serializer/CHANGELOG.md
+++ b/src/components/serializer/CHANGELOG.md
@@ -4,49 +4,73 @@
 
 ### Fixed
 
-- Fix serialization of value when its type is different type than the ivar ([#514](https://github.com/athena-framework/athena/pull/514)) (George Dietrich)
+- Fix serialization of value when its type is different type than the ivar ([#514]) (George Dietrich)
+
+[0.4.1]: https://github.com/athena-framework/serializer/releases/tag/v0.4.1
+[#514]: https://github.com/athena-framework/athena/pull/514
 
 ## [0.4.0] - 2025-01-26
 
 ### Changed
 
-- **Breaking:** Normalize exception types ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.13.0` ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
+- **Breaking:** Normalize exception types ([#428]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.13.0` ([#428]) (George Dietrich)
+
+[0.4.0]: https://github.com/athena-framework/serializer/releases/tag/v0.4.0
+[#428]: https://github.com/athena-framework/athena/pull/428
 
 ## [0.3.6] - 2024-04-27
 
 ### Fixed
 
-- Fix misnamed modules being defined in incorrect namespace ([#402](https://github.com/athena-framework/athena/pull/402)) (George Dietrich)
+- Fix misnamed modules being defined in incorrect namespace ([#402]) (George Dietrich)
+
+[0.3.6]: https://github.com/athena-framework/serializer/releases/tag/v0.3.6
+[#402]: https://github.com/athena-framework/athena/pull/402
 
 ## [0.3.5] - 2024-04-09
 
 ### Changed
 
-- Change `Config` dependency to `DependencyInjection` for the custom annotation feature ([#392](https://github.com/athena-framework/athena/pull/392)) (George Dietrich)
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Change `Config` dependency to `DependencyInjection` for the custom annotation feature ([#392]) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
+
+[0.3.5]: https://github.com/athena-framework/serializer/releases/tag/v0.3.5
+[#392]: https://github.com/athena-framework/athena/pull/392
+[#365]: https://github.com/athena-framework/athena/pull/365
 
 ## [0.3.4] - 2023-10-09
 
 _Administrative release, no functional changes_
 
+[0.3.4]: https://github.com/athena-framework/serializer/releases/tag/v0.3.4
+
 ## [0.3.3] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
+
+[0.3.3]: https://github.com/athena-framework/serializer/releases/tag/v0.3.3
+[#261]: https://github.com/athena-framework/athena/pull/261
 
 ## [0.3.2] - 2023-01-07
 
 ### Fixed
 
-- Fix deserializing `JSON::Any` and `YAML::Any` ([#215](https://github.com/athena-framework/athena/pull/215)) (George Dietrich)
+- Fix deserializing `JSON::Any` and `YAML::Any` ([#215]) (George Dietrich)
+
+[0.3.2]: https://github.com/athena-framework/serializer/releases/tag/v0.3.2
+[#215]: https://github.com/athena-framework/athena/pull/215
 
 ## [0.3.1] - 2022-09-05
 
 ### Changed
 
-- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188](https://github.com/athena-framework/athena/pull/188)) (George Dietrich)
+- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188]) (George Dietrich)
+
+[0.3.1]: https://github.com/athena-framework/serializer/releases/tag/v0.3.1
+[#188]: https://github.com/athena-framework/athena/pull/188
 
 ## [0.3.0] - 2022-05-14
 
@@ -54,136 +78,162 @@ _First release a part of the monorepo._
 
 ### Added
 
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
 
 ### Changed
 
-- **Breaking:** change serialization of [Enums](https://crystal-lang.org/api/Enum.html) to underscored strings by default ([#173](https://github.com/athena-framework/athena/pull/173)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- **Breaking:** change serialization of [Enums](https://crystal-lang.org/api/Enum.html) to underscored strings by default ([#173]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Fixed
 
-- Fix compiler error when trying to deserialize a `Hash` ([#165](https://github.com/athena-framework/athena/pull/165)) (George Dietrich)
+- Fix compiler error when trying to deserialize a `Hash` ([#165]) (George Dietrich)
+
+[0.3.0]: https://github.com/athena-framework/serializer/releases/tag/v0.3.0
+[#165]: https://github.com/athena-framework/athena/pull/165
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#172]: https://github.com/athena-framework/athena/pull/172
+[#173]: https://github.com/athena-framework/athena/pull/173
 
 ## [0.2.10] - 2021-11-12
 
 ### Fixed
 
-- Fix issue with empty YAML input ([#22](https://github.com/athena-framework/serializer/pull/22)) (George Dietrich)
+- Fix issue with empty YAML input ([#22]) (George Dietrich)
+
+[0.2.10]: https://github.com/athena-framework/serializer/releases/tag/v0.2.10
+[#22]: https://github.com/athena-framework/serializer/pull/22
 
 ## [0.2.9] - 2021-10-30
 
 ### Added
 
-- Add `VERSION` constant to `Athena::Serializer` namespace ([#20](https://github.com/athena-framework/serializer/pull/20)) (George Dietrich)
+- Add `VERSION` constant to `Athena::Serializer` namespace ([#20]) (George Dietrich)
 
 ### Fixed
 
-- Fix broken type link ([#19](https://github.com/athena-framework/serializer/pull/19)) (George Dietrich)
+- Fix broken type link ([#19]) (George Dietrich)
+
+[0.2.9]: https://github.com/athena-framework/serializer/releases/tag/v0.2.9
+[#19]: https://github.com/athena-framework/serializer/pull/19
+[#20]: https://github.com/athena-framework/serializer/pull/20
 
 ## [0.2.8] - 2021-05-17
 
 ### Fixed
 
-- Fixes incorrect `nil` check in macro logic ([#17](https://github.com/athena-framework/serializer/pull/17)) (George Dietrich)
+- Fixes incorrect `nil` check in macro logic ([#17]) (George Dietrich)
+
+[0.2.8]: https://github.com/athena-framework/serializer/releases/tag/v0.2.8
+[#17]: https://github.com/athena-framework/serializer/pull/17
 
 ## [0.2.7] - 2021-04-09
 
 ### Added
 
-- Add some more specialized exception types ([#16](https://github.com/athena-framework/serializer/pull/16)) (George Dietrich)
+- Add some more specialized exception types ([#16]) (George Dietrich)
+
+[0.2.7]: https://github.com/athena-framework/serializer/releases/tag/v0.2.7
+[#16]: https://github.com/athena-framework/serializer/pull/16
 
 ## [0.2.6] - 2021-03-16
 
 ### Added
 
-- Expose a setter for `ASR::Context#version=` ([#15](https://github.com/athena-framework/serializer/pull/15)) (George Dietrich)
+- Expose a setter for `ASR::Context#version=` ([#15]) (George Dietrich)
 
 ### Changed
 
-- Change `athena-framework/config` version constraint to `>= 2.0.0` ([#15](https://github.com/athena-framework/serializer/pull/15)) (George Dietrich)
+- Change `athena-framework/config` version constraint to `>= 2.0.0` ([#15]) (George Dietrich)
+
+[0.2.6]: https://github.com/athena-framework/serializer/releases/tag/v0.2.6
+[#15]: https://github.com/athena-framework/serializer/pull/15
 
 ## [0.2.5] - 2021-01-29
 
 ### Changed
 
-- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#14](https://github.com/athena-framework/serializer/pull/14)) (George Dietrich)
+- Migrate documentation to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#14]) (George Dietrich)
+
+[0.2.5]: https://github.com/athena-framework/serializer/releases/tag/v0.2.5
+[#14]: https://github.com/athena-framework/serializer/pull/14
 
 ## [0.2.4] - 2021-01-29
 
 ### Changed
 
-- Bump min `athena-framework/config` version to `~> 2.0.0` ([#13](https://github.com/athena-framework/serializer/pull/13)) (George Dietrich)
+- Bump min `athena-framework/config` version to `~> 2.0.0` ([#13]) (George Dietrich)
+
+[0.2.4]: https://github.com/athena-framework/serializer/releases/tag/v0.2.4
+[#13]: https://github.com/athena-framework/serializer/pull/13
 
 ## [0.2.3] - 2021-01-20
 
 ### Fixed
 
-- Fix since/until and group annotations not working for virtual properties ([#12](https://github.com/athena-framework/serializer/pull/12)) (George Dietrich)
+- Fix since/until and group annotations not working for virtual properties ([#12]) (George Dietrich)
+
+[0.2.3]: https://github.com/athena-framework/serializer/releases/tag/v0.2.3
+[#12]: https://github.com/athena-framework/serializer/pull/12
 
 ## [0.2.2] - 2020-12-03
 
 ### Changed
 
-- Update `crystal` version to allow version greater than `1.0.0` ([#11](https://github.com/athena-framework/serializer/pull/11)) (George Dietrich)
+- Update `crystal` version to allow version greater than `1.0.0` ([#11]) (George Dietrich)
+
+[0.2.2]: https://github.com/athena-framework/serializer/releases/tag/v0.2.2
+[#11]: https://github.com/athena-framework/serializer/pull/11
 
 ## [0.2.1] - 2020-11-08
 
 ### Added
 
-- Add deserialization support to `ASRA::Name` ([#9](https://github.com/athena-framework/serializer/pull/9)) (Joakim Repomaa)
+- Add deserialization support to `ASRA::Name` ([#9]) (Joakim Repomaa)
+
+[0.2.1]: https://github.com/athena-framework/serializer/releases/tag/v0.2.1
+[#9]: https://github.com/athena-framework/serializer/pull/9
 
 ## [0.2.0] - 2020-07-08
 
 ### Added
 
-- Add dependency on `athena-framework/config` ([#8](https://github.com/athena-framework/serializer/pull/8)) (George Dietrich)
-- Add ability to use custom annotations within [exclusion strategies](https://athenaframework.org/Serializer/ExclusionStrategies/ExclusionStrategyInterface/#Athena::Serializer::ExclusionStrategies::ExclusionStrategyInterface--annotation-configurations) ([#8](https://github.com/athena-framework/serializer/pull/8)) (George Dietrich)
-- Add [ASR::Context#direction](https://athenaframework.org/Serializer/Context/#Athena::Serializer::Context#direction) to represent which direction the context object represents ([#8](https://github.com/athena-framework/serializer/pull/8)) (George Dietrich)
+- Add dependency on `athena-framework/config` ([#8]) (George Dietrich)
+- Add ability to use custom annotations within [exclusion strategies](https://athenaframework.org/Serializer/ExclusionStrategies/ExclusionStrategyInterface/#Athena::Serializer::ExclusionStrategies::ExclusionStrategyInterface--annotation-configurations) ([#8]) (George Dietrich)
+- Add [ASR::Context#direction](https://athenaframework.org/Serializer/Context/#Athena::Serializer::Context#direction) to represent which direction the context object represents ([#8]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/serializer/releases/tag/v0.2.0
+[#8]: https://github.com/athena-framework/serializer/pull/8
 
 ## [0.1.3] - 2020-07-08
 
 ### Fixed
 
-- Fix overflow error when deserializing `Int64` values ([#7](https://github.com/athena-framework/serializer/pull/7)) (George Dietrich)
+- Fix overflow error when deserializing `Int64` values ([#7]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/serializer/releases/tag/v0.1.3
+[#7]: https://github.com/athena-framework/serializer/pull/7
 
 ## [0.1.2] - 2020-07-05
 
 ### Added
 
-- Add improved documentation to various types ([#6](https://github.com/athena-framework/serializer/pull/6)) (George Dietrich)
+- Add improved documentation to various types ([#6]) (George Dietrich)
+
+[0.1.2]: https://github.com/athena-framework/serializer/releases/tag/v0.1.2
+[#6]: https://github.com/athena-framework/serializer/pull/6
 
 ## [0.1.1] - 2020-06-27
 
 ### Added
 
-- Add [naming strategies](https://athenaframework.org/Serializer/Annotations/Name/#Athena::Serializer::Annotations::Name--naming-strategies) to `ASRA::Name` ([#5](https://github.com/athena-framework/serializer/pull/5)) (George Dietrich)
+- Add [naming strategies](https://athenaframework.org/Serializer/Annotations/Name/#Athena::Serializer::Annotations::Name--naming-strategies) to `ASRA::Name` ([#5]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/serializer/releases/tag/v0.1.1
+[#5]: https://github.com/athena-framework/serializer/pull/5
 
 ## [0.1.0] - 2020-06-23
 
 _Initial release._
 
-[0.4.1]: https://github.com/athena-framework/serializer/releases/tag/v0.4.1
-[0.4.0]: https://github.com/athena-framework/serializer/releases/tag/v0.4.0
-[0.3.6]: https://github.com/athena-framework/serializer/releases/tag/v0.3.6
-[0.3.5]: https://github.com/athena-framework/serializer/releases/tag/v0.3.5
-[0.3.4]: https://github.com/athena-framework/serializer/releases/tag/v0.3.4
-[0.3.3]: https://github.com/athena-framework/serializer/releases/tag/v0.3.3
-[0.3.2]: https://github.com/athena-framework/serializer/releases/tag/v0.3.2
-[0.3.1]: https://github.com/athena-framework/serializer/releases/tag/v0.3.1
-[0.3.0]: https://github.com/athena-framework/serializer/releases/tag/v0.3.0
-[0.2.10]: https://github.com/athena-framework/serializer/releases/tag/v0.2.10
-[0.2.9]: https://github.com/athena-framework/serializer/releases/tag/v0.2.9
-[0.2.8]: https://github.com/athena-framework/serializer/releases/tag/v0.2.8
-[0.2.7]: https://github.com/athena-framework/serializer/releases/tag/v0.2.7
-[0.2.6]: https://github.com/athena-framework/serializer/releases/tag/v0.2.6
-[0.2.5]: https://github.com/athena-framework/serializer/releases/tag/v0.2.5
-[0.2.4]: https://github.com/athena-framework/serializer/releases/tag/v0.2.4
-[0.2.3]: https://github.com/athena-framework/serializer/releases/tag/v0.2.3
-[0.2.2]: https://github.com/athena-framework/serializer/releases/tag/v0.2.2
-[0.2.1]: https://github.com/athena-framework/serializer/releases/tag/v0.2.1
-[0.2.0]: https://github.com/athena-framework/serializer/releases/tag/v0.2.0
-[0.1.3]: https://github.com/athena-framework/serializer/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/serializer/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/serializer/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/serializer/releases/tag/v0.1.0

--- a/src/components/spec/CHANGELOG.md
+++ b/src/components/spec/CHANGELOG.md
@@ -4,79 +4,116 @@
 
 ### Added
 
-- Add ability to generate macro code coverage reports for `ASPEC::Methods.assert_compile_time_error` usages ([#551](https://github.com/athena-framework/athena/pull/551)) (George Dietrich)
+- Add ability to generate macro code coverage reports for `ASPEC::Methods.assert_compile_time_error` usages ([#551]) (George Dietrich)
 
 ### Removed
 
-- **Breaking:** Remove `ASPEC::Methods.assert_error` and `ASPEC::Methods.assert_success` methods ([#551](https://github.com/athena-framework/athena/pull/551)) (George Dietrich)
+- **Breaking:** Remove `ASPEC::Methods.assert_error` and `ASPEC::Methods.assert_success` methods ([#551]) (George Dietrich)
+
+[0.4.0]: https://github.com/athena-framework/spec/releases/tag/v0.4.0
+[#551]: https://github.com/athena-framework/athena/pull/551
 
 ## [0.3.11] - 2025-05-19
 
 ### Fixed
 
-- Fix duplicate test case runs with abstract generic parent test case ([#538](https://github.com/athena-framework/athena/pull/538)) (George Dietrich)
+- Fix duplicate test case runs with abstract generic parent test case ([#538]) (George Dietrich)
+
+[0.3.11]: https://github.com/athena-framework/spec/releases/tag/v0.3.11
+[#538]: https://github.com/athena-framework/athena/pull/538
 
 ## [0.3.10] - 2025-02-08
 
 ### Changed
 
-- **Breaking:** prevent defining `ASPEC::TestCase#initialize` methods that accepts arguments/blocks ([#516](https://github.com/athena-framework/athena/pull/516)) (George Dietrich)
+- **Breaking:** prevent defining `ASPEC::TestCase#initialize` methods that accepts arguments/blocks ([#516]) (George Dietrich)
+
+[0.3.10]: https://github.com/athena-framework/spec/releases/tag/v0.3.10
+[#516]: https://github.com/athena-framework/athena/pull/516
 
 ## [0.3.9] - 2025-01-26
 
 _Administrative release, no functional changes_
 
+[0.3.9]: https://github.com/athena-framework/spec/releases/tag/v0.3.9
+
 ## [0.3.8] - 2024-07-31
 
 ### Added
 
-- Add support for using the `CRYSTAL` ENV var to customize binary used for `ASPEC::Methods.assert_error` and `ASPEC::Methods.assert_success` ([#424](https://github.com/athena-framework/athena/pull/424)) (George Dietrich)
+- Add support for using the `CRYSTAL` ENV var to customize binary used for `ASPEC::Methods.assert_error` and `ASPEC::Methods.assert_success` ([#424]) (George Dietrich)
+
+[0.3.8]: https://github.com/athena-framework/spec/releases/tag/v0.3.8
+[#424]: https://github.com/athena-framework/athena/pull/424
 
 ## [0.3.7] - 2024-04-09
 
 ### Changed
 
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
+
+[0.3.7]: https://github.com/athena-framework/spec/releases/tag/v0.3.7
+[#365]: https://github.com/athena-framework/athena/pull/365
 
 ## [0.3.6] - 2023-10-09
 
 _Administrative release, no functional changes_
 
+[0.3.6]: https://github.com/athena-framework/spec/releases/tag/v0.3.6
+
 ## [0.3.5] - 2023-04-26
 
 ### Fixed
 
-- Ensure `#before_all` runs exactly once, and before `#initialize` ([#285](https://github.com/athena-framework/athena/pull/285)) (George Dietrich)
+- Ensure `#before_all` runs exactly once, and before `#initialize` ([#285]) (George Dietrich)
+
+[0.3.5]: https://github.com/athena-framework/spec/releases/tag/v0.3.5
+[#285]: https://github.com/athena-framework/athena/pull/285
 
 ## [0.3.4] - 2023-03-19
 
 ### Fixed
 
-- Fix exceptions not being counted as errors when raised within the `initialize` method of a test case ([#276](https://github.com/athena-framework/athena/pull/276)) (George Dietrich)
-- Fix a documentation typo in the `TestWith` example ([#269](https://github.com/athena-framework/athena/pull/269)) (George Dietrich)
+- Fix exceptions not being counted as errors when raised within the `initialize` method of a test case ([#276]) (George Dietrich)
+- Fix a documentation typo in the `TestWith` example ([#269]) (George Dietrich)
+
+[0.3.4]: https://github.com/athena-framework/spec/releases/tag/v0.3.4
+[#269]: https://github.com/athena-framework/athena/pull/269
+[#276]: https://github.com/athena-framework/athena/pull/276
 
 ## [0.3.3] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
+
+[0.3.3]: https://github.com/athena-framework/spec/releases/tag/v0.3.3
+[#261]: https://github.com/athena-framework/athena/pull/261
 
 ## [0.3.2] - 2023-01-16
 
 ### Added
 
-- Add `ASPEC::TestCase::TestWith` that works similar to the `ASPEC::TestCase::DataProvider` but without needing to create a dedicated method ([#254](https://github.com/athena-framework/athena/pull/254)) (George Dietrich)
+- Add `ASPEC::TestCase::TestWith` that works similar to the `ASPEC::TestCase::DataProvider` but without needing to create a dedicated method ([#254]) (George Dietrich)
+
+[0.3.2]: https://github.com/athena-framework/spec/releases/tag/v0.3.2
+[#254]: https://github.com/athena-framework/athena/pull/254
 
 ## [0.3.1] - 2023-01-07
 
 ### Changed
 
-- Update the docs to clarify the component needs to be manually installed ([#247](https://github.com/athena-framework/athena/pull/247)) (George Dietrich)
+- Update the docs to clarify the component needs to be manually installed ([#247]) (George Dietrich)
 
 ### Added
 
-- Add support for *codegen* for the `ASPEC.assert_error` and `ASPEC.assert_success` methods ([#219](https://github.com/athena-framework/athena/pull/219)) (George Dietrich)
-- Add ability to skip running all examples within a test case via the `ASPEC::TestCase::Skip` annotation ([#248](https://github.com/athena-framework/athena/pull/248)) (George Dietrich)
+- Add support for *codegen* for the `ASPEC.assert_error` and `ASPEC.assert_success` methods ([#219]) (George Dietrich)
+- Add ability to skip running all examples within a test case via the `ASPEC::TestCase::Skip` annotation ([#248]) (George Dietrich)
+
+[0.3.1]: https://github.com/athena-framework/spec/releases/tag/v0.3.1
+[#219]: https://github.com/athena-framework/athena/pull/219
+[#247]: https://github.com/athena-framework/athena/pull/247
+[#248]: https://github.com/athena-framework/athena/pull/248
 
 ## [0.3.0] - 2022-05-14
 
@@ -84,80 +121,88 @@ _First release a part of the monorepo._
 
 ### Changed
 
-- **Breaking:** change the `assert_error` to no longer be file based. Code should now be provided as a HEREDOC argument to the method ([#173](https://github.com/athena-framework/athena/pull/173)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- **Breaking:** change the `assert_error` to no longer be file based. Code should now be provided as a HEREDOC argument to the method ([#173]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Added
 
-- Add `VERSION` constant to `Athena::Spec` namespace ([#166](https://github.com/athena-framework/athena/pull/166)) (George Dietrich)
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
-- Add [ASPEC::Methods.assert_success](https://athenaframework.org/Spec/Methods/#Athena::Spec::Methods#assert_success(code,*,line,file)) ([#173](https://github.com/athena-framework/athena/pull/173)) (George Dietrich)
+- Add `VERSION` constant to `Athena::Spec` namespace ([#166]) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
+- Add [ASPEC::Methods.assert_success](https://athenaframework.org/Spec/Methods/#Athena::Spec::Methods#assert_success(code,*,line,file)) ([#173]) (George Dietrich)
+
+[0.3.0]: https://github.com/athena-framework/spec/releases/tag/v0.3.0
+[#166]: https://github.com/athena-framework/athena/pull/166
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#172]: https://github.com/athena-framework/athena/pull/172
+[#173]: https://github.com/athena-framework/athena/pull/173
 
 ## [0.2.6] - 2021-11-03
 
 ### Fixed
 
-- Fix `test` helper macro generating invalid method names by replacing all non alphanumeric chars with `_`  ([#12](https://github.com/athena-framework/spec/pull/12)) (George Dietrich)
+- Fix `test` helper macro generating invalid method names by replacing all non alphanumeric chars with `_`  ([#12]) (George Dietrich)
+
+[0.2.6]: https://github.com/athena-framework/spec/releases/tag/v0.2.6
+[#12]: https://github.com/athena-framework/spec/pull/12
 
 ## [0.2.5] - 2021-11-03
 
 ### Fixed
 
-- Fix `test` helper macro not actually calling `yield`  ([#11](https://github.com/athena-framework/spec/pull/11)) (George Dietrich)
+- Fix `test` helper macro not actually calling `yield`  ([#11]) (George Dietrich)
+
+[0.2.5]: https://github.com/athena-framework/spec/releases/tag/v0.2.5
+[#11]: https://github.com/athena-framework/spec/pull/11
 
 ## [0.2.4] - 2021-01-29
 
 ### Changed
 
-- Finish migration to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#9](https://github.com/athena-framework/spec/pull/9)) (George Dietrich)
+- Finish migration to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#9]) (George Dietrich)
+
+[0.2.4]: https://github.com/athena-framework/spec/releases/tag/v0.2.4
+[#9]: https://github.com/athena-framework/spec/pull/9
 
 ## [0.2.3] - 2020-12-03
 
 ### Changed
 
-- Update `crystal` version to allow version greater than `1.0.0` ([#7](https://github.com/athena-framework/spec/pull/7)) (George Dietrich
+- Update `crystal` version to allow version greater than `1.0.0` ([#7]) (George Dietrich)
+
+[0.2.3]: https://github.com/athena-framework/spec/releases/tag/v0.2.3
+[#7]: https://github.com/athena-framework/spec/pull/7
 
 ## [0.2.2] - 2020-10-02
 
 ### Added
 
-- Add support for data providers defined in parent types ([#6](https://github.com/athena-framework/spec/pull/6)) (George Dietrich)
+- Add support for data providers defined in parent types ([#6]) (George Dietrich)
+
+[0.2.2]: https://github.com/athena-framework/spec/releases/tag/v0.2.2
+[#6]: https://github.com/athena-framework/spec/pull/6
 
 ## [0.2.1] - 2020-09-25
 
 ### Changed
 
-- Changed data provider generated `it` blocks have proper file names and line numbers ([#4](https://github.com/athena-framework/spec/pull/4)) (George Dietrich)
+- Changed data provider generated `it` blocks have proper file names and line numbers ([#4]) (George Dietrich)
+
+[0.2.1]: https://github.com/athena-framework/spec/releases/tag/v0.2.1
+[#4]: https://github.com/athena-framework/spec/pull/4
 
 ## [0.2.0] - 2020-08-08
 
 ### Changed
 
-- **Breaking:** require [data providers](https://athenaframework.org/Spec/TestCase/DataProvider/) methods to declare a return type of `Hash`, `NamedTuple`, `Tuple`, or `Array` ([#3](https://github.com/athena-framework/spec/pull/3)) (George Dietrich)
-- Changed data provider generated `it` blocks to include the key/index ([#2](https://github.com/athena-framework/spec/pull/2)) (George Dietrich)
+- **Breaking:** require [data providers](https://athenaframework.org/Spec/TestCase/DataProvider/) methods to declare a return type of `Hash`, `NamedTuple`, `Tuple`, or `Array` ([#3]) (George Dietrich)
+- Changed data provider generated `it` blocks to include the key/index ([#2]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/spec/releases/tag/v0.2.0
+[#2]: https://github.com/athena-framework/spec/pull/2
+[#3]: https://github.com/athena-framework/spec/pull/3
 
 ## [0.1.0] - 2020-08-06
 
 _Initial release._
 
-[0.4.0]: https://github.com/athena-framework/spec/releases/tag/v0.4.0
-[0.3.11]: https://github.com/athena-framework/spec/releases/tag/v0.3.11
-[0.3.10]: https://github.com/athena-framework/spec/releases/tag/v0.3.10
-[0.3.9]: https://github.com/athena-framework/spec/releases/tag/v0.3.9
-[0.3.8]: https://github.com/athena-framework/spec/releases/tag/v0.3.8
-[0.3.7]: https://github.com/athena-framework/spec/releases/tag/v0.3.7
-[0.3.6]: https://github.com/athena-framework/spec/releases/tag/v0.3.6
-[0.3.5]: https://github.com/athena-framework/spec/releases/tag/v0.3.5
-[0.3.4]: https://github.com/athena-framework/spec/releases/tag/v0.3.4
-[0.3.3]: https://github.com/athena-framework/spec/releases/tag/v0.3.3
-[0.3.2]: https://github.com/athena-framework/spec/releases/tag/v0.3.2
-[0.3.1]: https://github.com/athena-framework/spec/releases/tag/v0.3.1
-[0.3.0]: https://github.com/athena-framework/spec/releases/tag/v0.3.0
-[0.2.6]: https://github.com/athena-framework/spec/releases/tag/v0.2.6
-[0.2.5]: https://github.com/athena-framework/spec/releases/tag/v0.2.5
-[0.2.4]: https://github.com/athena-framework/spec/releases/tag/v0.2.4
-[0.2.3]: https://github.com/athena-framework/spec/releases/tag/v0.2.3
-[0.2.2]: https://github.com/athena-framework/spec/releases/tag/v0.2.2
-[0.2.1]: https://github.com/athena-framework/spec/releases/tag/v0.2.1
-[0.2.0]: https://github.com/athena-framework/spec/releases/tag/v0.2.0
 [0.1.0]: https://github.com/athena-framework/spec/releases/tag/v0.1.0

--- a/src/components/validator/CHANGELOG.md
+++ b/src/components/validator/CHANGELOG.md
@@ -4,107 +4,150 @@
 
 ### Changed
 
-- **Breaking:** Normalize exception types ([#428](https://github.com/athena-framework/athena/pull/428)) (George Dietrich)
+- **Breaking:** Normalize exception types ([#428]) (George Dietrich)
 
 ### Added
 
-- **Breaking:** Add and make `require_tld: true` the default for `AVD::Constraints::URL` ([#492](https://github.com/athena-framework/athena/pull/492)) (George Dietrich)
-- Add example usages to `AVD::Constraints::*` docs ([#483](https://github.com/athena-framework/athena/pull/483), [#493](https://github.com/athena-framework/athena/pull/493)) (Zohir Tamda, George Dietrich)
+- **Breaking:** Add and make `require_tld: true` the default for `AVD::Constraints::URL` ([#492]) (George Dietrich)
+- Add example usages to `AVD::Constraints::*` docs ([#483], [#493]) (Zohir Tamda, George Dietrich)
+
+[0.4.0]: https://github.com/athena-framework/validator/releases/tag/v0.4.0
+[#428]: https://github.com/athena-framework/athena/pull/428
+[#483]: https://github.com/athena-framework/athena/pull/483
+[#492]: https://github.com/athena-framework/athena/pull/492
+[#493]: https://github.com/athena-framework/athena/pull/493
 
 ## [0.3.4] - 2024-07-31
 
 ### Changed
 
-- Update minimum `crystal` version to `~> 1.13.0` ([#433](https://github.com/athena-framework/athena/pull/433)) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.13.0` ([#433]) (George Dietrich)
+
+[0.3.4]: https://github.com/athena-framework/validator/releases/tag/v0.3.4
+[#433]: https://github.com/athena-framework/athena/pull/433
 
 ## [0.3.3] - 2024-04-09
 
 ### Changed
 
-- Integrate website into monorepo ([#365](https://github.com/athena-framework/athena/pull/365)) (George Dietrich)
+- Integrate website into monorepo ([#365]) (George Dietrich)
+
+[0.3.3]: https://github.com/athena-framework/validator/releases/tag/v0.3.3
+[#365]: https://github.com/athena-framework/athena/pull/365
 
 ## [0.3.2] - 2023-10-09
 
 ### Fixed
 
-- Fix compiler error when using a composite constraint with a single member and no `of AVD::Constraint` ([#292](https://github.com/athena-framework/athena/pull/292)) (George Dietrich)
+- Fix compiler error when using a composite constraint with a single member and no `of AVD::Constraint` ([#292]) (George Dietrich)
+
+[0.3.2]: https://github.com/athena-framework/validator/releases/tag/v0.3.2
+[#292]: https://github.com/athena-framework/athena/pull/292
 
 ## [0.3.1] - 2023-02-18
 
 ### Changed
 
-- Update some links in preparation for Athena Framework `0.18.0` ([#261](https://github.com/athena-framework/athena/pull/261)) (George Dietrich)
+- Update some links in preparation for Athena Framework `0.18.0` ([#261]) (George Dietrich)
 
 ### Fixed
 
-- Fix issue when using `AVD::Metadata::GetterMetadata` with methods that have parameters ([#252](https://github.com/athena-framework/athena/pull/252)) (George Dietrich)
+- Fix issue when using `AVD::Metadata::GetterMetadata` with methods that have parameters ([#252]) (George Dietrich)
+
+[0.3.1]: https://github.com/athena-framework/validator/releases/tag/v0.3.1
+[#252]: https://github.com/athena-framework/athena/pull/252
+[#261]: https://github.com/athena-framework/athena/pull/261
 
 ## [0.3.0] - 2023-01-07
 
 ### Changed
 
-- **Breaking:** update default `AVD::Constraints::Email::Mode` to be `:html5` ([#230](https://github.com/athena-framework/athena/pull/230)) (George Dietrich)
-- Refactor `AVD::Constraints::IP` to use new dedicated `Socket::IPAddress` methods ([#205](https://github.com/athena-framework/athena/pull/205)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.6` ([#205](https://github.com/athena-framework/athena/pull/205)) (George Dietrich)
+- **Breaking:** update default `AVD::Constraints::Email::Mode` to be `:html5` ([#230]) (George Dietrich)
+- Refactor `AVD::Constraints::IP` to use new dedicated `Socket::IPAddress` methods ([#205]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.6` ([#205]) (George Dietrich)
 
 ### Added
 
-- Add `AVD::Constraints::Collection` ([#229](https://github.com/athena-framework/athena/pull/229)) (George Dietrich)
-- Add `AVD::Constraints::Existence`, `AVD::Constraints::Required`, and `AVD::Constraints::Optional` for use with the collection constraint ([#229](https://github.com/athena-framework/athena/pull/229)) (George Dietrich)
-- Add `AVD::Spec::ConstraintValidatorTestCase#expect_validate_value_at` to more easily handle validation of nested constraints ([#229](https://github.com/athena-framework/athena/pull/229)) (George Dietrich)
-- Add `AVD::Constraints::Email::Mode::HTML5_ALLOW_NO_TLD` that allows matching `HTML` input field validation exactly ([#231](https://github.com/athena-framework/athena/pull/231)) (George Dietrich)
+- Add `AVD::Constraints::Collection` ([#229]) (George Dietrich)
+- Add `AVD::Constraints::Existence`, `AVD::Constraints::Required`, and `AVD::Constraints::Optional` for use with the collection constraint ([#229]) (George Dietrich)
+- Add `AVD::Spec::ConstraintValidatorTestCase#expect_validate_value_at` to more easily handle validation of nested constraints ([#229]) (George Dietrich)
+- Add `AVD::Constraints::Email::Mode::HTML5_ALLOW_NO_TLD` that allows matching `HTML` input field validation exactly ([#231]) (George Dietrich)
 
 ### Removed
 
-- **Breaking:** remove `AVD::Constraints::Email::Mode::Loose` ([#230](https://github.com/athena-framework/athena/pull/230)) (George Dietrich)
+- **Breaking:** remove `AVD::Constraints::Email::Mode::Loose` ([#230]) (George Dietrich)
 
 ### Fixed
 
-- **Breaking:** fix spelling of `AVD::Constraints::ISSN#require_hyphen` parameter ([#222](https://github.com/athena-framework/athena/pull/222)) (George Dietrich)
-- Fix property path display issue with `Enumerable` objects ([#229](https://github.com/athena-framework/athena/pull/229)) (George Dietrich)
-- Fix `AVD::Constraints::Valid` constraints incorrectly being allowed within `AVD::Constraints::Composite` ([#229](https://github.com/athena-framework/athena/pull/229)) (George Dietrich)
+- **Breaking:** fix spelling of `AVD::Constraints::ISSN#require_hyphen` parameter ([#222]) (George Dietrich)
+- Fix property path display issue with `Enumerable` objects ([#229]) (George Dietrich)
+- Fix `AVD::Constraints::Valid` constraints incorrectly being allowed within `AVD::Constraints::Composite` ([#229]) (George Dietrich)
+
+[0.3.0]: https://github.com/athena-framework/validator/releases/tag/v0.3.0
+[#205]: https://github.com/athena-framework/athena/pull/205
+[#222]: https://github.com/athena-framework/athena/pull/222
+[#229]: https://github.com/athena-framework/athena/pull/229
+[#230]: https://github.com/athena-framework/athena/pull/230
+[#231]: https://github.com/athena-framework/athena/pull/231
 
 ## [0.2.1] - 2022-09-05
 
 ### Added
 
-- Add support for exclusive end support to `AVD::Constraints::Range` ([#184](https://github.com/athena-framework/athena/pull/184)) (George Dietrich)
+- Add support for exclusive end support to `AVD::Constraints::Range` ([#184]) (George Dietrich)
 
 ### Changed
 
-- Include allowed MIME types within `AVD::Constraints::Image` if they were customized ([#183](https://github.com/athena-framework/athena/pull/183)) (George Dietrich)
-- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188](https://github.com/athena-framework/athena/pull/188)) (George Dietrich)
+- Include allowed MIME types within `AVD::Constraints::Image` if they were customized ([#183]) (George Dietrich)
+- **Breaking:** ensure parameter names defined on interfaces match the implementation ([#188]) (George Dietrich)
 
 ### Fixed
 
-- Fix some file size factorization edge cases in `AVD::Constraints::File` ([#182](https://github.com/athena-framework/athena/pull/182)) (George Dietrich)
-- Fix duplicating constraints due to Crystal generics bug ([#192](https://github.com/athena-framework/athena/pull/192)) (George Dietrich)
+- Fix some file size factorization edge cases in `AVD::Constraints::File` ([#182]) (George Dietrich)
+- Fix duplicating constraints due to Crystal generics bug ([#192]) (George Dietrich)
+
+[0.2.1]: https://github.com/athena-framework/validator/releases/tag/v0.2.1
+[#182]: https://github.com/athena-framework/athena/pull/182
+[#183]: https://github.com/athena-framework/athena/pull/183
+[#184]: https://github.com/athena-framework/athena/pull/184
+[#188]: https://github.com/athena-framework/athena/pull/188
+[#192]: https://github.com/athena-framework/athena/pull/192
 
 ## [0.2.0] - 2022-05-14
 
 ### Added
 
-- Add the [AVD::Constraints::File](https://athenaframework.org/Validator/Constraints/File/) constraint ([#153](https://github.com/athena-framework/athena/pull/153)) (George Dietrich)
-- Allow `AVD::Spec::MockValidator` to dynamically configure returned violations ([#155](https://github.com/athena-framework/athena/pull/155), [#157](https://github.com/athena-framework/athena/pull/157)) (George Dietrich)
-- Add the [AVD::Constraints::Image](https://athenaframework.org/Validator/Constraints/Image/) constraint ([#153](https://github.com/athena-framework/athena/pull/153)) (George Dietrich)
-- Add getting started documentation to API docs ([#172](https://github.com/athena-framework/athena/pull/172)) (George Dietrich)
+- Add the [AVD::Constraints::File](https://athenaframework.org/Validator/Constraints/File/) constraint ([#153]) (George Dietrich)
+- Allow `AVD::Spec::MockValidator` to dynamically configure returned violations ([#155], [#157]) (George Dietrich)
+- Add the [AVD::Constraints::Image](https://athenaframework.org/Validator/Constraints/Image/) constraint ([#153]) (George Dietrich)
+- Add getting started documentation to API docs ([#172]) (George Dietrich)
 
 ### Changed
 
-- **Breaking:** make `AVD::ConstraintValidator` classes ([#154](https://github.com/athena-framework/athena/pull/154)) (George Dietrich)
-- **Breaking:** `AVD::ExecutionContext` is no longer a generic type ([#156](https://github.com/athena-framework/athena/pull/156)) (George Dietrich)
-- Update `assert_violation` to use a clearer failure message if no violations were found ([#153](https://github.com/athena-framework/athena/pull/153)) (George Dietrich)
-- Update `AVD::Constraints::ISIN` to use the validator off the context versus an ivar ([#155](https://github.com/athena-framework/athena/pull/155)) (George Dietrich)
-- Update minimum `crystal` version to `~> 1.4.0` ([#169](https://github.com/athena-framework/athena/pull/169)) (George Dietrich)
+- **Breaking:** make `AVD::ConstraintValidator` classes ([#154]) (George Dietrich)
+- **Breaking:** `AVD::ExecutionContext` is no longer a generic type ([#156]) (George Dietrich)
+- Update `assert_violation` to use a clearer failure message if no violations were found ([#153]) (George Dietrich)
+- Update `AVD::Constraints::ISIN` to use the validator off the context versus an ivar ([#155]) (George Dietrich)
+- Update minimum `crystal` version to `~> 1.4.0` ([#169]) (George Dietrich)
 
 ### Removed
 
-- **Breaking:** removed `AVD::Spec::MockValidator#violations=` ([#155](https://github.com/athena-framework/athena/pull/155)) (George Dietrich)
+- **Breaking:** removed `AVD::Spec::MockValidator#violations=` ([#155]) (George Dietrich)
 
 ### Fixed
 
-- Fix `AVD::Violation::ConstraintViolation` not comparing correctly ([#153](https://github.com/athena-framework/athena/pull/153)) (George Dietrich)
-- Ensure only `Indexable` types can be used with `AVD::Constraints::Unique` ([#168](https://github.com/athena-framework/athena/pull/168)) (George Dietrich)
+- Fix `AVD::Violation::ConstraintViolation` not comparing correctly ([#153]) (George Dietrich)
+- Ensure only `Indexable` types can be used with `AVD::Constraints::Unique` ([#168]) (George Dietrich)
+
+[0.2.0]: https://github.com/athena-framework/validator/releases/tag/v0.2.0
+[#153]: https://github.com/athena-framework/athena/pull/153
+[#154]: https://github.com/athena-framework/athena/pull/154
+[#155]: https://github.com/athena-framework/athena/pull/155
+[#156]: https://github.com/athena-framework/athena/pull/156
+[#157]: https://github.com/athena-framework/athena/pull/157
+[#168]: https://github.com/athena-framework/athena/pull/168
+[#169]: https://github.com/athena-framework/athena/pull/169
+[#172]: https://github.com/athena-framework/athena/pull/172
 
 ## [0.1.7] - 2021-12-27
 
@@ -112,70 +155,79 @@ _First release a part of the monorepo._
 
 ### Fixed
 
-- Fix callback constraint methods being incorrectly added as getters ([#132](https://github.com/athena-framework/athena/pull/132)) (George Dietrich)
+- Fix callback constraint methods being incorrectly added as getters ([#132]) (George Dietrich)
+
+[0.1.7]: https://github.com/athena-framework/validator/releases/tag/v0.1.7
+[#132]: https://github.com/athena-framework/athena/pull/132
 
 ## [0.1.6] - 2021-12-13
 
 ### Fixed
 
-- Fix `AVD::Validatable` not working when included into parent types ([#16](https://github.com/athena-framework/validator/pull/16)) (George Dietrich)
+- Fix `AVD::Validatable` not working when included into parent types ([#16]) (George Dietrich)
+
+[0.1.6]: https://github.com/athena-framework/validator/releases/tag/v0.1.6
+[#16]: https://github.com/athena-framework/validator/pull/16
 
 ## [0.1.5] - 2021-10-30
 
 ### Added
 
-- Add `VERSION` constant to `Athena::Validator` namespace ([#12](https://github.com/athena-framework/validator/pull/12)) (George Dietrich)
+- Add `VERSION` constant to `Athena::Validator` namespace ([#12]) (George Dietrich)
 
 ### Fixed
 
-- Fix incorrect type restriction on validator factory ([#12](https://github.com/athena-framework/validator/pull/12)) (George Dietrich)
-- Fix incorrect link within the docs ([#14](https://github.com/athena-framework/validator/pull/14)) (George Dietrich)
+- Fix incorrect type restriction on validator factory ([#12]) (George Dietrich)
+- Fix incorrect link within the docs ([#14]) (George Dietrich)
+
+[0.1.5]: https://github.com/athena-framework/validator/releases/tag/v0.1.5
+[#12]: https://github.com/athena-framework/validator/pull/12
+[#14]: https://github.com/athena-framework/validator/pull/14
 
 ## [0.1.4] - 2021-01-30
 
 ### Changed
 
-- Finish migration to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#10](https://github.com/athena-framework/validator/pull/10), [#11](https://github.com/athena-framework/validator/pull/11)) (George Dietrich)
+- Finish migration to [MkDocs](https://mkdocstrings.github.io/crystal/) ([#10], [#11]) (George Dietrich)
+
+[0.1.4]: https://github.com/athena-framework/validator/releases/tag/v0.1.4
+[#10]: https://github.com/athena-framework/validator/pull/10
+[#11]: https://github.com/athena-framework/validator/pull/11
 
 ## [0.1.3] - 2020-12-07
 
 ### Changed
 
-- Update `crystal` version to allow version greater than `1.0.0` ([#9](https://github.com/athena-framework/validator/pull/9)) (George Dietrich
+- Update `crystal` version to allow version greater than `1.0.0` ([#9]) (George Dietrich)
+
+[0.1.3]: https://github.com/athena-framework/validator/releases/tag/v0.1.3
+[#9]: https://github.com/athena-framework/validator/pull/9
 
 ## [0.1.2] - 2020-11-25
 
 ### Added
 
-- Add the [AVD::Constraints::Choice](https://athenaframework.org/Validator/Constraints/Choice/) constraint ([#7](https://github.com/athena-framework/validator/pull/7)) (George Dietrich)
+- Add the [AVD::Constraints::Choice](https://athenaframework.org/Validator/Constraints/Choice/) constraint ([#7]) (George Dietrich)
 
 ### Changed
 
-- Allow setting violations directly on mock validators ([#7](https://github.com/athena-framework/validator/pull/7)) (George Dietrich)
+- Allow setting violations directly on mock validators ([#7]) (George Dietrich)
+
+[0.1.2]: https://github.com/athena-framework/validator/releases/tag/v0.1.2
+[#7]: https://github.com/athena-framework/validator/pull/7
 
 ## [0.1.1] - 2020-11-08
 
 ### Fixed
 
-- Fix compiler error due to less strict `abstract def` implementations ([#6](https://github.com/athena-framework/validator/pull/6)) (George Dietrich)
+- Fix compiler error due to less strict `abstract def` implementations ([#6]) (George Dietrich)
+
+[0.1.1]: https://github.com/athena-framework/validator/releases/tag/v0.1.1
+[#6]: https://github.com/athena-framework/validator/pull/6
 
 ## [0.1.0] - 2020-10-17
 
 _Initial release._
 
-[0.4.0]: https://github.com/athena-framework/validator/releases/tag/v0.4.0
-[0.3.4]: https://github.com/athena-framework/validator/releases/tag/v0.3.4
-[0.3.3]: https://github.com/athena-framework/validator/releases/tag/v0.3.3
-[0.3.2]: https://github.com/athena-framework/validator/releases/tag/v0.3.2
-[0.3.1]: https://github.com/athena-framework/validator/releases/tag/v0.3.1
-[0.3.0]: https://github.com/athena-framework/validator/releases/tag/v0.3.0
-[0.2.1]: https://github.com/athena-framework/validator/releases/tag/v0.2.1
-[0.2.0]: https://github.com/athena-framework/validator/releases/tag/v0.2.0
-[0.1.7]: https://github.com/athena-framework/validator/releases/tag/v0.1.7
-[0.1.6]: https://github.com/athena-framework/validator/releases/tag/v0.1.6
-[0.1.5]: https://github.com/athena-framework/validator/releases/tag/v0.1.5
-[0.1.4]: https://github.com/athena-framework/validator/releases/tag/v0.1.4
-[0.1.3]: https://github.com/athena-framework/validator/releases/tag/v0.1.3
-[0.1.2]: https://github.com/athena-framework/validator/releases/tag/v0.1.2
-[0.1.1]: https://github.com/athena-framework/validator/releases/tag/v0.1.1
 [0.1.0]: https://github.com/athena-framework/validator/releases/tag/v0.1.0
+


### PR DESCRIPTION
## Context

Previously the format used Markdown link references _only_ for the version numbers, of which all of them were at the bottom of this file. This PR makes it so PR links also leverage link references and moves version references into the footer of each version.

The primary reason for making this change, other than having the changelog be less noisy of course. Is that the old structure was incompatible with #573. Keeping the old convention was impossible, and I figured it would be best to make everything consistent versus having new releases be different than the previous ones.

These changes are all internal, the rendered markdown looks the same as it did before.

## Changelog

* Tweak `CHANGELOG.md` structure

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
