### PR TITLE
Add new overload to allow loading a single dotenv file

### DIFF
--- a/.changes/dotenv/v0.2.1.md
+++ b/.changes/dotenv/v0.2.1.md
@@ -1,0 +1,8 @@
+## [0.2.1] - 2025-11-09
+
+### Fixed
+
+- Fix being unable to call `Athena::Dotenv.load` with a single file ([#609]) (George Dietrich) <!-- blacksmoke16 -->
+
+[0.2.1]: https://github.com/athena-framework/dotenv/releases/tag/v0.2.1
+[#609]: https://github.com/athena-framework/athena/pull/609

--- a/src/components/dotenv/CHANGELOG.md
+++ b/src/components/dotenv/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.2.1] - 2025-11-09
+
+### Fixed
+
+- Fix being unable to call `Athena::Dotenv.load` with a single file ([#609]) (George Dietrich) <!-- blacksmoke16 -->
+
+[0.2.1]: https://github.com/athena-framework/dotenv/releases/tag/v0.2.1
+[#609]: https://github.com/athena-framework/athena/pull/609
+
 ## [0.2.0] - 2025-01-26
 
 ### Changed

--- a/src/components/dotenv/shard.yml
+++ b/src/components/dotenv/shard.yml
@@ -1,6 +1,6 @@
 name: athena-dotenv
 
-version: 0.2.0
+version: 0.2.1
 
 crystal: ~> 1.13
 

--- a/src/components/dotenv/spec/athena-dotenv_spec.cr
+++ b/src/components/dotenv/spec/athena-dotenv_spec.cr
@@ -216,6 +216,22 @@ struct DotEnvTest < ASPEC::TestCase
     file2.delete
   end
 
+  def test_class_load_single_file : Nil
+    ENV.delete "FOO"
+
+    file = File.tempfile do |f|
+      f.puts "FOO=BAR"
+    end
+
+    Athena::Dotenv.load file.path
+
+    ENV["FOO"]?.should eq "BAR"
+
+    ENV.delete "FOO"
+
+    file.delete
+  end
+
   def test_class_load_defaults : Nil
     ENV.delete "BAZ"
 

--- a/src/components/dotenv/src/athena-dotenv.cr
+++ b/src/components/dotenv/src/athena-dotenv.cr
@@ -142,7 +142,7 @@ require "./exception/*"
 # They can of course continue to be used in production by distributing the base `.env` file along with the binary, then creating a `.env.local` on the production server and including production values within it.
 # This can work quite well for simple applications, but ultimately a more robust solution that best leverages the features of the server the application is running on is best.
 class Athena::Dotenv
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 
   # Both acts as a namespace for exceptions related to the `Athena::Dotenv` component, as well as a way to check for exceptions from the component.
   module Exception; end
@@ -152,6 +152,13 @@ class Athena::Dotenv
   private enum State
     VARNAME
     VALUE
+  end
+
+  # Convenience method that loads the file at the provided *path*, defaulting to `.env`.
+  def self.load(path : String | ::Path = ".env") : self
+    instance = new
+    instance.load path
+    instance
   end
 
   # Convenience method that loads one or more `.env` files, defaulting to `.env`.


### PR DESCRIPTION
## Context

The existing `Athena::Dotnev.load` method has a `*paths` parameter. Crystal is expecting additional paths for this method and as such only allows passing no arguments or two or more. This PR adds another without the splat that accepts a single path with the same default.

## Changelog

* Add new overload to allow loading a single dotenv file

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
