### PR TITLE
Fix incorrect console getting started docs

### DIFF
--- a/src/components/console/docs/README.md
+++ b/src/components/console/docs/README.md
@@ -37,7 +37,7 @@ This method is where the [ACON::Input::Argument][]s and [ACON::Input::Option][]s
 protected def configure : Nil
   self
     .argument("username", :required, "The username of the user")
-    .alias("new-user")
+    .aliases("new-user")
 end
 ```
 
@@ -59,7 +59,7 @@ application.add CreateUserCommand.new
 application.register "foo" do |input, output, cmd|
   # Do stuff
 
-  ACON::Command::Status::Success
+  ACON::Command::Status::SUCCESS
 end
 
 # Run the application.


### PR DESCRIPTION
## Context

Fixes some invalid code in the console getting started docs as pointed out in [gitter](https://matrix.to/#/!DCnOFYRfeFHMcbUHoI:gitter.im/$dKBeNMcNrYpnozKRzQA86R3F5mTGlBzXcZQSGKVQAV8?via=gitter.im&via=matrix.org&via=beeper.com).

## Changelog

* Fix incorrect console getting started docs

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
