### PR TITLE
Document Mercure component

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,6 +1,6 @@
 [default]
 extend-ignore-re = [
-  "(?Rm)^.*#\\s*spellchecker:disable-line$", # All disabling specific lines
+  "(?Rm)^.*#\\s*spellchecker:disable-line$", # Allow disabling specific lines
   "=[0-9A-F \n\r]{2}", # Disable checking Quoted-Printable encoded strings
 ]
 

--- a/mkdocs-common.yml
+++ b/mkdocs-common.yml
@@ -1,14 +1,14 @@
 theme:
   name: material
   palette:
-    - media: "(prefers-color-scheme: light)"
+    - media: '(prefers-color-scheme: light)'
       scheme: default
       primary: black
       accent: red
       toggle:
         icon: material/weather-sunny
         name: Switch to dark theme
-    - media: "(prefers-color-scheme: dark)"
+    - media: '(prefers-color-scheme: dark)'
       scheme: slate
       primary: black
       accent: red
@@ -18,6 +18,7 @@ theme:
   features:
     - navigation.sections
     - navigation.instant
+    - content.code.copy
 
 use_directory_urls: true
 
@@ -49,7 +50,11 @@ markdown_extensions:
   - pymdownx.highlight
   - pymdownx.magiclink
   - pymdownx.saneheaders
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - deduplicate-toc
   - toc:
-      permalink: "#"
+      permalink: '#'

--- a/src/components/mercure/docs/README.md
+++ b/src/components/mercure/docs/README.md
@@ -1,4 +1,40 @@
 The `Athena::Mercure` component allows easily pushing updates to web browsers and other HTTP clients using the [Mercure protocol](https://mercure.rocks/docs/mercure).
+Because it is built on top of [Server-Sent Events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events), Mercure is supported out of the box in modern browsers.
+
+Mercure comes with an authorization mechanism, automatic reconnection in case of network issues with retrieving of lost updates, a presence API, "connection-less" push for smartphones and auto-discoverability (a supported client can automatically discover and subscribe to updates of a given resource thanks to a specific HTTP header).
+
+Unlike the Crystal stdlib's [HTP::WebSocketHandler](https://crystal-lang.org/api/HTTP/WebSocketHandler.html), Mercure relies on a centralized hub to manage the persistent SSE connections with the client(s) as opposed to connecting directly to the Crystal HTTP server.
+
+```mermaid
+flowchart LR
+
+  %% Publishers
+  subgraph Publishers
+    P1["Athena app"]
+    P2["Other HTTP service"]
+  end
+
+  %% Mercure Hub
+  H["Mercure Hub"]
+
+  %% Subscribers
+  subgraph Subscribers
+    S1["Browser client JavaScript"]
+    S2["Mobile app React Native"]
+    S3["Other HTTP client"]
+  end
+
+  %% Flows from publishers to hub
+  P1 -->|HTTP POST| H
+  P2 -->|HTTP POST| H
+
+  %% Flows from hub to subscribers
+  H -->|SSE| S1
+  H -->|SSE| S2
+  H -->|SSE| S3
+```
+
+Ultimately this makes the interactions/usage of it simpler since the majority of the complex parts are abstracted away.
 
 ## Installation
 
@@ -11,6 +47,172 @@ dependencies:
     version: ~> 0.1.0
 ```
 
+### Setup
+
+Because the Mercure Hub is a separate process from the Athena HTTP server, it does mean you have to [install](https://mercure.rocks/docs/hub/install) a Mercure hub by yourself.
+For production usages, an official and open source (AGPL) hub based on the Caddy web server can be downloaded as a static binary from [Mercure.rocks](https://mercure.rocks).
+A Docker image, a Helm chart for Kubernetes and a managed, High Availability Hub are also provided.
+
+Locally, it's easiest to run the Hub via [docker compose](https://docs.docker.com/compose).
+A minimal development compose file would look like:
+
+```yaml
+services:
+  mercure:
+    image: dunglas/mercure
+    restart: unless-stopped
+    environment:
+      SERVER_NAME: ':80' # Disable HTTPS for local dev
+      MERCURE_PUBLISHER_JWT_KEY: '!ChangeThisMercureHubJWTSecretKey!'
+      MERCURE_SUBSCRIBER_JWT_KEY: '!ChangeThisMercureHubJWTSecretKey!'
+      MERCURE_EXTRA_DIRECTIVES: |
+        cors_origins http://localhost:3000 # Allow Athena Server
+    command: /usr/bin/caddy run --config /etc/caddy/dev.Caddyfile # Enable dev mode
+    ports:
+      - '80:80'
+    volumes:
+      - mercure_data:/data
+      - mercure_config:/config
+
+volumes:
+  mercure_data:
+  mercure_config:
+```
+
 ## Usage
 
-TODO: Write me
+Now that the Mercure hub is running, we can use it to publish updates, and subscribe to receive those updates on the client side.
+
+### Publishing
+
+In order to publish an update, a [AMC::Hub][] instance is required.
+This type expects to be provided a URL to the Mercure Hub that updates should be sent to, and an [AMC::TokenProvider::Interface][] instance.
+The token provider is responsible for returning a JWT token used to authenticate the request sent to the Mercure Hub.
+Most commonly this'll be generated using a static secret key via the [Crystal JWT](https://github.com/crystal-community/jwt) shard.
+
+An [AMC::Update][] instance should then be instantiated that represents the update to publish, and provided to the `#publish` method of the hub instance.
+A complete example of this flow is as follows:
+
+```crystal
+token_factory = AMC::TokenFactory::JWT.new ENV["MERCURE_JWT_SECRET"]
+
+# Use `*` to give the created JWT access to all topics.
+token_provider = AMC::TokenProvider::Factory.new token_factory, publish: ["*"]
+
+hub = AMC::Hub.new ENV["MERCURE_URL"], token_provider, token_factory
+
+update = AMC::Update.new(
+  "https://example.com/my-topic",
+  {message: "Hello world @ #{Time.local}!"}.to_json
+)
+
+hub.publish update # => urn:uuid:e1ee88e2-532a-4d6f-ba70-f0f8bd584022
+```
+
+Multiple hubs can be used and accessed by name via a [AMC::Hub::Registry][].
+
+### Subscribing
+
+Updates can be subscribed to on any platform that supports [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).
+For example via JS:
+
+```html
+<!doctype html>
+<html>
+  <body>
+    <script type="application/javascript">
+      const url = new URL("http://localhost/.well-known/mercure");
+      url.searchParams.append("topic", "https://example.com/my-topic");
+
+      const eventSource = new EventSource(url);
+
+      console.log("listening...");
+      eventSource.onmessage = (e) => console.log(e);
+    </script>
+
+    <h2>Mercure Testing</h2>
+  </body>
+</html>
+```
+This code would log each received update to the console.
+Be sure to call `eventSource.close()` when no longer needed to avoid a resource leak.
+
+### Authorization
+
+Mercure allows dispatching updates to only authorized clients.
+To do so, mark an [AMC::Update][] as `private` via the third constructor argument, the `private` named argument:
+
+```crystal
+AMC::Update.new(
+  "https://example.com/books/1",
+  {status: "OutOfStock"}.to_json,
+  private: true
+)
+```
+
+To subscribe to private updates, subscribers must provide to the Hub a JWT containing a topic selector matching by the topic of the update.
+The preferred way of providing the JWT in a browser context is via a cookie.
+
+WARNING: To use the cookies, the Athena app and the Mercure Hub must be served from the same domain (can be different sub-domains).
+
+The Mercure component provides [AMC::Authorization][] that can handle generating/setting the cookie given a request/response.
+Cookies set by this helper class are automatically passed by the browser to the Mercure hub if the `withCredentials` attribute of `EventSource` is set to `true`:
+
+```js
+const eventSource = new EventSource(url, { withCredentials: true });
+```
+
+### Discovery
+
+Mercure comes with the ability to automatically discover the hub via a [Link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Link) header.
+
+```mermaid
+sequenceDiagram
+
+  participant C as Client
+  participant A as Athena API
+  participant H as Mercure Hub
+
+  C->>A: GET resource
+  A-->>C: 200 OK resource
+  A-->>C: Link header rel mercure
+
+  Note over C: Discover hub URL
+  Note over C: Add topic parameter
+
+  C->>H: Open SSE connection
+  H-->>C: Updates for topic
+```
+
+The header may be added using the [AMC::Discovery][] type.
+The client would then be able to extract the hub URL from the `Link` header to be able to subscribe to updates related to that resource:
+
+```js
+// Fetch the original resource served by the Athena web API
+fetch('/books/1') // Has Link: <https://hub.example.com/.well-known/mercure>; rel="mercure"
+  .then(response => {
+    // Extract the hub URL from the Link header
+    const hubUrl = response.headers.get('Link').match(/<([^>]+)>;\s+rel=(?:mercure|"[^"]*mercure[^"]*")/)[1];
+
+    // Append the topic(s) to subscribe as query parameter
+    const hub = new URL(hubUrl, window.origin);
+    hub.searchParams.append('topic', 'https://example.com/books/{id}');
+
+    // Subscribe to updates
+    const eventSource = new EventSource(hub);
+    eventSource.onmessage = event => console.log(event.data);
+  });
+```
+
+### Testing
+
+The Mercure component comes with some helper types for testing code that publishes updates, without actually sending the update.
+See [AMC::Spec][] for more information.
+
+```crystal
+require "athena-mercure/spec"
+
+hub = AMC::Spec::MockHub.new("https://foo.com", AMC::TokenProvider::Static.new("JWT")) { "id" }
+
+# ...
+```

--- a/src/components/mercure/spec/authorization_spec.cr
+++ b/src/components/mercure/spec/authorization_spec.cr
@@ -1,6 +1,5 @@
 require "./spec_helper"
 
-# @[ASPEC::TestCase::Focus]
 struct AuthorizationTest < ASPEC::TestCase
   def test_jwt_lifetime : Nil
     registry = AMC::Hub::Registry.new(AMC::Spec::MockHub.new(

--- a/src/components/mercure/src/athena-mercure.cr
+++ b/src/components/mercure/src/athena-mercure.cr
@@ -15,8 +15,18 @@ require "./token_factory/*"
 # Convenience alias to make referencing `Athena::Mercure` types easier.
 alias AMC = Athena::Mercure
 
+# The `Athena::Mercure` component allows easily pushing updates to web browsers and other HTTP clients using the [Mercure protocol](https://mercure.rocks/docs/mercure).
+# Because it is built on top of [Server-Sent Events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events), Mercure is supported out of the box in modern browsers.
+#
+# Mercure comes with an authorization mechanism, automatic reconnection in case of network issues with retrieving of lost updates, a presence API, "connection-less" push for smartphones and auto-discoverability (a supported client can automatically discover and subscribe to updates of a given resource thanks to a specific HTTP header).
 module Athena::Mercure
   VERSION = "0.1.0"
+
+  # See [AMC::TokenFactory::Interface][]
+  module TokenFactory; end
+
+  # See [AMC::TokenProvider::Interface][]
+  module TokenProvider; end
 
   # Both acts as a namespace for exceptions related to the `Athena::Mercure` component, as well as a way to check for exceptions from the component.
   module Exception; end

--- a/src/components/mercure/src/authorization.cr
+++ b/src/components/mercure/src/authorization.cr
@@ -1,3 +1,5 @@
+# Helper class for adding the Mercure authorization cookie to an HTTP response in order to enable private updates.
+# See [Authorization](/Mercure/#authorization) for more information.
 class Athena::Mercure::Authorization
   private COOKIE_NAME = "mercureAuthorization"
 
@@ -7,6 +9,10 @@ class Athena::Mercure::Authorization
     @cookie_samesite : HTTP::Cookie::SameSite = :strict,
   ); end
 
+  # Sets the `mercureAuthorization` cookie on the provided *response* given the provided *request*, optionally for the provided *hub*.
+  # The JWT cookie value by default does not have access to publish or subscribe to any topic.
+  # Be sure to set the *subscribe* and *publish* arrays to the topics you want it to be able to interact with, or `["*"]` to handle all topics.
+  # *additional_claims* may also be used to define additional claims to the JWT if needed.
   def set_cookie(
     request : HTTP::Request,
     response : HTTP::Server::Response,
@@ -18,6 +24,7 @@ class Athena::Mercure::Authorization
     self.update_cookies request, response, hub_name, self.create_cookie(request, subscribe, publish, additional_claims, hub_name)
   end
 
+  # Clears the Mercure cookie from the provided *response*, optionally for the provided *hub*.
   def clear_cookie(
     request : HTTP::Request,
     response : HTTP::Server::Response,
@@ -26,6 +33,11 @@ class Athena::Mercure::Authorization
     self.update_cookies request, response, hub_name, self.create_clear_cookie(request, hub_name)
   end
 
+  # Returns a Mercure auth cookie given the provided *request* and optionally for the provided *hub_name*.
+  #
+  # The JWT cookie value by default does not have access to publish or subscribe to any topic.
+  # Be sure to set the *subscribe* and *publish* arrays to the topics you want it to be able to interact with, or `["*"]` to handle all topics.
+  # *additional_claims* may also be used to define additional claims to the JWT if needed.
   def create_cookie(
     request : HTTP::Request,
     subscribe : Array(String)? = [] of String,

--- a/src/components/mercure/src/discovery.cr
+++ b/src/components/mercure/src/discovery.cr
@@ -1,8 +1,13 @@
+# Allows for automatically discovering the Mercure hub via a [Link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Link) header.
+# E.g. can be included with the response for a resource to allow clients to then extract the URL from the rel `mercure` header to subscribe to future updates for that resource.
+#
+# See [Discovery](/Mercure/#discovery) for more information.
 class Athena::Mercure::Discovery
   def initialize(
     @hub_registry : AMC::Hub::Registry,
   ); end
 
+  # Adds the mercure relation `link` header to the provided *response*, optionally for the provided *hub_name*.
   def add_link(request : HTTP::Request, response : HTTP::Server::Response, hub_name : String? = nil) : Nil
     return if self.preflight_request? request
 

--- a/src/components/mercure/src/hub/hub.cr
+++ b/src/components/mercure/src/hub/hub.cr
@@ -1,9 +1,13 @@
 require "./interface"
 
+# Default implementation of [AMC::Hub::Interface][].
 class Athena::Mercure::Hub
   include Athena::Mercure::Hub::Interface
 
+  # :inherit:
   getter token_provider : AMC::TokenProvider::Interface
+
+  # :inherit:
   getter token_factory : AMC::TokenFactory::Interface?
 
   @uri : URI
@@ -13,22 +17,25 @@ class Athena::Mercure::Hub
   def initialize(
     url : String,
     @token_provider : AMC::TokenProvider::Interface,
-    @public_url : String? = nil,
     @token_factory : AMC::TokenFactory::Interface? = nil,
+    @public_url : String? = nil,
     http_client : HTTP::Client? = nil,
   )
     @uri = URI.parse url
     @http_client = http_client || HTTP::Client.new @uri
   end
 
+  # :inherit:
   def url : String
     @uri.to_s
   end
 
+  # :inherit:
   def public_url : String
     @public_url || @uri.to_s
   end
 
+  # :inherit:
   def publish(update : AMC::Update) : String
     @http_client.post(
       @uri.path,

--- a/src/components/mercure/src/hub/interface.cr
+++ b/src/components/mercure/src/hub/interface.cr
@@ -1,9 +1,19 @@
 class Athena::Mercure::Hub; end
 
+# Represents the API that a Mercure hub instance must implement.
 module Athena::Mercure::Hub::Interface
+  # Returns the internal URL of this hub used to publish updates.
   abstract def url : String
+
+  # Returns the public URL of this hub used to subscribe.
   abstract def public_url : String
-  abstract def token_provider : AMC::TokenProvider::Interface
+
+  # Returns the [AMC::TokenProvider::Interface][] associated with this hub.
+  abstract def token_provider : AMC::TokenProvider::Interface?
+
+  # Returns the [AMC::TokenFactory::Interface][] associated with this hub.
   abstract def token_factory : AMC::TokenFactory::Interface?
+
+  # Publishes the provided *update* to this hub.
   abstract def publish(update : AMC::Update) : String
 end

--- a/src/components/mercure/src/hub/registry.cr
+++ b/src/components/mercure/src/hub/registry.cr
@@ -1,4 +1,22 @@
+# The [AMC::Hub::Registry][] can be used to store multiple [AMC::Hub][] instances, accessing them by unique names.
+#
+# ```
+# foo_hub = hub = AMC::Hub.new ENV["FOO_HUB_MERCURE_URL"], foo_token_provider, foo_token_factory
+# bar_hub = hub = AMC::Hub.new ENV["BAR_HUB_MERCURE_URL"], bar_token_provider, bar_token_factory
+#
+# registry = AMC::Hub::Registry.new(
+#   foo_hub,
+#   {
+#     "foo" => foo_hub,
+#     "bar" => bar_hub,
+#   } of String => AMC::Hub::Interface
+# )
+#
+# registry.hub       # => (default foo_hub)
+# registry.hub "bar" # => (bar_hub)
+# ```
 class Athena::Mercure::Hub::Registry
+  # Returns the mapping of hub names to their related instance.
   getter hubs : Hash(String, AMC::Hub::Interface)
 
   def initialize(
@@ -6,6 +24,7 @@ class Athena::Mercure::Hub::Registry
     @hubs : Hash(String, AMC::Hub::Interface) = {} of String => AMC::Hub::Interface,
   ); end
 
+  # Returns the hub with the provided *name*, or the default one if no name was provided.
   def hub(name : String? = nil) : AMC::Hub::Interface
     return @default_hub if name.nil?
 

--- a/src/components/mercure/src/spec.cr
+++ b/src/components/mercure/src/spec.cr
@@ -1,9 +1,17 @@
+# Provides helper types for testing `Athena::Mercure` related logic.
 module Athena::Mercure::Spec
+  # Similar to [AMC::Hub][] but does not make any requests to a real Mercure hub.
+  # Instead, it accepts a block that can be used to make assertions against the related [AMC::Update][], and is expected to return the id of the related update.
   struct MockHub
     include Athena::Mercure::Hub::Interface
 
+    # :inherit:
     getter url : String
+
+    # :inherit:
     getter token_provider : AMC::TokenProvider::Interface
+
+    # :inherit:
     getter token_factory : AMC::TokenFactory::Interface?
 
     @publisher : Proc(AMC::Update, String)
@@ -17,15 +25,18 @@ module Athena::Mercure::Spec
     )
     end
 
+    # :inherit:
     def public_url : String
       @public_url || @url
     end
 
+    # :inherit:
     def publish(update : AMC::Update) : String
       @publisher.call update
     end
   end
 
+  # An [AMC::TokenFactory::Interface][] implementation that will assert it was called with the expected arguments to `#create`.
   class AssertingTokenFactory
     include AMC::TokenFactory::Interface
 

--- a/src/components/mercure/src/token_factory/interface.cr
+++ b/src/components/mercure/src/token_factory/interface.cr
@@ -1,4 +1,7 @@
+# A token factory is responsible for creating the token used to authenticate requests to the Mercure hub.
 module Athena::Mercure::TokenFactory::Interface
+  # Returns a JWT token that has access to *subscribe* and *publish* to the provided topics.
+  # Optionally, *additional_claims* may be added to the JWT.
   abstract def create(
     subscribe : Array(String)? = [] of String,
     publish : Array(String)? = [] of String,

--- a/src/components/mercure/src/token_factory/jwt.cr
+++ b/src/components/mercure/src/token_factory/jwt.cr
@@ -1,3 +1,4 @@
+# A token factory implementation based on the [Crystal JWT](https://github.com/crystal-community/jwt) shard.
 struct Athena::Mercure::TokenFactory::JWT
   include Athena::Mercure::TokenFactory::Interface
 
@@ -43,6 +44,7 @@ struct Athena::Mercure::TokenFactory::JWT
     @jwt_lifetime = jwt_lifetime.is_a?(Int32) ? jwt_lifetime.seconds : jwt_lifetime
   end
 
+  # :inherit:
   def create(
     subscribe : Array(String)? = [] of String,
     publish : Array(String)? = [] of String,

--- a/src/components/mercure/src/token_provider/callable.cr
+++ b/src/components/mercure/src/token_provider/callable.cr
@@ -1,5 +1,6 @@
 require "./interface"
 
+# A token provider implementation that provides the JWT via the return value of a callback block.
 struct Athena::Mercure::TokenProvider::Callable
   include Athena::Mercure::TokenProvider::Interface
 
@@ -9,6 +10,7 @@ struct Athena::Mercure::TokenProvider::Callable
 
   def initialize(@callback : Proc(String)); end
 
+  # :inherit:
   def jwt : String
     @callback.call
   end

--- a/src/components/mercure/src/token_provider/factory.cr
+++ b/src/components/mercure/src/token_provider/factory.cr
@@ -1,14 +1,16 @@
 require "./interface"
 
+# A token provider implementation that provides the JWT via an [AMC::TokenFactory::Interface][] instance.
 struct Athena::Mercure::TokenProvider::Factory
   include Athena::Mercure::TokenProvider::Interface
 
   def initialize(
     @factory : AMC::TokenFactory::Interface,
-    @subscribe : Array(String) = ["*"],
-    @publish : Array(String) = ["*"],
+    @subscribe : Array(String) = [] of String,
+    @publish : Array(String) = [] of String,
   ); end
 
+  # :inherit:
   def jwt : String
     @factory.create @subscribe, @publish
   end

--- a/src/components/mercure/src/token_provider/interface.cr
+++ b/src/components/mercure/src/token_provider/interface.cr
@@ -1,3 +1,5 @@
+# A token provider is responsible for providing the token used to authenticate requests to the Mercure hub.
 module Athena::Mercure::TokenProvider::Interface
+  # Returns the JWT token used to authenticate requests to the Mercure hub.
   abstract def jwt : String
 end

--- a/src/components/mercure/src/token_provider/static.cr
+++ b/src/components/mercure/src/token_provider/static.cr
@@ -1,8 +1,10 @@
+# A token provider implementation that provides the JWT as a static value from the constructor.
 struct Athena::Mercure::TokenProvider::Static
   include Athena::Mercure::TokenProvider::Interface
 
   def initialize(@token : String); end
 
+  # :inherit:
   def jwt : String
     @token
   end

--- a/src/components/mercure/src/update.cr
+++ b/src/components/mercure/src/update.cr
@@ -1,9 +1,37 @@
+# Represents an update to publish.
+#
+# ```
+# AMC::Update.new(
+#   "https://example.com/books/1",
+#   {status: "OutOfStock"}.to_json
+# )
+# ```
+#
+# The topic may be any string, but is recommended it be an [IRI (Internationalized Resource Identifier)](https://datatracker.ietf.org/doc/html/rfc3987) that uniquely identifies the resource the update related to.
+# The data may also be any string, but will most commonly be JSON.
+#
+# ### Private Updates
+#
+# By default, an update would be sent to all subscribers listening on that topic.
+# However, if `private: true` is defined on the update, then it'll only be sent to subscribers who are authorized to receive it.
+# See [Authorization](/Mercure/#authorization) for more information.
 struct Athena::Mercure::Update
+  # Returns the identifiers this update is associated with.
   getter topics : Array(String)
+
+  # Returns the string content of the update.
   getter data : String
+
+  # If `true`, the update will not be sent to subscribers who are not authorized to receive it.
   getter? private : Bool
+
+  # Maps to the SSE's [id](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#id) property.
   getter id : String?
+
+  # Maps to the SSE's [event](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event) property
   getter type : String?
+
+  # Maps to the SSE's [retry](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#retry) property
   getter retry : Int32?
 
   def initialize(


### PR DESCRIPTION
## Context

Resolves #624

## Changelog

- Document Mercure component
- Swap order of `public_url` and `token_factory` `Hub` constructor arg positions
- Default to no topics when using the `TokenProvider::Factory`

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
