### PR TITLE
Fix release job in sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Changie
         uses: miniscruff/changie-action@5036dffa79ffc007110dc7f75eca7ef72780e147 # v2.1.0
         with:
-          version: 1.22.1
+          version: v1.22.1
       - name: Get the latest version
         working-directory: root
         id: current-release


### PR DESCRIPTION
## Context

#601 updated the sync script to use the `changie-action` which I set to the same version as before, but it seems to require the version starts with `v`, otherwise:
```
filename: changie_.22.1_linux_amd64.tar.gz
Downloading https://github.com/miniscruff/changie/releases/download/1.22.1/changie_.22.1_linux_amd64.tar.gz
Error: Unexpected HTTP response: 404
```

## Changelog

* Fix release job in sync workflow

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
