### PR TITLE
Use Athena bot SSH key for the building docs jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
-          ssh-private-key: ${{ secrets.MKDOCS_INSIDERS_SSH_PRIV_KEY }}
+          ssh-private-key: ${{ secrets.ATHENA_BOT_SSH_PRIV_KEY }}
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Install Crystal

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -200,7 +200,7 @@ jobs:
     steps:
       - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
-          ssh-private-key: ${{ secrets.MKDOCS_INSIDERS_SSH_PRIV_KEY }}
+          ssh-private-key: ${{ secrets.ATHENA_BOT_SSH_PRIV_KEY }}
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Install Crystal


### PR DESCRIPTION
## Context

Athena bot user now has access to MKDocs insiders repo. As such we can now just re-use the same SSH key, which has much more limited access than I do.

## Changelog

* Use Athena bot SSH key for the building docs jobs

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
