### PR TITLE
Bump `serializer`

### DIFF
--- a/.changes/serializer/v0.4.2.md
+++ b/.changes/serializer/v0.4.2.md
@@ -1,0 +1,8 @@
+## [0.4.2] - 2025-08-12
+
+### Fixed
+
+- Fix nightly type incompatibility with `ASR::Any` ([#562]) (George Dietrich)
+
+[0.4.2]: https://github.com/athena-framework/serializer/releases/tag/v0.4.2
+[#562]: https://github.com/athena-framework/athena/pull/562

--- a/.changes/unreleased/serializer-Fixed-20250809-213627.yaml
+++ b/.changes/unreleased/serializer-Fixed-20250809-213627.yaml
@@ -1,8 +1,0 @@
-project: serializer
-kind: Fixed
-body: Fix nightly type incompatibility with `ASR::Any`
-time: 2025-08-09T21:36:27.416169819-04:00
-custom:
-    Author: George Dietrich
-    PR: "562"
-    Username: blacksmoke16

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -147,5 +147,5 @@ newlines:
   beforeChangelogVersion: 1
   afterKind: 1
   beforeKind: 1
-  beforeFooterTemplate: 0
+  beforeFooterTemplate: 1
 envPrefix: CHANGIE_

--- a/src/components/serializer/CHANGELOG.md
+++ b/src/components/serializer/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.4.2] - 2025-08-12
+
+### Fixed
+
+- Fix nightly type incompatibility with `ASR::Any` ([#562]) (George Dietrich)
+
+[0.4.2]: https://github.com/athena-framework/serializer/releases/tag/v0.4.2
+[#562]: https://github.com/athena-framework/athena/pull/562
+
 ## [0.4.1] - 2025-02-08
 
 ### Fixed

--- a/src/components/serializer/shard.yml
+++ b/src/components/serializer/shard.yml
@@ -1,6 +1,6 @@
 name: athena-serializer
 
-version: 0.4.1
+version: 0.4.2
 
 crystal: ~> 1.13
 

--- a/src/components/serializer/src/athena-serializer.cr
+++ b/src/components/serializer/src/athena-serializer.cr
@@ -36,7 +36,7 @@ module YAML; end
 
 # Provides enhanced (de)serialization features.
 module Athena::Serializer
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 
   # Returns an `ASR::SerializerInterface` instance for ad-hoc (de)serialization.
   #


### PR DESCRIPTION
## Context

First release using [changie](https://changie.dev)! Had to enable `beforeFooterTemplate` now that the version is before the PR link reference list.

But this release is in order so I can update the demo repo to avoid nightly CI failures.

## Changelog

* Bump `serializer` to `v0.4.2`

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
