### PR TITLE
Fix segfault due to uninitialized object

### DIFF
--- a/.changes/spec/v0.4.1.md
+++ b/.changes/spec/v0.4.1.md
@@ -1,0 +1,8 @@
+## [0.4.1] - 2025-11-12
+
+### Fixed
+
+- Fix segfault when interacting with a test case ivar object's ivar that was left uninitialized due to an exception in its initializer, within the `tear_down` method ([#613]) (George Dietrich) <!-- blacksmoke16 -->
+
+[0.4.1]: https://github.com/athena-framework/spec/releases/tag/v0.4.1
+[#613]: https://github.com/athena-framework/athena/pull/613

--- a/src/components/spec/CHANGELOG.md
+++ b/src/components/spec/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.4.1] - 2025-11-12
+
+### Fixed
+
+- Fix segfault when interacting with a test case ivar object's ivar that was left uninitialized due to an exception in its initializer, within the `tear_down` method ([#613]) (George Dietrich) <!-- blacksmoke16 -->
+
+[0.4.1]: https://github.com/athena-framework/spec/releases/tag/v0.4.1
+[#613]: https://github.com/athena-framework/athena/pull/613
+
 ## [0.4.0] - 2025-09-04
 
 ### Added

--- a/src/components/spec/shard.yml
+++ b/src/components/spec/shard.yml
@@ -1,6 +1,6 @@
 name: athena-spec
 
-version: 0.4.0
+version: 0.4.1
 
 crystal: ~> 1.17
 

--- a/src/components/spec/src/athena-spec.cr
+++ b/src/components/spec/src/athena-spec.cr
@@ -6,7 +6,7 @@ require "./test_case"
 
 # A set of common [Spec](https://crystal-lang.org/api/Spec.html) compliant testing utilities/types.
 module Athena::Spec
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 
   # Runs all `ASPEC::TestCase`s.
   #

--- a/src/components/spec/src/test_case.cr
+++ b/src/components/spec/src/test_case.cr
@@ -329,6 +329,11 @@ abstract struct Athena::Spec::TestCase
       {{!!@type.annotation(Pending) ? "pending".id : "describe".id}} {{@type.name.stringify}}, focus: {{!!@type.annotation Focus}}{% if (tags = @type.annotation(Tags)) %}, tags: {{tags.args}}{% end %} do
         before_all do
           instance.before_all
+
+          # Run this here to validate the instance is valid before calling tear_down,
+          # which could possibly lead to segfaults if there was an exception raised during
+          # initialization of an object when assigning an ivar in initialize and some state of that object is interacted with.
+          instance.initialize
         end
 
         before_each do


### PR DESCRIPTION
## Context

Because of some of the ~hacks~ the spec component does, if an ivar defined within the initializer of a `TestCase` is assigned to an object where an exception is raised within that object's initializer; that ivar would be uninitialized but not fail the test or anything. If the state within that ivar was then accessed within the `tear_down` method, it would segfault.

This PR makes it so the real initializer is called once before the rest of the suite to properly bubble up the error to prevent the segfaults.

## Changelog

* Fix segfault when interacting with a test case ivar objects ivar thatwas left uninitialized due to an exception in its initializer, within the `tear_down` method

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
