### PR TITLE
Remove un-necessary quotes around the tag message

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -106,7 +106,7 @@ jobs:
           COMPONENT_NAME=$(echo "${{ matrix.component }}" | tr '-' ' ' | sed -e 's/\b./\u\0/g')
           MESSAGE="Athena $COMPONENT_NAME ${{ steps.current-release.outputs.tag }}"
 
-          git tag -asm "'$MESSAGE'" ${{ steps.current-release.outputs.tag }}
+          git tag -asm "$MESSAGE" ${{ steps.current-release.outputs.tag }}
           git push --quiet origin ${{ steps.current-release.outputs.tag }}
 
           # Be sure to reset `docs` branch back to current state of `master` as a release assumes the previously cherry-picked commits are now inherently included


### PR DESCRIPTION
## Context

Noticed these un-necessary quotes around the tag message which you can see on `v0.1.11` for example within https://github.com/athena-framework/routing/tags.

## Changelog

* Remove un-necessary quotes around the tag message

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
