### PR TITLE
Make `ATH::File#realpath` spec more robust

### DIFF
--- a/src/components/framework/spec/file_spec.cr
+++ b/src/components/framework/spec/file_spec.cr
@@ -112,7 +112,7 @@ struct FileTest < ASPEC::TestCase
   end
 
   def test_realpath : Nil
-    ATH::File.new("#{__DIR__}/../spec/assets/foo.txt").realpath.should eq Path[__DIR__, "assets", "foo.txt"].to_s
+    ATH::File.new("#{__DIR__}/../spec/assets/foo.txt").realpath.should eq ::File.realpath(Path[__DIR__, "assets", "foo.txt"].to_s)
   end
 
   def test_basename : Nil


### PR DESCRIPTION
## Context

This PR makes the `ATH::File#realpath` spec a bit more robust by handling the case it runs within a directory that is a symlink. `Path#to_s` was not resolving the link, thus causing the spec to fail when `ATH::File#realpath` did.

## Changelog

* Make `ATH::File#realpath` spec more robust

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
