### PR TITLE
Some misc doc improvements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ These include:
 * [DependencyInjection](/DependencyInjection/) (`ADI`) - Robust dependency injection service container framework
 * [Dotenv](/Dotenv/) - Registers environment variables from a `.env` file
 * [EventDispatcher](/EventDispatcher/) (`AED`) - A Mediator and Observer pattern event library
+* [Framework](/Framework/) (`ATH`) - Integrates the components into a single cohesive, flexible, and modular framework
 * [ImageSize](/ImageSize/) (`AIS`) - Measures the size of various image formats
 * [Mercure](/Mercure/) (`AMC`) - Allows easily pushing updates to web browsers and other HTTP clients using the Mercure protocol
 * [MIME](/MIME/) (`AMIME`) - Allows manipulating `MIME` messages

--- a/docs/getting_started/testing.md
+++ b/docs/getting_started/testing.md
@@ -1,6 +1,22 @@
 One of the benefits of using the Athena Framework is testing is considered a first class citizen.
 Both the framework and the components themselves provides testing utilities to help ensure your code is working as expected.
 
+A small amount of setup is required to make use of the testing features provided by the framework.
+If you created your project via the [skeleton](https://github.com/athena-framework/skeleton) template repository, then everything is ready for use out of the box.
+Otherwise, ensure that your `spec/spec_helper.cr` file includes the following requires/method calls, in this order:
+
+```crystal
+require "spec"
+require "../src/main" # Or whatever the name of your entrypoint file is called
+require "athena/spec"
+
+# ...
+
+ASPEC.run_all
+```
+
+WARNING: It's important that your main entrypoint file is required _before_ `athena/spec`.
+
 ## TestCase
 
 At the core is the [Athena::Spec](/Spec) component, with [ASPEC::TestCase](/Spec/TestCase) being the primary type.

--- a/justfile
+++ b/justfile
@@ -76,7 +76,7 @@ build-docs: _symlink_lib
 # Serve live-preview of the docs
 [group('docs')]
 serve-docs: _symlink_lib
-    {{ UV }} run --frozen mkdocs serve --open
+    {{ UV }} run --frozen mkdocs serve --livereload
 
 # Clean MKDocs build artifacts
 [group('docs')]

--- a/src/components/framework/src/bundle.cr
+++ b/src/components/framework/src/bundle.cr
@@ -64,7 +64,7 @@ struct Athena::Framework::Bundle < Athena::Framework::AbstractBundle
       #     format_listener: {
       #       enabled: true,
       #       rules:   [
-      #         {priorities: ["json", "xml"], host: "api.example.com", fallback_format: "json"},
+      #         {priorities: ["json", "xml"], host: /api\.example\.com/, fallback_format: "json"},
       #         {path: /^\/image/, priorities: ["jpeg", "gif"], fallback_format: false},
       #         {path: /^\/admin/, priorities: ["xml", "html"]},
       #         {priorities: ["text/html", "*/*"], fallback_format: "html"},

--- a/src/components/spec/docs/README.md
+++ b/src/components/spec/docs/README.md
@@ -13,6 +13,16 @@ dependencies:
     version: ~> 0.4.0
 ```
 
+Next, require the shard within your `spec/spec_helper.cr` file, being sure things are required in this order:
+
+```crystal
+require "spec"
+require "../src/main" # Or whatever the name of your entrypoint file is called
+require "athena-spec"
+```
+
+Finally, call [ASPEC.run_all][] at the bottom of `spec/spec_helper.cr` to ensure [ASPEC::TestCase][] based specs are ran as expected.
+
 ## Usage
 
 A core focus of this component is allowing for a more classic unit testing approach that makes it easy to share/reduce test code duplication.


### PR DESCRIPTION
## Context

Some small doc improvements I have been wanting to do for a while.

## Changelog

* Add `Framework` link to main list of components
* Better document setup requirements for using `Spec` component, both on its own and within the framework
* Fix incorrect type of the format listener rule's host property
* Workaround upstream `mkdocs` bug related to live reloading

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
