### PR TITLE
Fix broken `pick-docs` job

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -72,20 +72,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        repo: ${{ fromJson(needs.sync.outputs.updated_components) }}
+        component: ${{ fromJson(needs.sync.outputs.updated_components) }}
     steps:
       - uses: webfactory/ssh-agent@v0.9.1
         with:
           ssh-private-key: ${{ secrets.ATHENA_BOT_SSH_PRIV_KEY }}
       - uses: actions/checkout@v5
         with:
-          repository: athena-framework/${{ matrix.repository }}
+          repository: athena-framework/${{ matrix.component }}
           ref: docs
       - name: Cherry pick commit
         run: |
           set -euo pipefail
 
-          NEW_COMMIT=$(git ls-remote "git@github.com:athena-framework/${{ matrix.repository }}.git" HEAD | awk '{ print $1}')
+          NEW_COMMIT=$(git ls-remote "git@github.com:athena-framework/${{ matrix.component }}.git" HEAD | awk '{ print $1}')
           git config user.name "Pallas Athenaie"
           git config user.email "pallas@athenaframework.org"
           git fetch origin $NEW_COMMIT

--- a/src/components/clock/src/aware.cr
+++ b/src/components/clock/src/aware.cr
@@ -11,7 +11,7 @@ class Athena::Clock; end
 #   end
 # end
 #
-# # By default uses an `Athena::Clock` instance
+# # Will use a `Athena::Clock` instance if a custom one is not set on the instance.
 # example = Example.new
 #
 # # Or use a custom implementation.


### PR DESCRIPTION
## Context

Follow up to #577. Missed that the matrix key was `repo` but I was referencing `repository`. Updated them both to `component` to make it a bit more clear as that's what each value is; the name of a component (git repo format).

## Changelog

* Fix broken `pick-docs` job

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
