### PR TITLE
Make `ASPEC.assert_compile_time_error` ENV var customization spec more robust

### DIFF
--- a/src/components/spec/spec/methods_spec.cr
+++ b/src/components/spec/spec/methods_spec.cr
@@ -4,7 +4,13 @@ describe ASPEC::Methods do
   describe ".assert_compile_time_error", tags: "compiled" do
     it "allows customizing crystal binary via CRYSTAL env var" do
       # Do this in its own sub-process to avoid mucking with ENV.
-      assert_runtime_error "'/path/to/crystal': No such file or directory", <<-CR
+      message = {% if flag? "windows" %}
+                  "The system cannot find the file specified"
+                {% else %}
+                  "No such file or directory"
+                {% end %}
+
+      assert_runtime_error message, <<-CR
         require "./spec_helper"
 
         ENV["CRYSTAL"] = "/path/to/crystal"


### PR DESCRIPTION
## Context

This wasn't caught via CI since compiled specs only run against linux since this normally shouldn't affect the outcome. However this specs runs in a sub-process to avoid messing with the system's ENV state. As such the exception message for the file not existing can vary depending on the OS it's ran on.

This PR makes the spec more robust by picking the right message based on OS so it can pass on Windows directly as well.

## Changelog

* Make `ASPEC.assert_compile_time_error` ENV var customization spec more robust

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
