### PR TITLE
Final new sync GHA workflow tweaks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,10 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: webfactory/ssh-agent@v0.9.1
         with:
-          ssh-key: ${{ secrets.MKDOCS_INSIDERS_SSH_PRIV_KEY }}
+          ssh-private-key: ${{ secrets.MKDOCS_INSIDERS_SSH_PRIV_KEY }}
+      - uses: actions/checkout@v5
       - uses: extractions/setup-just@v3
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -97,6 +97,7 @@ jobs:
       - pick-docs
     if: needs.sync.outputs.kind_docs == 'true' && needs.sync.outputs.updated_components != '[]'
     steps:
+      - uses: actions/checkout@v5
       - run: gh workflow run release.yml
         env:
           GH_TOKEN: ${{ github.token }}
@@ -108,6 +109,7 @@ jobs:
       - sync
     if: needs.sync.outputs.kind_docs == 'true' && needs.sync.outputs.updated_components == '[]'
     steps:
+      - uses: actions/checkout@v5
       - run: gh workflow run release.yml
         env:
           GH_TOKEN: ${{ github.token }}
@@ -116,9 +118,10 @@ jobs:
   build-dev-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: webfactory/ssh-agent@v0.9.1
         with:
-          ssh-key: ${{ secrets.MKDOCS_INSIDERS_SSH_PRIV_KEY }}
+          ssh-private-key: ${{ secrets.MKDOCS_INSIDERS_SSH_PRIV_KEY }}
+      - uses: actions/checkout@v5
       - uses: extractions/setup-just@v3
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1


### PR DESCRIPTION
## Context

Hopefully one last follow up to #579. Restore the `ssh-agent` action as it's still needed to install the `pip` deps. Also be sure to clone the repo before calling `gh workflow run` so it knows what to actually do.

## Changelog

* Restore usages of `ssh-agent` for building docs
* Clone the repo before running `gh workflow run`

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
