### PR TITLE
Make identifying constraint violation inequality easier within spec failures

### DIFF
--- a/.changes/unreleased/validator-Changed-20251110-011030.yaml
+++ b/.changes/unreleased/validator-Changed-20251110-011030.yaml
@@ -1,0 +1,9 @@
+project: validator
+kind: Changed
+body: Make identifying constraint violation inequality easier within spec failures
+time: 2025-11-10T01:10:30.267021186-05:00
+custom:
+    Author: George Dietrich
+    Breaking: "No"
+    PR: "610"
+    Username: blacksmoke16

--- a/src/components/validator/src/spec/constraint_validator_test_case.cr
+++ b/src/components/validator/src/spec/constraint_validator_test_case.cr
@@ -119,8 +119,21 @@ abstract struct Athena::Validator::Spec::ConstraintValidatorTestCase < ASPEC::Te
 
       violations.size.should eq(1), failure_message: "Expected 1 violation, got #{violations.size}."
 
-      expected_violations.each_with_index do |violation, idx|
-        violations[idx].should eq(violation), file: file, line: line
+      expected_violations.each_with_index do |expected_violation, idx|
+        actual_violation = violations[idx]
+
+        # This is derived from `AVD::Violation::ConstraintViolation#==(other : AVD::Violation::ConstraintViolationInterface)`
+        # but is broken out here to make knowing _what_ wasn't equal easier to identity within spec failures.
+        self.assert_equals "message", actual_violation.message, expected_violation.message, file: file, line: line
+        self.assert_equals "message_template", actual_violation.message_template, expected_violation.message_template, file: file, line: line
+        self.assert_equals "parameters", actual_violation.parameters, expected_violation.parameters, file: file, line: line
+        self.assert_equals "root_container", actual_violation.root_container, expected_violation.root_container, file: file, line: line
+        self.assert_equals "property_path", actual_violation.property_path, expected_violation.property_path, file: file, line: line
+        self.assert_equals "invalid_value_container", actual_violation.invalid_value_container, expected_violation.invalid_value_container, file: file, line: line
+        self.assert_equals "plural", actual_violation.plural, expected_violation.plural, file: file, line: line
+        self.assert_equals "code", actual_violation.code, expected_violation.code, file: file, line: line
+        self.assert_equals "constraint", actual_violation.constraint, expected_violation.constraint, file: file, line: line
+        self.assert_equals "cause", actual_violation.cause, expected_violation.cause, file: file, line: line
       end
     end
 
@@ -137,6 +150,10 @@ abstract struct Athena::Validator::Spec::ConstraintValidatorTestCase < ASPEC::Te
         @constraint,
         @cause
       )
+    end
+
+    private def assert_equals(property : String, actual : _, expected : _, file : String, line : Int32) : Nil
+      actual.should eq(expected), failure_message: "Expected #{property} to be: #{expected}, got: #{actual}", file: file, line: line
     end
   end
 


### PR DESCRIPTION
## Context

When making use of the builder methods to assert violation failures when using `AVD::Spec::Spec::ConstraintValidatorTestCase` and the expected and actual violations did _NOT_ match you previously got something like:

```cr
  1) SizeValidatorTest invalid values max 2
     Failure/Error: self

       Expected: Athena::Validator::Violation::ConstraintViolation(
        @cause=nil,
        @code="a1fa7a63-ea3b-46a0-adcc-5e1bcc26f73a",
        @constraint=
         #<Athena::Validator::Constraints::NotBlank:0x7ffff53a6750
          @allow_nil=false,
          @groups=nil,
          @message="This value should not be blank.",
          @payload=nil>,
        @invalid_value_container=
         Athena::Validator::ValueContainer(Array(Int32) | String | Tuple(Int32, Int32, Int32, Int32, Int32))(
          @value="ééééé"),
        @message="my_message",
        @message_template="my_message",
        @parameters=
         {"{{ value }}" => "ééééé",
          "{{ limit }}" => "4",
          "{{ type }}" => "character"},
        @plural=5,
        @property_path="property.path",
        @root_container=Athena::Validator::ValueContainer(String)(@value="root"))
            got: Athena::Validator::Violation::ConstraintViolation(
        @cause=nil,
        @code="a1fa7a63-ea3b-46a0-adcc-5e1bcc26f73a",
        @constraint=
         #<Athena::Validator::Constraints::NotBlank:0x7ffff53a6750
          @allow_nil=false,
          @groups=nil,
          @message="This value should not be blank.",
          @payload=nil>,
        @invalid_value_container=
         Athena::Validator::ValueContainer(Array(Int32) | String | Tuple(Int32, Int32, Int32, Int32, Int32))(
          @value="ééééé"),
        @message="my_message",
        @message_template="my_message",
        @parameters=
         {"{{ value }}" => "ééééé",
          "{{ limit }}" => "4",
          "{{ type }}" => "character"},
        @plural=4,
        @property_path="property.path",
        @root_container=Athena::Validator::ValueContainer(String)(@value="root"))
```

Due to the amount of output, trying to figure out _what_ exactly isn't equal isn't immediately clear. However with this PR, it is much more so:

```cr
  1) SizeValidatorTest invalid values max 2
     Failure/Error: self

       Expected plural to be: 5, got: 4
```

The code is a bit verbose, and would require re-running the tests to see each failure, but from a troubleshooting POV, it's a _MUCH_ needed improvement. Could possibly revisit this later if/when https://github.com/crystal-lang/crystal/issues/9948 is implemented. But will have to see how that shakes out.

## Changelog

<!-- List out the high level changes this PR makes, especially those that are breaking -->

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
