### PR TITLE
Fix failing nightly `serializer` spec

### DIFF
--- a/src/components/serializer/spec/serializer_spec.cr
+++ b/src/components/serializer/spec/serializer_spec.cr
@@ -192,7 +192,7 @@ describe ASR::Serializer do
 
     describe "primitive" do
       it nil do
-        expect_raises ASR::Exception::DeserializationException, "Could not parse String from 'nil'." do
+        expect_raises ASR::Exception::DeserializationException, "Could not parse String from ''." do
           ASR.serializer.deserialize String, "null", :json
         end
       end

--- a/src/components/serializer/src/visitors/deserialization_visitor.cr
+++ b/src/components/serializer/src/visitors/deserialization_visitor.cr
@@ -41,7 +41,7 @@ end
     def {{type}}.deserialize(visitor : ASR::Visitors::DeserializationVisitorInterface, data : ASR::Any)
       data{{method.id}}
     rescue ex : TypeCastError
-      raise ASR::Exception::DeserializationException.new "Could not parse {{type}} from '#{data.inspect}'."
+      raise ASR::Exception::DeserializationException.new "Could not parse {{type}} from '#{data}'."
     end
   {% end %}
 {% end %}


### PR DESCRIPTION
## Context

https://github.com/crystal-lang/crystal/pull/15979 changed the representation of `#inspect`. This PR just changes the spec to be less specific and rely on the `#to_s` implementation.

## Changelog

* Fix failing nightly `serializer` spec

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
