### PR TITLE
Revert unexpected changes to `spec` component

### DIFF
--- a/.changes/spec/v0.3.11.md
+++ b/.changes/spec/v0.3.11.md
@@ -1,16 +1,3 @@
-## [0.4.0] - 2025-??-??
-
-### Added
-
-- Add ability to generate macro code coverage reports for `ASPEC::Methods.assert_compile_time_error` usages ([#551]) (George Dietrich)
-
-### Removed
-
-- **Breaking:** Remove `ASPEC::Methods.assert_error` and `ASPEC::Methods.assert_success` methods ([#551]) (George Dietrich)
-
-[0.4.0]: https://github.com/athena-framework/spec/releases/tag/v0.4.0
-[#551]: https://github.com/athena-framework/athena/pull/551
-
 ## [0.3.11] - 2025-05-19
 
 ### Fixed

--- a/src/components/spec/CHANGELOG.md
+++ b/src/components/spec/CHANGELOG.md
@@ -1,18 +1,5 @@
 # Changelog
 
-## [0.4.0] - 2025-??-??
-
-### Added
-
-- Add ability to generate macro code coverage reports for `ASPEC::Methods.assert_compile_time_error` usages ([#551]) (George Dietrich)
-
-### Removed
-
-- **Breaking:** Remove `ASPEC::Methods.assert_error` and `ASPEC::Methods.assert_success` methods ([#551]) (George Dietrich)
-
-[0.4.0]: https://github.com/athena-framework/spec/releases/tag/v0.4.0
-[#551]: https://github.com/athena-framework/athena/pull/551
-
 ## [0.3.11] - 2025-05-19
 
 ### Fixed

--- a/src/components/spec/docs/README.md
+++ b/src/components/spec/docs/README.md
@@ -10,7 +10,7 @@ First, install the component by adding the following to your `shard.yml`, then r
 dependencies:
   athena-spec:
     github: athena-framework/spec
-    version: ~> 0.4.0
+    version: ~> 0.3.0
 ```
 
 ## Usage

--- a/src/components/spec/shard.yml
+++ b/src/components/spec/shard.yml
@@ -1,6 +1,6 @@
 name: athena-spec
 
-version: 0.4.0
+version: 0.3.11
 
 crystal: ~> 1.17
 

--- a/src/components/spec/src/athena-spec.cr
+++ b/src/components/spec/src/athena-spec.cr
@@ -6,7 +6,7 @@ require "./test_case"
 
 # A set of common [Spec](https://crystal-lang.org/api/Spec.html) compliant testing utilities/types.
 module Athena::Spec
-  VERSION = "0.4.0"
+  VERSION = "0.3.11"
 
   # Runs all `ASPEC::TestCase`s.
   #


### PR DESCRIPTION
## Context

#551 included an unreleased version in the `CHANGELOG.md` file. This is unexpected since it's not actually released which ended up confusing changie (and myself). This PR reverts the versions back to the currently released version and removes that section from the changelog.

## Changelog

* Revert unexpected changes to `spec` component

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
