### PR TITLE
Fix permission issue in `pick-docs` when running `git push`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: webfactory/ssh-agent@v0.9.1
+      - uses: actions/checkout@v5
         with:
-          ssh-private-key: ${{ secrets.MKDOCS_INSIDERS_SSH_PRIV_KEY }}
-      - uses: actions/checkout@v4
+          ssh-key: ${{ secrets.MKDOCS_INSIDERS_SSH_PRIV_KEY }}
       - uses: extractions/setup-just@v3
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -18,12 +18,10 @@ jobs:
       kind_docs: ${{ steps.subtree-sync.outputs.kind_docs }}
       kind_release: ${{ steps.subtree-sync.outputs.kind_release }}
     steps:
-      - uses: webfactory/ssh-agent@v0.9.1
-        with:
-          ssh-private-key: ${{ secrets.ATHENA_BOT_SSH_PRIV_KEY }}
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Required so `git subtree` can find its split commit
+          ssh-key: ${{ secrets.ATHENA_BOT_SSH_PRIV_KEY }}
       - name: Sync Components
         id: subtree-sync
         env:
@@ -74,23 +72,22 @@ jobs:
       matrix:
         component: ${{ fromJson(needs.sync.outputs.updated_components) }}
     steps:
-      - uses: webfactory/ssh-agent@v0.9.1
-        with:
-          ssh-private-key: ${{ secrets.ATHENA_BOT_SSH_PRIV_KEY }}
       - uses: actions/checkout@v5
         with:
           repository: athena-framework/${{ matrix.component }}
           ref: docs
+          ssh-key: ${{ secrets.ATHENA_BOT_SSH_PRIV_KEY }}
       - name: Cherry pick commit
         run: |
           set -euo pipefail
 
+          git config user.name "${{ vars.BOT_USER_NAME }}"
+          git config user.email "${{ vars.BOT_USER_EMAIL }}"
+
           NEW_COMMIT=$(git ls-remote "git@github.com:athena-framework/${{ matrix.component }}.git" HEAD | awk '{ print $1}')
-          git config user.name "Pallas Athenaie"
-          git config user.email "pallas@athenaframework.org"
           git fetch origin $NEW_COMMIT
           git cherry-pick $NEW_COMMIT
-          git push
+          git push origin docs
 
   # If there were component related doc updates, trigger a re-build after all components were synced.
   build-component-docs:
@@ -119,10 +116,9 @@ jobs:
   build-dev-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: webfactory/ssh-agent@v0.9.1
-        with:
-          ssh-private-key: ${{ secrets.MKDOCS_INSIDERS_SSH_PRIV_KEY }}
       - uses: actions/checkout@v5
+        with:
+          ssh-key: ${{ secrets.MKDOCS_INSIDERS_SSH_PRIV_KEY }}
       - uses: extractions/setup-just@v3
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1

--- a/src/components/clock/src/aware.cr
+++ b/src/components/clock/src/aware.cr
@@ -14,7 +14,8 @@ class Athena::Clock; end
 # # Will use a `Athena::Clock` instance if a custom one is not set on the instance.
 # example = Example.new
 #
-# # Or use a custom implementation.
+# # Or if so desired, explicitly set custom implementation.
+# my_clock = MySpecialClock.new
 # custom_example = Example.new
 # custom_example.clock = my_clock
 # ```


### PR DESCRIPTION
## Context

Follow up to #578 as it now seems the commit failed to push :thinking:.

EDIT: Was doing the checkout with `https` auth. Updated `actions/checkout` to use `ssh-key`, which might also make it so we don't need `webfactory/ssh-agent` anymore?

## Changelog

* Fix permission issue in `pick-docs` when running `git push`

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
