### PR TITLE
Mercure bundle integration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,9 @@ These include:
 * [Validator](/Validator/) (`AVD`) - Object/value validation library
 
 These components may be used on their own to aid in existing projects or integrated into existing (or new) frameworks.
+Additionally, some bundles are also provided that provide opt-in integrations of select components:
+
+* [MercureBundle](/MercureBundle/) (`ABM`) - Integrations the Mercure component into the framework.
 
 TIP: Each component may also define additional shortcut aliases. Check the `Aliases` page of each component in the [API Reference](./api_reference.md) for more information.
 

--- a/docs/bundle_reference.md
+++ b/docs/bundle_reference.md
@@ -1,1 +1,6 @@
-TODO
+Bundles integrate components into the framework by registering services, configuring defaults, and wiring up dependencies via the [dependency injection](/DependencyInjection) component.
+Each bundle defines a schema that describes its available configuration options, allowing behavior to be customized without modifying code.
+See [Getting Started > Configuration](./getting_started/configuration.md#bundles) for more information on the role bundles play in Athena.
+
+The built-in [Framework Bundle](/Framework/Bundle/) schema is documented in the framework API docs.
+Third-party and standalone bundles, such as the [Mercure Bundle](/MercureBundle), are documented in this section.

--- a/justfile
+++ b/justfile
@@ -71,12 +71,12 @@ spellcheck:
 # Build the docs
 [group('docs')]
 build-docs: _symlink_lib
-    {{ UV }} run --frozen mkdocs build -d {{ OUTPUT_DIR }}
+    NO_MKDOCS_2_WARNING=1 {{ UV }} run --frozen mkdocs build -d {{ OUTPUT_DIR }}
 
 # Serve live-preview of the docs
 [group('docs')]
 serve-docs: _symlink_lib
-    {{ UV }} run --frozen mkdocs serve --livereload
+    NO_MKDOCS_2_WARNING=1 {{ UV }} run --frozen mkdocs serve --livereload
 
 # Clean MkDocs build artifacts
 [group('docs')]

--- a/src/bundles/mercure/shard.yml
+++ b/src/bundles/mercure/shard.yml
@@ -19,3 +19,10 @@ authors:
 dependencies:
   athena-dependency_injection:
     github: athena-framework/dependency-injection
+    version: ~> 0.4.0
+  athena-http_kernel:
+    github: athena-framework/http-kernel
+    version: ~> 0.1.0
+  athena-mercure:
+    github: athena-framework/mercure
+    version: ~> 0.1.0

--- a/src/bundles/mercure/spec/authorization_spec.cr
+++ b/src/bundles/mercure/spec/authorization_spec.cr
@@ -1,0 +1,60 @@
+require "./spec_helper"
+
+struct BundleAuthorizationTest < ASPEC::TestCase
+  def test_set_cookie : Nil
+    token_factory = AMC::Spec::AssertingTokenFactory.new(
+      "JWT",
+      ["foo"],
+      ["bar"],
+      {"x-foo" => "baz"},
+    )
+
+    authorization = ABM::Authorization.new new_hub_registry(token_factory: token_factory)
+    request = new_request(headers: ::HTTP::Headers{"host" => "example.com"})
+
+    authorization.set_cookie request, ["foo"], ["bar"], {"x-foo" => "baz"}
+    token_factory.called?.should be_true
+
+    cookies = request.attributes.get?("_mercure_authorization_cookies", Hash(String, ::HTTP::Cookie)).should_not be_nil
+    cookies[""].value.should_not be_empty
+  end
+
+  def test_set_cookie_stores_in_request_attributes : Nil
+    authorization = ABM::Authorization.new new_hub_registry
+    request = new_request(headers: ::HTTP::Headers{"host" => "example.com"})
+
+    authorization.set_cookie request
+
+    cookies = request.attributes.get?("_mercure_authorization_cookies", Hash(String, ::HTTP::Cookie)).should_not be_nil
+    cookies.size.should eq 1
+  end
+
+  def test_set_cookie_prevents_duplicate : Nil
+    authorization = ABM::Authorization.new new_hub_registry
+    request = new_request(headers: ::HTTP::Headers{"host" => "example.com"})
+
+    expect_raises AMC::Exception::Runtime, "The 'mercureAuthorization' cookie for the 'default hub' has already been set." do
+      authorization.set_cookie request
+      authorization.set_cookie request
+    end
+  end
+
+  def test_clear_cookie : Nil
+    authorization = ABM::Authorization.new new_hub_registry
+    request = new_request(headers: ::HTTP::Headers{"host" => "example.com"})
+
+    authorization.clear_cookie request
+
+    cookies = request.attributes.get?("_mercure_authorization_cookies", Hash(String, ::HTTP::Cookie)).should_not be_nil
+    cookies[""].value.should be_empty
+  end
+
+  def test_create_cookie : Nil
+    authorization = ABM::Authorization.new new_hub_registry
+    request = new_request(headers: ::HTTP::Headers{"host" => "example.com"})
+
+    cookie = authorization.create_cookie request
+    cookie.name.should eq "mercureAuthorization"
+    cookie.value.should_not be_empty
+  end
+end

--- a/src/bundles/mercure/spec/bundle_spec.cr
+++ b/src/bundles/mercure/spec/bundle_spec.cr
@@ -1,0 +1,274 @@
+require "./spec_helper"
+
+private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
+  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
+    require "./spec_helper.cr"
+    #{code}
+  CR
+end
+
+private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
+  ASPEC::Methods.assert_compiles <<-CR, line: line
+    require "./spec_helper.cr"
+    #{code}
+  CR
+end
+
+# Simulates a user service that injects the bundle's services,
+# keeping them alive through the DI compiler's unused service removal pass.
+CONSUMER_SERVICE = <<-'CR'
+  @[ADI::Register(public: true)]
+  class MercureConsumer
+    def initialize(
+      @hub : AMC::Hub::Interface,
+      @authorization : ABM::Authorization,
+      @discovery : ABM::Discovery,
+    ); end
+  end
+CR
+
+describe ABM, tags: "compiled" do
+  it "registers services for a hub with a jwt secret" do
+    assert_compiles <<-CR
+      ADI.configure({
+        mercure: {
+          hubs: {
+            default: {
+              url: "https://hub.example.com/.well-known/mercure",
+              jwt: {
+                secret:    "looooooooooooongenoughtestsecret",
+                publish:   ["*"],
+                subscribe: ["https://example.com/books/{id}"],
+              },
+            },
+          },
+        },
+      })
+
+      #{CONSUMER_SERVICE}
+
+      macro finished
+        macro finished
+          \\{%
+            sh = ADI::ServiceContainer::SERVICE_HASH
+
+            # Hub service
+            hub = sh["mercure_hub_default"]
+            raise "missing hub" unless hub
+            raise "wrong class: \#{hub["class"]}" unless hub["class"].resolve == Athena::Mercure::Hub
+
+            params = hub["parameters"]
+            raise "wrong url" unless params["url"]["value"] == "https://hub.example.com/.well-known/mercure"
+
+            # Token factory should be set
+            raise "token_factory should not be nil" if params["token_factory"]["value"] == nil
+
+            # JWT factory service
+            factory = sh["mercure_hub_default_jwt_factory"]
+            raise "missing factory" unless factory
+            raise "wrong factory class: \#{factory["class"]}" unless factory["class"].resolve == Athena::Mercure::TokenFactory::JWT
+
+            # Token provider service (factory-based)
+            provider = sh["mercure_hub_default_jwt_provider"]
+            raise "missing provider" unless provider
+            raise "wrong provider class: \#{provider["class"]}" unless provider["class"].resolve == Athena::Mercure::TokenProvider::Factory
+
+            # Hub registry
+            raise "missing registry" unless sh["mercure_hub_registry"]
+            raise "wrong registry class" unless sh["mercure_hub_registry"]["class"].resolve == Athena::Mercure::Hub::Registry
+
+            # Authorization
+            raise "missing auth" unless sh["mercure_authorization"]
+            raise "wrong auth class" unless sh["mercure_authorization"]["class"].resolve == Athena::MercureBundle::Authorization
+
+            # Discovery
+            raise "missing discovery" unless sh["mercure_discovery"]
+            raise "wrong discovery class" unless sh["mercure_discovery"]["class"].resolve == Athena::MercureBundle::Discovery
+          %}
+        end
+      end
+    CR
+  end
+
+  it "registers services for a hub with a static jwt value" do
+    assert_compiles <<-CR
+      ADI.configure({
+        mercure: {
+          hubs: {
+            default: {
+              url: "https://hub.example.com/.well-known/mercure",
+              jwt: {
+                value: "eyJhbGciOiJIUzI1NiJ9.static-token",
+              },
+            },
+          },
+        },
+      })
+
+      #{CONSUMER_SERVICE}
+
+      macro finished
+        macro finished
+          \\{%
+            sh = ADI::ServiceContainer::SERVICE_HASH
+
+            # Hub service
+            hub = sh["mercure_hub_default"]
+            raise "missing hub" unless hub
+
+            params = hub["parameters"]
+
+            # Token factory should be nil for static token
+            raise "token_factory should be nil: \#{params["token_factory"]["value"]}" unless params["token_factory"]["value"] == nil
+
+            # Static token provider
+            provider = sh["mercure_hub_default_jwt_provider"]
+            raise "missing provider" unless provider
+            raise "wrong provider class: \#{provider["class"]}" unless provider["class"].resolve == Athena::Mercure::TokenProvider::Static
+          %}
+        end
+      end
+    CR
+  end
+
+  it "uses the first hub as default when default_hub is not set" do
+    assert_compiles <<-CR
+      ADI.configure({
+        mercure: {
+          hubs: {
+            my_hub: {
+              url: "https://hub.example.com/.well-known/mercure",
+              jwt: {
+                secret: "looooooooooooongenoughtestsecret",
+              },
+            },
+          },
+        },
+      })
+
+      #{CONSUMER_SERVICE}
+
+      macro finished
+        macro finished
+          \\{%
+            registry = ADI::ServiceContainer::SERVICE_HASH["mercure_hub_registry"]
+            default_hub = registry["parameters"]["default_hub"]["value"]
+            raise "wrong default hub: \#{default_hub}" unless default_hub.stringify =~ /mercure_hub_my_hub/
+          %}
+        end
+      end
+    CR
+  end
+
+  it "respects explicit default_hub setting" do
+    assert_compiles <<-CR
+      ADI.configure({
+        mercure: {
+          hubs: {
+            first: {
+              url: "https://first.example.com/.well-known/mercure",
+              jwt: {
+                secret: "looooooooooooongenoughtestsecret",
+              },
+            },
+            second: {
+              url: "https://second.example.com/.well-known/mercure",
+              jwt: {
+                secret: "looooooooooooongenoughtestsecret",
+              },
+            },
+          },
+          default_hub: "second",
+        },
+      })
+
+      #{CONSUMER_SERVICE}
+
+      macro finished
+        macro finished
+          \\{%
+            registry = ADI::ServiceContainer::SERVICE_HASH["mercure_hub_registry"]
+            default_hub = registry["parameters"]["default_hub"]["value"]
+            raise "wrong default hub: \#{default_hub}" unless default_hub.stringify =~ /mercure_hub_second/
+          %}
+        end
+      end
+    CR
+  end
+
+  it "retains named aliases for all hubs in a multi-hub configuration" do
+    assert_compiles <<-CR
+      ADI.configure({
+        mercure: {
+          hubs: {
+            first: {
+              url: "https://first.example.com/.well-known/mercure",
+              jwt: {
+                secret: "looooooooooooongenoughtestsecret",
+              },
+            },
+            second: {
+              url: "https://second.example.com/.well-known/mercure",
+              jwt: {
+                secret: "looooooooooooongenoughtestsecret",
+              },
+            },
+          },
+        },
+      })
+
+      #{CONSUMER_SERVICE}
+
+      macro finished
+        macro finished
+          \\{%
+            aliases = ADI::ServiceContainer::ALIASES[Athena::Mercure::Hub::Interface]
+
+            # Named aliases for both hubs should be present, plus the unnamed default
+            first_alias = aliases.find { |a| a["name"] && a["name"].id == "first" }
+            raise "missing named alias for 'first' hub" unless first_alias
+            raise "wrong id for 'first': \#{first_alias["id"]}" unless first_alias["id"].stringify =~ /mercure_hub_first/
+
+            second_alias = aliases.find { |a| a["name"] && a["name"].id == "second" }
+            raise "missing named alias for 'second' hub" unless second_alias
+            raise "wrong id for 'second': \#{second_alias["id"]}" unless second_alias["id"].stringify =~ /mercure_hub_second/
+
+            default_alias = aliases.find { |a| a["name"] == nil }
+            raise "missing unnamed default alias" unless default_alias
+            raise "default should be first hub: \#{default_alias["id"]}" unless default_alias["id"].stringify =~ /mercure_hub_first/
+          %}
+        end
+      end
+    CR
+  end
+
+  it "passes cookie_lifetime from configuration" do
+    assert_compiles <<-CR
+      ADI.configure({
+        mercure: {
+          hubs: {
+            default: {
+              url: "https://hub.example.com/.well-known/mercure",
+              jwt: {
+                secret: "looooooooooooongenoughtestsecret",
+              },
+            },
+          },
+          default_cookie_lifetime: 2.hours,
+        },
+      })
+
+      #{CONSUMER_SERVICE}
+
+      macro finished
+        macro finished
+          \\{%
+            auth = ADI::ServiceContainer::SERVICE_HASH["mercure_authorization"]
+            lifetime = auth["parameters"]["cookie_lifetime"]["value"]
+            raise "wrong lifetime: \#{lifetime}" unless lifetime.stringify == "2.hours"
+          %}
+        end
+      end
+    CR
+  end
+end

--- a/src/bundles/mercure/spec/bundle_spec.cr
+++ b/src/bundles/mercure/spec/bundle_spec.cr
@@ -152,8 +152,7 @@ describe ABM, tags: "compiled" do
       macro finished
         macro finished
           \{%
-            registry = ADI::ServiceContainer::SERVICE_HASH["mercure_hub_registry"]
-            default_hub = registry["parameters"]["default_hub"]["value"]
+            default_hub = ADI::ServiceContainer::SERVICE_HASH["mercure_hub_registry"]["parameters"]["default_hub"]["value"]
           %}
           ASPEC.compile_time_assert(\{{ default_hub.stringify =~ /mercure_hub_second/ }}, "Expected default hub to be second")
         end
@@ -219,8 +218,7 @@ describe ABM, tags: "compiled" do
       macro finished
         macro finished
           \{%
-            auth = ADI::ServiceContainer::SERVICE_HASH["mercure_authorization"]
-            lifetime = auth["parameters"]["cookie_lifetime"]["value"]
+            lifetime = ADI::ServiceContainer::SERVICE_HASH["mercure_authorization"]["parameters"]["cookie_lifetime"]["value"]
           %}
           ASPEC.compile_time_assert(\{{ lifetime.stringify == "2.hours" }}, "Expected cookie_lifetime to be 2.hours")
         end

--- a/src/bundles/mercure/spec/bundle_spec.cr
+++ b/src/bundles/mercure/spec/bundle_spec.cr
@@ -1,24 +1,7 @@
 require "./spec_helper"
 
-private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
-    require "./spec_helper.cr"
-
-    @[ADI::Register(public: true)]
-    class MercureConsumer
-      def initialize(
-        @hub : AMC::Hub::Interface,
-        @authorization : ABM::Authorization,
-        @discovery : ABM::Discovery,
-      ); end
-    end
-
-    #{code}
-  CR
-end
-
 private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compiles <<-CR, line: line
+  ASPEC::Methods.assert_compiles <<-CR, line: line - 11 # Account for extra code before *code* is interpolated
     require "./spec_helper.cr"
 
     @[ADI::Register(public: true)]
@@ -59,71 +42,26 @@ describe ABM, tags: "compiled" do
 
             # Hub service
             hub = sh["mercure_hub_default"]
-            unless hub
-              raise "missing hub"
-            end
-
-            unless hub["class"].resolve == Athena::Mercure::Hub
-              raise "wrong class: #{hub["class"]}"
-            end
-
             params = hub["parameters"]
-            unless params["url"]["value"] == "https://hub.example.com/.well-known/mercure"
-              raise "wrong url"
-            end
-
-            # Token factory should be set
-            if params["token_factory"]["value"] == nil
-              raise "token_factory should not be nil"
-            end
 
             # JWT factory service
             factory = sh["mercure_hub_default_jwt_factory"]
-            unless factory
-              raise "missing factory"
-            end
-
-            unless factory["class"].resolve == Athena::Mercure::TokenFactory::JWT
-              raise "wrong factory class: #{factory["class"]}"
-            end
 
             # Token provider service (factory-based)
             provider = sh["mercure_hub_default_jwt_provider"]
-            unless provider
-              raise "missing provider"
-            end
-
-            unless provider["class"].resolve == Athena::Mercure::TokenProvider::Factory
-              raise "wrong provider class: #{provider["class"]}"
-            end
-
-            # Hub registry
-            unless sh["mercure_hub_registry"]
-              raise "missing registry"
-            end
-
-            unless sh["mercure_hub_registry"]["class"].resolve == Athena::Mercure::Hub::Registry
-              raise "wrong registry class"
-            end
-
-            # Authorization
-            unless sh["mercure_authorization"]
-              raise "missing auth"
-            end
-
-            unless sh["mercure_authorization"]["class"].resolve == Athena::MercureBundle::Authorization
-              raise "wrong auth class"
-            end
-
-            # Discovery
-            unless sh["mercure_discovery"]
-              raise "missing discovery"
-            end
-
-            unless sh["mercure_discovery"]["class"].resolve == Athena::MercureBundle::Discovery
-              raise "wrong discovery class"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ hub["class"].resolve == Athena::Mercure::Hub }}, "Expected hub class to be Athena::Mercure::Hub")
+          ASPEC.compile_time_assert(\{{ params["url"]["value"] == "https://hub.example.com/.well-known/mercure" }}, "Expected hub url to match configuration")
+          # Token factory should be set
+          ASPEC.compile_time_assert(\{{ params["token_factory"]["value"] != nil }}, "Expected token_factory to be set")
+          ASPEC.compile_time_assert(\{{ factory["class"].resolve == Athena::Mercure::TokenFactory::JWT }}, "Expected factory class to be Athena::Mercure::TokenFactory::JWT")
+          ASPEC.compile_time_assert(\{{ provider["class"].resolve == Athena::Mercure::TokenProvider::Factory }}, "Expected provider class to be Athena::Mercure::TokenProvider::Factory")
+          # Hub registry
+          ASPEC.compile_time_assert(\{{ sh["mercure_hub_registry"]["class"].resolve == Athena::Mercure::Hub::Registry }}, "Expected registry class to be Athena::Mercure::Hub::Registry")
+          # Authorization
+          ASPEC.compile_time_assert(\{{ sh["mercure_authorization"]["class"].resolve == Athena::MercureBundle::Authorization }}, "Expected auth class to be Athena::MercureBundle::Authorization")
+          # Discovery
+          ASPEC.compile_time_assert(\{{ sh["mercure_discovery"]["class"].resolve == Athena::MercureBundle::Discovery }}, "Expected discovery class to be Athena::MercureBundle::Discovery")
         end
       end
     CR
@@ -149,29 +87,15 @@ describe ABM, tags: "compiled" do
           \{%
             sh = ADI::ServiceContainer::SERVICE_HASH
 
-            # Hub service
             hub = sh["mercure_hub_default"]
-            unless hub
-              raise "missing hub"
-            end
-
             params = hub["parameters"]
-
-            # Token factory should be nil for static token
-            unless params["token_factory"]["value"] == nil.id
-              raise "token_factory should be nil: #{params["token_factory"]["value"]}"
-            end
 
             # Static token provider
             provider = sh["mercure_hub_default_jwt_provider"]
-            unless provider
-              raise "missing provider"
-            end
-
-            unless provider["class"].resolve == Athena::Mercure::TokenProvider::Static
-              raise "wrong provider class: #{provider["class"]}"
-            end
           %}
+          # Token factory should be nil for static token
+          ASPEC.compile_time_assert(\{{ params["token_factory"]["value"] == nil.id }}, "Expected token_factory to be nil")
+          ASPEC.compile_time_assert(\{{ provider["class"].resolve == Athena::Mercure::TokenProvider::Static }}, "Expected provider class to be Athena::Mercure::TokenProvider::Static")
         end
       end
     CR
@@ -195,12 +119,9 @@ describe ABM, tags: "compiled" do
       macro finished
         macro finished
           \{%
-            registry = ADI::ServiceContainer::SERVICE_HASH["mercure_hub_registry"]
-            default_hub = registry["parameters"]["default_hub"]["value"]
-            unless default_hub.stringify =~ /mercure_hub_my_hub/
-              raise "wrong default hub: #{default_hub}"
-            end
+            default_hub = ADI::ServiceContainer::SERVICE_HASH["mercure_hub_registry"]["parameters"]["default_hub"]["value"]
           %}
+          ASPEC.compile_time_assert(\{{ default_hub.stringify =~ /mercure_hub_my_hub/ }}, "Expected default hub to be my_hub")
         end
       end
     CR
@@ -233,10 +154,8 @@ describe ABM, tags: "compiled" do
           \{%
             registry = ADI::ServiceContainer::SERVICE_HASH["mercure_hub_registry"]
             default_hub = registry["parameters"]["default_hub"]["value"]
-            unless default_hub.stringify =~ /mercure_hub_second/
-              raise "wrong default hub: #{default_hub}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ default_hub.stringify =~ /mercure_hub_second/ }}, "Expected default hub to be second")
         end
       end
     CR
@@ -270,32 +189,12 @@ describe ABM, tags: "compiled" do
 
             # Named aliases for both hubs should be present, plus the unnamed default
             first_alias = aliases.find { |a| a["name"].id == "first" }
-            unless first_alias
-              raise "missing named alias for 'first' hub"
-            end
-
-            unless first_alias["id"].stringify =~ /mercure_hub_first/
-              raise "wrong id for 'first': #{first_alias["id"]}"
-            end
-
             second_alias = aliases.find { |a| a["name"].id == "second" }
-            unless second_alias
-              raise "missing named alias for 'second' hub"
-            end
-
-            unless second_alias["id"].stringify =~ /mercure_hub_second/
-              raise "wrong id for 'second': #{second_alias["id"]}"
-            end
-
             default_alias = aliases.find { |a| a["name"] == nil }
-            unless default_alias
-              raise "missing unnamed default alias"
-            end
-
-            unless default_alias["id"].stringify =~ /mercure_hub_first/
-              raise "default should be first hub: #{default_alias["id"]}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ first_alias["id"].stringify =~ /mercure_hub_first/ }}, "Expected first alias id to match mercure_hub_first")
+          ASPEC.compile_time_assert(\{{ second_alias["id"].stringify =~ /mercure_hub_second/ }}, "Expected second alias id to match mercure_hub_second")
+          ASPEC.compile_time_assert(\{{ default_alias["id"].stringify =~ /mercure_hub_first/ }}, "Expected default alias to be first hub")
         end
       end
     CR
@@ -322,10 +221,8 @@ describe ABM, tags: "compiled" do
           \{%
             auth = ADI::ServiceContainer::SERVICE_HASH["mercure_authorization"]
             lifetime = auth["parameters"]["cookie_lifetime"]["value"]
-            unless lifetime.stringify == "2.hours"
-              raise "wrong lifetime: #{lifetime}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ lifetime.stringify == "2.hours" }}, "Expected cookie_lifetime to be 2.hours")
         end
       end
     CR

--- a/src/bundles/mercure/spec/bundle_spec.cr
+++ b/src/bundles/mercure/spec/bundle_spec.cr
@@ -3,6 +3,16 @@ require "./spec_helper"
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
   ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
     require "./spec_helper.cr"
+
+    @[ADI::Register(public: true)]
+    class MercureConsumer
+      def initialize(
+        @hub : AMC::Hub::Interface,
+        @authorization : ABM::Authorization,
+        @discovery : ABM::Discovery,
+      ); end
+    end
+
     #{code}
   CR
 end
@@ -10,26 +20,23 @@ end
 private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
   ASPEC::Methods.assert_compiles <<-CR, line: line
     require "./spec_helper.cr"
+
+    @[ADI::Register(public: true)]
+    class MercureConsumer
+      def initialize(
+        @hub : AMC::Hub::Interface,
+        @authorization : ABM::Authorization,
+        @discovery : ABM::Discovery,
+      ); end
+    end
+
     #{code}
   CR
 end
 
-# Simulates a user service that injects the bundle's services,
-# keeping them alive through the DI compiler's unused service removal pass.
-CONSUMER_SERVICE = <<-'CR'
-  @[ADI::Register(public: true)]
-  class MercureConsumer
-    def initialize(
-      @hub : AMC::Hub::Interface,
-      @authorization : ABM::Authorization,
-      @discovery : ABM::Discovery,
-    ); end
-  end
-CR
-
 describe ABM, tags: "compiled" do
   it "registers services for a hub with a jwt secret" do
-    assert_compiles <<-CR
+    assert_compiles <<-'CR'
       ADI.configure({
         mercure: {
           hubs: {
@@ -45,17 +52,15 @@ describe ABM, tags: "compiled" do
         },
       })
 
-      #{CONSUMER_SERVICE}
-
       macro finished
         macro finished
-          \\{%
+          \{%
             sh = ADI::ServiceContainer::SERVICE_HASH
 
             # Hub service
             hub = sh["mercure_hub_default"]
             raise "missing hub" unless hub
-            raise "wrong class: \#{hub["class"]}" unless hub["class"].resolve == Athena::Mercure::Hub
+            raise "wrong class: #{hub["class"]}" unless hub["class"].resolve == Athena::Mercure::Hub
 
             params = hub["parameters"]
             raise "wrong url" unless params["url"]["value"] == "https://hub.example.com/.well-known/mercure"
@@ -66,12 +71,12 @@ describe ABM, tags: "compiled" do
             # JWT factory service
             factory = sh["mercure_hub_default_jwt_factory"]
             raise "missing factory" unless factory
-            raise "wrong factory class: \#{factory["class"]}" unless factory["class"].resolve == Athena::Mercure::TokenFactory::JWT
+            raise "wrong factory class: #{factory["class"]}" unless factory["class"].resolve == Athena::Mercure::TokenFactory::JWT
 
             # Token provider service (factory-based)
             provider = sh["mercure_hub_default_jwt_provider"]
             raise "missing provider" unless provider
-            raise "wrong provider class: \#{provider["class"]}" unless provider["class"].resolve == Athena::Mercure::TokenProvider::Factory
+            raise "wrong provider class: #{provider["class"]}" unless provider["class"].resolve == Athena::Mercure::TokenProvider::Factory
 
             # Hub registry
             raise "missing registry" unless sh["mercure_hub_registry"]
@@ -91,7 +96,7 @@ describe ABM, tags: "compiled" do
   end
 
   it "registers services for a hub with a static jwt value" do
-    assert_compiles <<-CR
+    assert_compiles <<-'CR'
       ADI.configure({
         mercure: {
           hubs: {
@@ -105,11 +110,9 @@ describe ABM, tags: "compiled" do
         },
       })
 
-      #{CONSUMER_SERVICE}
-
       macro finished
         macro finished
-          \\{%
+          \{%
             sh = ADI::ServiceContainer::SERVICE_HASH
 
             # Hub service
@@ -119,12 +122,12 @@ describe ABM, tags: "compiled" do
             params = hub["parameters"]
 
             # Token factory should be nil for static token
-            raise "token_factory should be nil: \#{params["token_factory"]["value"]}" unless params["token_factory"]["value"] == nil
+            raise "token_factory should be nil: #{params["token_factory"]["value"]}" unless params["token_factory"]["value"] == nil.id
 
             # Static token provider
             provider = sh["mercure_hub_default_jwt_provider"]
             raise "missing provider" unless provider
-            raise "wrong provider class: \#{provider["class"]}" unless provider["class"].resolve == Athena::Mercure::TokenProvider::Static
+            raise "wrong provider class: #{provider["class"]}" unless provider["class"].resolve == Athena::Mercure::TokenProvider::Static
           %}
         end
       end
@@ -132,7 +135,7 @@ describe ABM, tags: "compiled" do
   end
 
   it "uses the first hub as default when default_hub is not set" do
-    assert_compiles <<-CR
+    assert_compiles <<-'CR'
       ADI.configure({
         mercure: {
           hubs: {
@@ -146,14 +149,12 @@ describe ABM, tags: "compiled" do
         },
       })
 
-      #{CONSUMER_SERVICE}
-
       macro finished
         macro finished
-          \\{%
+          \{%
             registry = ADI::ServiceContainer::SERVICE_HASH["mercure_hub_registry"]
             default_hub = registry["parameters"]["default_hub"]["value"]
-            raise "wrong default hub: \#{default_hub}" unless default_hub.stringify =~ /mercure_hub_my_hub/
+            raise "wrong default hub: #{default_hub}" unless default_hub.stringify =~ /mercure_hub_my_hub/
           %}
         end
       end
@@ -161,7 +162,7 @@ describe ABM, tags: "compiled" do
   end
 
   it "respects explicit default_hub setting" do
-    assert_compiles <<-CR
+    assert_compiles <<-'CR'
       ADI.configure({
         mercure: {
           hubs: {
@@ -182,14 +183,12 @@ describe ABM, tags: "compiled" do
         },
       })
 
-      #{CONSUMER_SERVICE}
-
       macro finished
         macro finished
-          \\{%
+          \{%
             registry = ADI::ServiceContainer::SERVICE_HASH["mercure_hub_registry"]
             default_hub = registry["parameters"]["default_hub"]["value"]
-            raise "wrong default hub: \#{default_hub}" unless default_hub.stringify =~ /mercure_hub_second/
+            raise "wrong default hub: #{default_hub}" unless default_hub.stringify =~ /mercure_hub_second/
           %}
         end
       end
@@ -197,7 +196,7 @@ describe ABM, tags: "compiled" do
   end
 
   it "retains named aliases for all hubs in a multi-hub configuration" do
-    assert_compiles <<-CR
+    assert_compiles <<-'CR'
       ADI.configure({
         mercure: {
           hubs: {
@@ -217,25 +216,23 @@ describe ABM, tags: "compiled" do
         },
       })
 
-      #{CONSUMER_SERVICE}
-
       macro finished
         macro finished
-          \\{%
+          \{%
             aliases = ADI::ServiceContainer::ALIASES[Athena::Mercure::Hub::Interface]
 
             # Named aliases for both hubs should be present, plus the unnamed default
             first_alias = aliases.find { |a| a["name"] && a["name"].id == "first" }
             raise "missing named alias for 'first' hub" unless first_alias
-            raise "wrong id for 'first': \#{first_alias["id"]}" unless first_alias["id"].stringify =~ /mercure_hub_first/
+            raise "wrong id for 'first': #{first_alias["id"]}" unless first_alias["id"].stringify =~ /mercure_hub_first/
 
             second_alias = aliases.find { |a| a["name"] && a["name"].id == "second" }
             raise "missing named alias for 'second' hub" unless second_alias
-            raise "wrong id for 'second': \#{second_alias["id"]}" unless second_alias["id"].stringify =~ /mercure_hub_second/
+            raise "wrong id for 'second': #{second_alias["id"]}" unless second_alias["id"].stringify =~ /mercure_hub_second/
 
             default_alias = aliases.find { |a| a["name"] == nil }
             raise "missing unnamed default alias" unless default_alias
-            raise "default should be first hub: \#{default_alias["id"]}" unless default_alias["id"].stringify =~ /mercure_hub_first/
+            raise "default should be first hub: #{default_alias["id"]}" unless default_alias["id"].stringify =~ /mercure_hub_first/
           %}
         end
       end
@@ -243,7 +240,7 @@ describe ABM, tags: "compiled" do
   end
 
   it "passes cookie_lifetime from configuration" do
-    assert_compiles <<-CR
+    assert_compiles <<-'CR'
       ADI.configure({
         mercure: {
           hubs: {
@@ -258,14 +255,12 @@ describe ABM, tags: "compiled" do
         },
       })
 
-      #{CONSUMER_SERVICE}
-
       macro finished
         macro finished
-          \\{%
+          \{%
             auth = ADI::ServiceContainer::SERVICE_HASH["mercure_authorization"]
             lifetime = auth["parameters"]["cookie_lifetime"]["value"]
-            raise "wrong lifetime: \#{lifetime}" unless lifetime.stringify == "2.hours"
+            raise "wrong lifetime: #{lifetime}" unless lifetime.stringify == "2.hours"
           %}
         end
       end

--- a/src/bundles/mercure/spec/bundle_spec.cr
+++ b/src/bundles/mercure/spec/bundle_spec.cr
@@ -59,36 +59,70 @@ describe ABM, tags: "compiled" do
 
             # Hub service
             hub = sh["mercure_hub_default"]
-            raise "missing hub" unless hub
-            raise "wrong class: #{hub["class"]}" unless hub["class"].resolve == Athena::Mercure::Hub
+            unless hub
+              raise "missing hub"
+            end
+
+            unless hub["class"].resolve == Athena::Mercure::Hub
+              raise "wrong class: #{hub["class"]}"
+            end
 
             params = hub["parameters"]
-            raise "wrong url" unless params["url"]["value"] == "https://hub.example.com/.well-known/mercure"
+            unless params["url"]["value"] == "https://hub.example.com/.well-known/mercure"
+              raise "wrong url"
+            end
 
             # Token factory should be set
-            raise "token_factory should not be nil" if params["token_factory"]["value"] == nil
+            if params["token_factory"]["value"] == nil
+              raise "token_factory should not be nil"
+            end
 
             # JWT factory service
             factory = sh["mercure_hub_default_jwt_factory"]
-            raise "missing factory" unless factory
-            raise "wrong factory class: #{factory["class"]}" unless factory["class"].resolve == Athena::Mercure::TokenFactory::JWT
+            unless factory
+              raise "missing factory"
+            end
+
+            unless factory["class"].resolve == Athena::Mercure::TokenFactory::JWT
+              raise "wrong factory class: #{factory["class"]}"
+            end
 
             # Token provider service (factory-based)
             provider = sh["mercure_hub_default_jwt_provider"]
-            raise "missing provider" unless provider
-            raise "wrong provider class: #{provider["class"]}" unless provider["class"].resolve == Athena::Mercure::TokenProvider::Factory
+            unless provider
+              raise "missing provider"
+            end
+
+            unless provider["class"].resolve == Athena::Mercure::TokenProvider::Factory
+              raise "wrong provider class: #{provider["class"]}"
+            end
 
             # Hub registry
-            raise "missing registry" unless sh["mercure_hub_registry"]
-            raise "wrong registry class" unless sh["mercure_hub_registry"]["class"].resolve == Athena::Mercure::Hub::Registry
+            unless sh["mercure_hub_registry"]
+              raise "missing registry"
+            end
+
+            unless sh["mercure_hub_registry"]["class"].resolve == Athena::Mercure::Hub::Registry
+              raise "wrong registry class"
+            end
 
             # Authorization
-            raise "missing auth" unless sh["mercure_authorization"]
-            raise "wrong auth class" unless sh["mercure_authorization"]["class"].resolve == Athena::MercureBundle::Authorization
+            unless sh["mercure_authorization"]
+              raise "missing auth"
+            end
+
+            unless sh["mercure_authorization"]["class"].resolve == Athena::MercureBundle::Authorization
+              raise "wrong auth class"
+            end
 
             # Discovery
-            raise "missing discovery" unless sh["mercure_discovery"]
-            raise "wrong discovery class" unless sh["mercure_discovery"]["class"].resolve == Athena::MercureBundle::Discovery
+            unless sh["mercure_discovery"]
+              raise "missing discovery"
+            end
+
+            unless sh["mercure_discovery"]["class"].resolve == Athena::MercureBundle::Discovery
+              raise "wrong discovery class"
+            end
           %}
         end
       end
@@ -117,17 +151,26 @@ describe ABM, tags: "compiled" do
 
             # Hub service
             hub = sh["mercure_hub_default"]
-            raise "missing hub" unless hub
+            unless hub
+              raise "missing hub"
+            end
 
             params = hub["parameters"]
 
             # Token factory should be nil for static token
-            raise "token_factory should be nil: #{params["token_factory"]["value"]}" unless params["token_factory"]["value"] == nil.id
+            unless params["token_factory"]["value"] == nil.id
+              raise "token_factory should be nil: #{params["token_factory"]["value"]}"
+            end
 
             # Static token provider
             provider = sh["mercure_hub_default_jwt_provider"]
-            raise "missing provider" unless provider
-            raise "wrong provider class: #{provider["class"]}" unless provider["class"].resolve == Athena::Mercure::TokenProvider::Static
+            unless provider
+              raise "missing provider"
+            end
+
+            unless provider["class"].resolve == Athena::Mercure::TokenProvider::Static
+              raise "wrong provider class: #{provider["class"]}"
+            end
           %}
         end
       end
@@ -154,7 +197,9 @@ describe ABM, tags: "compiled" do
           \{%
             registry = ADI::ServiceContainer::SERVICE_HASH["mercure_hub_registry"]
             default_hub = registry["parameters"]["default_hub"]["value"]
-            raise "wrong default hub: #{default_hub}" unless default_hub.stringify =~ /mercure_hub_my_hub/
+            unless default_hub.stringify =~ /mercure_hub_my_hub/
+              raise "wrong default hub: #{default_hub}"
+            end
           %}
         end
       end
@@ -188,7 +233,9 @@ describe ABM, tags: "compiled" do
           \{%
             registry = ADI::ServiceContainer::SERVICE_HASH["mercure_hub_registry"]
             default_hub = registry["parameters"]["default_hub"]["value"]
-            raise "wrong default hub: #{default_hub}" unless default_hub.stringify =~ /mercure_hub_second/
+            unless default_hub.stringify =~ /mercure_hub_second/
+              raise "wrong default hub: #{default_hub}"
+            end
           %}
         end
       end
@@ -222,17 +269,32 @@ describe ABM, tags: "compiled" do
             aliases = ADI::ServiceContainer::ALIASES[Athena::Mercure::Hub::Interface]
 
             # Named aliases for both hubs should be present, plus the unnamed default
-            first_alias = aliases.find { |a| a["name"] && a["name"].id == "first" }
-            raise "missing named alias for 'first' hub" unless first_alias
-            raise "wrong id for 'first': #{first_alias["id"]}" unless first_alias["id"].stringify =~ /mercure_hub_first/
+            first_alias = aliases.find { |a| a["name"].id == "first" }
+            unless first_alias
+              raise "missing named alias for 'first' hub"
+            end
 
-            second_alias = aliases.find { |a| a["name"] && a["name"].id == "second" }
-            raise "missing named alias for 'second' hub" unless second_alias
-            raise "wrong id for 'second': #{second_alias["id"]}" unless second_alias["id"].stringify =~ /mercure_hub_second/
+            unless first_alias["id"].stringify =~ /mercure_hub_first/
+              raise "wrong id for 'first': #{first_alias["id"]}"
+            end
+
+            second_alias = aliases.find { |a| a["name"].id == "second" }
+            unless second_alias
+              raise "missing named alias for 'second' hub"
+            end
+
+            unless second_alias["id"].stringify =~ /mercure_hub_second/
+              raise "wrong id for 'second': #{second_alias["id"]}"
+            end
 
             default_alias = aliases.find { |a| a["name"] == nil }
-            raise "missing unnamed default alias" unless default_alias
-            raise "default should be first hub: #{default_alias["id"]}" unless default_alias["id"].stringify =~ /mercure_hub_first/
+            unless default_alias
+              raise "missing unnamed default alias"
+            end
+
+            unless default_alias["id"].stringify =~ /mercure_hub_first/
+              raise "default should be first hub: #{default_alias["id"]}"
+            end
           %}
         end
       end
@@ -260,7 +322,9 @@ describe ABM, tags: "compiled" do
           \{%
             auth = ADI::ServiceContainer::SERVICE_HASH["mercure_authorization"]
             lifetime = auth["parameters"]["cookie_lifetime"]["value"]
-            raise "wrong lifetime: #{lifetime}" unless lifetime.stringify == "2.hours"
+            unless lifetime.stringify == "2.hours"
+              raise "wrong lifetime: #{lifetime}"
+            end
           %}
         end
       end

--- a/src/bundles/mercure/spec/bundle_spec.cr
+++ b/src/bundles/mercure/spec/bundle_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compiles <<-CR, line: line - 11 # Account for extra code before *code* is interpolated
+  ASPEC::Methods.assert_compiles code, line: line, preamble: <<-'CR'
     require "./spec_helper.cr"
 
     @[ADI::Register(public: true)]
@@ -12,8 +12,6 @@ private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
         @discovery : ABM::Discovery,
       ); end
     end
-
-    #{code}
   CR
 end
 

--- a/src/bundles/mercure/spec/discovery_spec.cr
+++ b/src/bundles/mercure/spec/discovery_spec.cr
@@ -12,10 +12,7 @@ struct DiscoveryTest < ASPEC::TestCase
   end
 
   def test_add_link_with_named_hub : Nil
-    hub = AMC::Spec::MockHub.new(
-      "https://hub1.example.com/.well-known/mercure",
-      AMC::TokenProvider::Static.new("JWT"),
-    ) { "ID" }
+    hub = AMC::Spec::MockHub.new("https://hub1.example.com/.well-known/mercure", AMC::TokenProvider::Static.new("JWT")) { "ID" }
 
     registry = AMC::Hub::Registry.new(hub, {"hub1" => hub.as(AMC::Hub::Interface)})
     discovery = ABM::Discovery.new registry
@@ -28,15 +25,8 @@ struct DiscoveryTest < ASPEC::TestCase
   end
 
   def test_add_link_accumulates_multiple_links : Nil
-    hub1 = AMC::Spec::MockHub.new(
-      "https://hub1.example.com/.well-known/mercure",
-      AMC::TokenProvider::Static.new("JWT"),
-    ) { "ID" }
-
-    hub2 = AMC::Spec::MockHub.new(
-      "https://hub2.example.com/.well-known/mercure",
-      AMC::TokenProvider::Static.new("JWT"),
-    ) { "ID" }
+    hub1 = AMC::Spec::MockHub.new("https://hub1.example.com/.well-known/mercure", AMC::TokenProvider::Static.new("JWT")) { "ID" }
+    hub2 = AMC::Spec::MockHub.new("https://hub2.example.com/.well-known/mercure", AMC::TokenProvider::Static.new("JWT")) { "ID" }
 
     registry = AMC::Hub::Registry.new(hub1, {
       "hub1" => hub1.as(AMC::Hub::Interface),

--- a/src/bundles/mercure/spec/discovery_spec.cr
+++ b/src/bundles/mercure/spec/discovery_spec.cr
@@ -1,0 +1,67 @@
+require "./spec_helper"
+
+struct DiscoveryTest < ASPEC::TestCase
+  def test_add_link : Nil
+    discovery = ABM::Discovery.new new_hub_registry
+    request = new_request
+
+    discovery.add_link request
+
+    links = request.attributes.get? "_links", Array(String)
+    links.should eq [%(<https://example.com/.well-known/mercure>; rel="mercure")]
+  end
+
+  def test_add_link_with_named_hub : Nil
+    hub = AMC::Spec::MockHub.new(
+      "https://hub1.example.com/.well-known/mercure",
+      AMC::TokenProvider::Static.new("JWT"),
+    ) { "ID" }
+
+    registry = AMC::Hub::Registry.new(hub, {"hub1" => hub.as(AMC::Hub::Interface)})
+    discovery = ABM::Discovery.new registry
+    request = new_request
+
+    discovery.add_link request, "hub1"
+
+    links = request.attributes.get? "_links", Array(String)
+    links.should eq [%(<https://hub1.example.com/.well-known/mercure>; rel="mercure")]
+  end
+
+  def test_add_link_accumulates_multiple_links : Nil
+    hub1 = AMC::Spec::MockHub.new(
+      "https://hub1.example.com/.well-known/mercure",
+      AMC::TokenProvider::Static.new("JWT"),
+    ) { "ID" }
+
+    hub2 = AMC::Spec::MockHub.new(
+      "https://hub2.example.com/.well-known/mercure",
+      AMC::TokenProvider::Static.new("JWT"),
+    ) { "ID" }
+
+    registry = AMC::Hub::Registry.new(hub1, {
+      "hub1" => hub1.as(AMC::Hub::Interface),
+      "hub2" => hub2.as(AMC::Hub::Interface),
+    })
+
+    discovery = ABM::Discovery.new registry
+    request = new_request
+
+    discovery.add_link request, "hub1"
+    discovery.add_link request, "hub2"
+
+    links = request.attributes.get? "_links", Array(String)
+    links.should eq [
+      %(<https://hub1.example.com/.well-known/mercure>; rel="mercure"),
+      %(<https://hub2.example.com/.well-known/mercure>; rel="mercure"),
+    ]
+  end
+
+  def test_add_link_skips_preflight_request : Nil
+    discovery = ABM::Discovery.new new_hub_registry
+    request = new_request(method: "OPTIONS", headers: ::HTTP::Headers{"access-control-request-method" => "GET"})
+
+    discovery.add_link request
+
+    request.attributes.has?("_links").should be_false
+  end
+end

--- a/src/bundles/mercure/spec/listeners/add_link_header_spec.cr
+++ b/src/bundles/mercure/spec/listeners/add_link_header_spec.cr
@@ -1,0 +1,56 @@
+require "../spec_helper"
+
+struct AddLinkHeaderListenerTest < ASPEC::TestCase
+  def test_no_links_attribute : Nil
+    event = new_response_event
+
+    ABM::Listeners::AddLinkHeader.new.on_response event
+
+    event.response.headers["link"]?.should be_nil
+  end
+
+  def test_single_link : Nil
+    request = new_request
+    request.attributes.set "_links", [%(<https://hub.example.com/.well-known/mercure>; rel="mercure")], Array(String)
+
+    event = new_response_event(request: request)
+
+    ABM::Listeners::AddLinkHeader.new.on_response event
+
+    event.response.headers.get("link").should eq [%(<https://hub.example.com/.well-known/mercure>; rel="mercure")]
+  end
+
+  def test_multiple_links : Nil
+    request = new_request
+    request.attributes.set "_links", [
+      %(<https://hub1.example.com/.well-known/mercure>; rel="mercure"),
+      %(<https://hub2.example.com/.well-known/mercure>; rel="mercure"),
+    ], Array(String)
+
+    event = new_response_event(request: request)
+
+    ABM::Listeners::AddLinkHeader.new.on_response event
+
+    event.response.headers.get("link").should eq [
+      %(<https://hub1.example.com/.well-known/mercure>; rel="mercure"),
+      %(<https://hub2.example.com/.well-known/mercure>; rel="mercure"),
+    ]
+  end
+
+  def test_preserves_existing_link_headers : Nil
+    request = new_request
+    request.attributes.set "_links", [%(<https://hub.example.com/.well-known/mercure>; rel="mercure")], Array(String)
+
+    response = AHTTP::Response.new
+    response.headers.add "link", %(<https://example.com>; rel="preload")
+
+    event = new_response_event(request: request, response: response)
+
+    ABM::Listeners::AddLinkHeader.new.on_response event
+
+    event.response.headers.get("link").should eq [
+      %(<https://example.com>; rel="preload"),
+      %(<https://hub.example.com/.well-known/mercure>; rel="mercure"),
+    ]
+  end
+end

--- a/src/bundles/mercure/spec/listeners/set_cookie_spec.cr
+++ b/src/bundles/mercure/spec/listeners/set_cookie_spec.cr
@@ -1,0 +1,53 @@
+require "../spec_helper"
+
+struct SetCookieListenerTest < ASPEC::TestCase
+  def test_no_cookies_attribute : Nil
+    event = new_response_event
+
+    ABM::Listeners::SetCookie.new.on_response event
+
+    event.response.headers.cookies.should be_empty
+  end
+
+  def test_applies_cookies_to_response : Nil
+    request = new_request
+    cookies = Hash(String, ::HTTP::Cookie).new
+    cookies[""] = ::HTTP::Cookie.new("mercureAuthorization", "token123", path: "/")
+    request.attributes.set "_mercure_authorization_cookies", cookies, Hash(String, ::HTTP::Cookie)
+
+    event = new_response_event(request: request)
+
+    ABM::Listeners::SetCookie.new.on_response event
+
+    event.response.headers.cookies["mercureAuthorization"].value.should eq "token123"
+  end
+
+  def test_removes_attribute_after_processing : Nil
+    request = new_request
+    cookies = Hash(String, ::HTTP::Cookie).new
+    cookies[""] = ::HTTP::Cookie.new("mercureAuthorization", "token123", path: "/")
+    request.attributes.set "_mercure_authorization_cookies", cookies, Hash(String, ::HTTP::Cookie)
+
+    event = new_response_event(request: request)
+
+    ABM::Listeners::SetCookie.new.on_response event
+
+    request.attributes.has?("_mercure_authorization_cookies").should be_false
+  end
+
+  def test_applies_multiple_cookies : Nil
+    request = new_request
+    cookies = Hash(String, ::HTTP::Cookie).new
+    cookies[""] = ::HTTP::Cookie.new("mercureAuthorization", "default-token", path: "/")
+    cookies["hub1"] = ::HTTP::Cookie.new("mercureAuthorization", "hub1-token", path: "/hub1")
+    request.attributes.set "_mercure_authorization_cookies", cookies, Hash(String, ::HTTP::Cookie)
+
+    event = new_response_event(request: request)
+
+    ABM::Listeners::SetCookie.new.on_response event
+
+    # The last cookie with the same name wins in the cookies collection,
+    # but both should have been added via <<
+    event.response.headers.cookies.size.should be >= 1
+  end
+end

--- a/src/bundles/mercure/spec/spec_helper.cr
+++ b/src/bundles/mercure/spec/spec_helper.cr
@@ -4,4 +4,33 @@ require "athena-spec"
 
 require "../src/athena-mercure_bundle"
 
+require "athena-mercure/src/spec"
+
 ASPEC.run_all
+
+def new_hub_registry(
+  url : String = "https://example.com/.well-known/mercure",
+  token_factory : AMC::TokenFactory::Interface? = AMC::TokenFactory::JWT.new("looooooooooooongenoughtestsecret", jwt_lifetime: 4000),
+) : AMC::Hub::Registry
+  AMC::Hub::Registry.new(AMC::Spec::MockHub.new(
+    url,
+    AMC::TokenProvider::Static.new("JWT"),
+    token_factory: token_factory,
+  ) { "ID" })
+end
+
+def new_request(
+  *,
+  method : String = "GET",
+  path : String = "/",
+  headers : ::HTTP::Headers = ::HTTP::Headers.new,
+) : AHTTP::Request
+  AHTTP::Request.new(method, path, headers)
+end
+
+def new_response_event(
+  request : AHTTP::Request = new_request,
+  response : AHTTP::Response = AHTTP::Response.new,
+) : AHK::Events::Response
+  AHK::Events::Response.new(request, response)
+end

--- a/src/bundles/mercure/spec/spec_helper.cr
+++ b/src/bundles/mercure/spec/spec_helper.cr
@@ -12,11 +12,7 @@ def new_hub_registry(
   url : String = "https://example.com/.well-known/mercure",
   token_factory : AMC::TokenFactory::Interface? = AMC::TokenFactory::JWT.new("looooooooooooongenoughtestsecret", jwt_lifetime: 4000),
 ) : AMC::Hub::Registry
-  AMC::Hub::Registry.new(AMC::Spec::MockHub.new(
-    url,
-    AMC::TokenProvider::Static.new("JWT"),
-    token_factory: token_factory,
-  ) { "ID" })
+  AMC::Hub::Registry.new(AMC::Spec::MockHub.new(url, AMC::TokenProvider::Static.new("JWT"), token_factory: token_factory) { "ID" })
 end
 
 def new_request(

--- a/src/bundles/mercure/src/athena-mercure_bundle.cr
+++ b/src/bundles/mercure/src/athena-mercure_bundle.cr
@@ -1,12 +1,94 @@
 require "athena-dependency_injection"
+require "athena-http_kernel"
+require "athena-mercure"
 
+require "./authorization"
+require "./discovery"
+
+require "./listeners/*"
+
+# Convenience alias to make referencing `Athena::MercureBundle` types easier.
+alias ABM = Athena::MercureBundle
+
+# The `Athena::MercureBundle` integrates the `Athena::Mercure` component into the Athena framework.
 @[ADI::Bundle("mercure")]
 struct Athena::MercureBundle < ADI::AbstractBundle
   # :nodoc:
   PASSES = [] of _
 
+  # Represents the possible properties used to configure and customize the Mercure integration.
+  # See the [Getting Started](/getting_started/configuration) docs for more information on how the bundle system works in Athena.
+  #
+  # A full example showing all properties is as follows:
+  #
+  # ```
+  # ADI.configure({
+  #   mercure: {
+  #     hubs: {
+  #       default: {
+  #         url:        "https://internal-hub/.well-known/mercure",
+  #         public_url: "https://hub.example.com/.well-known/mercure",
+  #         jwt:        {
+  #           # Provide *secret* to generate JWTs dynamically via a token factory...
+  #           secret:     "my-jwt-secret",
+  #           publish:    ["*"],
+  #           subscribe:  ["https://example.com/books/{id}"],
+  #           algorithm:  :hs256,
+  #           passphrase: "",
+  #
+  #           # ...or provide *value* to use a static JWT token directly.
+  #           # value: "eyJhbGciOiJIUzI1NiJ9...",
+  #         },
+  #       },
+  #     },
+  #     default_hub:             "default",
+  #     default_cookie_lifetime: 1.hour,
+  #   },
+  # })
+  # ```
   module Schema
     include ADI::Extension::Schema
+
+    # JWT configuration for authenticating with a Mercure hub.
+    # Provide either *secret* to generate tokens dynamically, or *value* to use a static token.
+    #
+    # ---
+    # >>secret: The secret key used to sign JWTs.
+    # Required when generating tokens dynamically via a `AMC::TokenFactory::JWT` (i.e. when *value* is not set).
+    # Should be set via ENV var.
+    # >>publish: Topic selectors that the generated JWT grants publish access to. Included in the JWT's `mercure.publish` claim.
+    # >>subscribe: Topic selectors that the generated JWT grants subscribe access to. Included in the JWT's `mercure.subscribe` claim.
+    # >>algorithm: The signing algorithm used to encode the JWT.
+    # >>passphrase: Passphrase for the secret key, if the algorithm requires one (e.g. RSA).
+    # >>value: A pre-built static JWT token string provided via `AMC::TokenProvider::Static`. When set, the token is used as-is and *secret*, *algorithm*, and *passphrase* are ignored.
+    # ---
+    object_schema JWT,
+      secret : String? = nil,
+      publish : Array(String) = [] of String,
+      subscribe : Array(String) = [] of String,
+      algorithm : ::JWT::Algorithm = :hs256,
+      passphrase : String = "",
+      value : String? = nil
+
+    # Named Mercure hub definitions. Each hub requires a *url* and *jwt* configuration.
+    #
+    # ---
+    # >>url: The internal URL used by the server to publish updates to this hub.
+    # Should be set via ENV var.
+    # >>public_url: The public URL exposed to clients via the `Link` header for hub discovery.
+    # Falls back to *url* if not set. Useful when the internal hub URL differs from the one clients should connect to.
+    # Should be set via ENV var.
+    # ---
+    map_of hubs,
+      url : String,
+      public_url : String? = nil,
+      jwt : JWT
+
+    # The name of the hub to use when none is specified. Defaults to the first defined hub if not explicitly set.
+    property default_hub : String? = nil
+
+    # Default lifetime for authorization cookies set via `ABM::Authorization`.
+    property default_cookie_lifetime : Time::Span = 1.hour
   end
 
   # :nodoc:
@@ -15,7 +97,120 @@ struct Athena::MercureBundle < ADI::AbstractBundle
       macro finished
         {% verbatim do %}
           {%
+            cfg = CONFIG["mercure"]
+            parameters = CONFIG["parameters"]
 
+            default_hub_id = nil
+            default_hub_name = nil
+            hubs = {} of Nil => Nil
+
+            hub_aliases = [] of Nil
+            token_factory_aliases = [] of Nil
+            token_provider_aliases = [] of Nil
+
+            cfg["hubs"].to_a.reject { |(name, _)| name.stringify == "__nil" }.each do |(name, hub)|
+              token_provider = nil
+              token_factory = nil
+
+              jwt = hub["jwt"]
+
+              if value = jwt["value"]
+                SERVICE_HASH[token_provider = "mercure_hub_#{name}_jwt_provider"] = {
+                  class:      Athena::Mercure::TokenProvider::Static,
+                  parameters: {
+                    token: {value: value},
+                  },
+                }
+              else
+                # TODO: Maybe support providing the factory/provider service ID?
+
+                # TODO: Service is already lazy so no need for dedicated lazy service?
+                SERVICE_HASH[token_factory = "mercure_hub_#{name}_jwt_factory"] = {
+                  class:      Athena::Mercure::TokenFactory::JWT,
+                  tags:       ["mercure.jwt.factory"],
+                  parameters: {
+                    jwt_secret: {value: jwt["secret"]},
+                    algorithm:  {value: jwt["algorithm"]},
+                    # jwt_lifetime: {value: nil},
+                    passphrase: {value: jwt["passphrase"]},
+                  },
+                }
+
+                SERVICE_HASH[token_provider = "mercure_hub_#{name}_jwt_provider"] = {
+                  class:      Athena::Mercure::TokenProvider::Factory,
+                  tags:       ["mercure.jwt.provider"],
+                  parameters: {
+                    factory:   {value: token_factory.id},
+                    subscribe: {value: jwt["subscribe"]},
+                    publish:   {value: jwt["publish"]},
+                  },
+                }
+
+                token_factory_aliases << {id: token_factory, public: false, name: name}
+                token_factory_aliases << {id: token_factory, public: false, name: "#{name}_factory"}
+                token_factory_aliases << {id: token_factory, public: false, name: "#{name}_token_factory"}
+              end
+
+              if token_provider
+                token_provider_aliases << {id: token_provider, public: false, name: name}
+                token_provider_aliases << {id: token_provider, public: false, name: "#{name}_provider"}
+                token_provider_aliases << {id: token_provider, public: false, name: "#{name}_token_provider"}
+              end
+
+              hub_id = "mercure_hub_#{name}"
+              publisher_id = "mercure_hub_#{name}_publisher"
+              hubs[name.stringify] = hub_id.id
+
+              if cfg["default_hub"] == name || default_hub_id == nil
+                default_hub_name = name
+                default_hub_id = hub_id
+              end
+
+              SERVICE_HASH[hub_id] = {
+                class:      Athena::Mercure::Hub,
+                tags:       ["mercure.hub"],
+                parameters: {
+                  url:            {value: hub["url"]},
+                  token_provider: {value: token_provider.id},
+                  token_factory:  {value: token_factory ? token_factory.id : nil},
+                  public_url:     {value: hub["public_url"]},
+                  # http_client
+                },
+              }
+
+              hub_aliases << {id: hub_id, public: false, name: name}
+              hub_aliases << {id: hub_id, public: false, name: "#{name}_hub"}
+            end
+
+            # Unnamed alias resolves to the default hub
+            hub_aliases << {id: default_hub_id, public: false}
+
+            ALIASES[Athena::Mercure::Hub::Interface] = hub_aliases
+            ALIASES[Athena::Mercure::TokenFactory::Interface] = token_factory_aliases unless token_factory_aliases.empty?
+            ALIASES[Athena::Mercure::TokenProvider::Interface] = token_provider_aliases unless token_provider_aliases.empty?
+
+            SERVICE_HASH[hub_registry_id = "mercure_hub_registry"] = {
+              class:      Athena::Mercure::Hub::Registry,
+              parameters: {
+                default_hub: {value: default_hub_id.id},
+                hubs:        {value: "#{hubs} of String => Athena::Mercure::Hub::Interface".id},
+              },
+            }
+
+            SERVICE_HASH["mercure_authorization"] = {
+              class:      ABM::Authorization,
+              parameters: {
+                hub_registry:    {value: hub_registry_id.id},
+                cookie_lifetime: {value: cfg["default_cookie_lifetime"]},
+              },
+            }
+
+            SERVICE_HASH["mercure_discovery"] = {
+              class:      ABM::Discovery,
+              parameters: {
+                hub_registry: {value: hub_registry_id.id},
+              },
+            }
           %}
         {% end %}
       end

--- a/src/bundles/mercure/src/athena-mercure_bundle.cr
+++ b/src/bundles/mercure/src/athena-mercure_bundle.cr
@@ -105,8 +105,6 @@ struct Athena::MercureBundle < ADI::AbstractBundle
             hubs = {} of Nil => Nil
 
             hub_aliases = [] of Nil
-            token_factory_aliases = [] of Nil
-            token_provider_aliases = [] of Nil
 
             cfg["hubs"].to_a.reject { |(name, _)| name.stringify == "__nil" }.each do |(name, hub)|
               token_provider = nil
@@ -146,15 +144,19 @@ struct Athena::MercureBundle < ADI::AbstractBundle
                   },
                 }
 
-                token_factory_aliases << {id: token_factory, public: false, name: name}
-                token_factory_aliases << {id: token_factory, public: false, name: "#{name}_factory"}
-                token_factory_aliases << {id: token_factory, public: false, name: "#{name}_token_factory"}
+                ALIASES[Athena::Mercure::TokenFactory::Interface] = [
+                  {id: token_factory, public: false, name: name},
+                  {id: token_factory, public: false, name: "#{name}_factory"},
+                  {id: token_factory, public: false, name: "#{name}_token_factory"},
+                ]
               end
 
               if token_provider
-                token_provider_aliases << {id: token_provider, public: false, name: name}
-                token_provider_aliases << {id: token_provider, public: false, name: "#{name}_provider"}
-                token_provider_aliases << {id: token_provider, public: false, name: "#{name}_token_provider"}
+                ALIASES[Athena::Mercure::TokenProvider::Interface] = [
+                  {id: token_provider, public: false, name: name},
+                  {id: token_provider, public: false, name: "#{name}_provider"},
+                  {id: token_provider, public: false, name: "#{name}_token_provider"},
+                ]
               end
 
               hub_id = "mercure_hub_#{name}"
@@ -172,7 +174,7 @@ struct Athena::MercureBundle < ADI::AbstractBundle
                 parameters: {
                   url:            {value: hub["url"]},
                   token_provider: {value: token_provider.id},
-                  token_factory:  {value: token_factory ? token_factory.id : nil},
+                  token_factory:  {value: token_factory.id},
                   public_url:     {value: hub["public_url"]},
                   # http_client
                 },
@@ -186,8 +188,6 @@ struct Athena::MercureBundle < ADI::AbstractBundle
             hub_aliases << {id: default_hub_id, public: false}
 
             ALIASES[Athena::Mercure::Hub::Interface] = hub_aliases
-            ALIASES[Athena::Mercure::TokenFactory::Interface] = token_factory_aliases unless token_factory_aliases.empty?
-            ALIASES[Athena::Mercure::TokenProvider::Interface] = token_provider_aliases unless token_provider_aliases.empty?
 
             SERVICE_HASH[hub_registry_id = "mercure_hub_registry"] = {
               class:      Athena::Mercure::Hub::Registry,

--- a/src/bundles/mercure/src/authorization.cr
+++ b/src/bundles/mercure/src/authorization.cr
@@ -1,0 +1,69 @@
+struct Athena::MercureBundle < ADI::AbstractBundle; end
+
+# Extension of [AMC::Authorization](/Mercure/Authorization) to add support for [AHTTP::Request](/HTTP/Request).
+class Athena::MercureBundle::Authorization < Athena::Mercure::Authorization
+  def initialize(
+    hub_registry : AMC::Hub::Registry,
+    cookie_lifetime : Time::Span = 1.hour,
+    cookie_samesite : ::HTTP::Cookie::SameSite = :strict,
+  )
+    super
+  end
+
+  # Sets the `mercureAuthorization` cookie for the provided *hub_name*.
+  # The cookie is automatically applied to the `AHTTP::Response` via the `Listeners::SetCookie` listener.
+  #
+  # The JWT cookie value by default does not have access to publish or subscribe to any topic.
+  # Be sure to set the *subscribe* and *publish* arrays to the topics you want it to be able to interact with, or `["*"]` to handle all topics.
+  # *additional_claims* may also be used to define additional claims to the JWT if needed.
+  def set_cookie(
+    request : AHTTP::Request,
+    subscribe : Array(String)? = [] of String,
+    publish : Array(String)? = [] of String,
+    additional_claims : Hash? = nil,
+    hub_name : String? = nil,
+  ) : Nil
+    self.update_cookies request, hub_name, self.create_cookie(request, subscribe, publish, additional_claims, hub_name)
+  end
+
+  # Clears the `mercureAuthorization` cookie for the given *hub_name*.
+  def clear_cookie(
+    request : AHTTP::Request,
+    hub_name : String? = nil,
+  ) : Nil
+    self.update_cookies request, hub_name, self.create_clear_cookie(request.request, hub_name)
+  end
+
+  # Returns a Mercure auth cookie given the provided *request* and optionally for the provided *hub_name*.
+  #
+  # The JWT cookie value by default does not have access to publish or subscribe to any topic.
+  # Be sure to set the *subscribe* and *publish* arrays to the topics you want it to be able to interact with, or `["*"]` to handle all topics.
+  # *additional_claims* may also be used to define additional claims to the JWT if needed.
+  def create_cookie(
+    request : AHTTP::Request,
+    subscribe : Array(String)? = [] of String,
+    publish : Array(String)? = [] of String,
+    additional_claims : Hash? = nil,
+    hub_name : String? = nil,
+  ) : ::HTTP::Cookie
+    super request.request, subscribe, publish, additional_claims, hub_name
+  end
+
+  private def update_cookies(
+    request : AHTTP::Request,
+    hub_name : String?,
+    cookie : ::HTTP::Cookie,
+  ) : Nil
+    hub_name ||= ""
+
+    cookies = request.attributes.get?("_mercure_authorization_cookies", Hash(String, ::HTTP::Cookie)) || Hash(String, ::HTTP::Cookie).new
+
+    if cookies.has_key? hub_name
+      raise AMC::Exception::Runtime.new "The 'mercureAuthorization' cookie for the '#{hub_name.presence ? "#{hub_name} hub" : "default hub"}' has already been set. You cannot set it two times during the same request."
+    end
+
+    cookies[hub_name] = cookie
+
+    request.attributes.set "_mercure_authorization_cookies", cookies, Hash(String, ::HTTP::Cookie)
+  end
+end

--- a/src/bundles/mercure/src/discovery.cr
+++ b/src/bundles/mercure/src/discovery.cr
@@ -1,0 +1,21 @@
+# Extension of [AMC::Discovery](/Mercure/Discovery/) that accepts [AHTTP::Request](/HTTP/Request/)
+# and stores the link in a request attribute for the [AddLinkHeader](/MercureBundle/Listeners/AddLinkHeader/) listener.
+class Athena::MercureBundle::Discovery < AMC::Discovery
+  def initialize(
+    hub_registry : AMC::Hub::Registry,
+  )
+    super
+  end
+
+  # Adds the mercure relation `link` header to the provided *request*, optionally for the provided *hub_name*.
+  def add_link(request : AHTTP::Request, hub_name : String? = nil) : Nil
+    return if self.preflight_request? request.request
+
+    hub = @hub_registry.hub hub_name
+
+    # TODO: Create WebLink component?
+    links = request.attributes.get?("_links", Array(String)) || Array(String).new
+    links << self.generate_link(hub.public_url)
+    request.attributes.set("_links", links, Array(String))
+  end
+end

--- a/src/bundles/mercure/src/listeners/add_link_header.cr
+++ b/src/bundles/mercure/src/listeners/add_link_header.cr
@@ -1,0 +1,16 @@
+# Adds Mercure hub `Link` headers that was stored in the request attributes via `ABM::Discovery`.
+@[ADI::Register]
+struct Athena::MercureBundle::Listeners::AddLinkHeader
+  # :nodoc:
+  def initialize; end
+
+  @[AEDA::AsEventListener]
+  def on_response(event : AHK::Events::Response) : Nil
+    return unless links = event.request.attributes.get? "_links", Array(String)
+
+    # TODO: Create WebLink component?
+    links.each do |link|
+      event.response.headers.add "link", link
+    end
+  end
+end

--- a/src/bundles/mercure/src/listeners/set_cookie.cr
+++ b/src/bundles/mercure/src/listeners/set_cookie.cr
@@ -1,0 +1,17 @@
+# Adds `mercureAuthorization` cookies that were stored in the request attributes via `ABM::Authorization`.
+@[ADI::Register]
+struct Athena::MercureBundle::Listeners::SetCookie
+  # :nodoc:
+  def initialize; end
+
+  @[AEDA::AsEventListener]
+  def on_response(event : AHK::Events::Response) : Nil
+    return unless cookies = event.request.attributes.get? "_mercure_authorization_cookies", Hash(String, ::HTTP::Cookie)
+
+    event.request.attributes.remove "_mercure_authorization_cookies"
+
+    cookies.each_value do |cookie|
+      event.response.headers << cookie
+    end
+  end
+end

--- a/src/components/mercure-bundle/docs/README.md
+++ b/src/components/mercure-bundle/docs/README.md
@@ -1,3 +1,5 @@
+The `ABM` integrates the `Athena::Mercure` component into the Athena framework; abstracting away the setup down to just a couple configuration values.
+
 ## Installation
 
 First, install the bundle by adding the following to your `shard.yml`, then running `shards install`:
@@ -9,20 +11,112 @@ dependencies:
     version: ~> 0.1.0
 ```
 
-Then, register it:
+Then, require it:
 ```crystal
-ADI.register_bundle Athena::MercureBundle
+require "athena-mercure_bundle"
 ```
+This automatically registers the bundle with the framework.
 
-Finally, optionally configure it:
+Finally, configure it with at least one hub and required configuration:
 ```crystal
 ADI.configure({
   mercure: {
-    foo: bar
+    hubs: {
+      default: {
+        url:        ENV["MERCURE_URL"],
+        jwt: {
+          secret:    ENV["MERCURE_JWT_SECRET"],
+          publish:   ["*"],
+          subscribe: ["*"],
+        },
+      },
+    },
   },
 })
 ```
+See the bundle [Schema](/MercureBundle/Schema) for the full set of possible configuration options.
+
+If multiple hubs are configured, they may be injected using the hub name as a constructor parameter typed to [AMC::Hub::Interface](/Mercure/Hub/Interface/).
+For example `some_hub : AMC::Hub::Interface` assuming the key used in the `hubs` named tuple was `some_hub`.
 
 ## Usage
 
-TODO: Write me
+The Mercure bundle brings [AMC::Hub](/Mercure/Hub/), [AMC::Authorization](/Mercure/Authorization/), and [AMC::Discovery](/Mercure/Discovery/) into the framework as injectable services, with event listeners that handle response headers and cookies automatically.
+
+### Publishing
+
+Inject [AMC::Hub::Interface](/Mercure/Hub/Interface/) to publish updates from a controller:
+
+```crystal
+@[ARTA::Route(path: "/broadcast")]
+class BroadcastController < ATH::Controller
+  def initialize(@hub : AMC::Hub::Interface); end
+
+  @[ARTA::Post("/")]
+  def broadcast : Nil
+    @hub.publish AMC::Update.new(
+      "https://example.com/books/1",
+      {status: "OutOfStock"}.to_json
+    )
+  end
+end
+```
+
+### Authorization
+
+Inject [ABM::Authorization](/MercureBundle/Authorization/) to set the `mercureAuthorization` cookie for [private updates](/Mercure/#authorization).
+The [SetCookie](/MercureBundle/Listeners/SetCookie/) listener automatically adds the cookie to the response — there is no need to modify the response directly:
+
+```crystal
+@[ARTA::Route(path: "/auth")]
+class AuthController < ATH::Controller
+  def initialize(@authorization : ABM::Authorization); end
+
+  @[ARTA::Get("/subscribe")]
+  def subscribe(request : AHTTP::Request) : Nil
+    @authorization.set_cookie(
+      request,
+      subscribe: ["https://example.com/books/{id}"],
+    )
+  end
+end
+```
+
+See [Authorization](/Mercure/#authorization) in the Mercure component docs for more on private updates and cookie-based auth.
+
+### Discovery
+
+Inject [ABM::Discovery](/MercureBundle/Discovery/) to add the Mercure hub `Link` header to a response.
+The [AddLinkHeader](/MercureBundle/Listeners/AddLinkHeader/) listener handles adding the header — there is no need to modify the response directly:
+
+```crystal
+@[ARTA::Route(path: "/books")]
+class BookController < ATH::Controller
+  def initialize(@discovery : ABM::Discovery); end
+
+  @[ARTA::Get("/{id}")]
+  def show(request : AHTTP::Request, id : Int32) : {id: Int32, title : String}
+    @discovery.add_link request
+
+    {id: id, title: "Hello World!"}
+  end
+end
+```
+
+The response will include a `Link: <https://hub.example.com/.well-known/mercure>; rel="mercure"` header.
+A client can then extract the hub URL to subscribe to updates for this resource:
+
+```js
+fetch('/books/1')
+  .then(response => {
+    const hubUrl = response.headers.get('Link').match(/<([^>]+)>;\s+rel=(?:mercure|"[^"]*mercure[^"]*")/)[1];
+
+    const hub = new URL(hubUrl, window.origin);
+    hub.searchParams.append('topic', 'https://example.com/books/{id}');
+
+    const eventSource = new EventSource(hub);
+    eventSource.onmessage = event => console.log(event.data);
+  });
+```
+
+See [Discovery](/Mercure/#discovery) in the Mercure component docs for more on the discovery protocol.

--- a/src/components/mercure-bundle/docs/README.md
+++ b/src/components/mercure-bundle/docs/README.md
@@ -1,4 +1,4 @@
-The `ABM` integrates the `Athena::Mercure` component into the Athena framework; abstracting away the setup down to just a couple configuration values.
+The `Athena::MercureBundle` integrates the `Athena::Mercure` component into the Athena framework; abstracting away the setup down to just a couple configuration values.
 
 ## Installation
 

--- a/src/components/mercure-bundle/mkdocs.yml
+++ b/src/components/mercure-bundle/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
   - Introduction: README.md
   - Back to Manual: project://.
   - API:
+      - Aliases: aliases.md
       - Top Level: top_level.md
       - '*'
 
@@ -26,6 +27,11 @@ plugins:
           crystal_docs_flags:
             - ../../../docs/index.cr
             - ./lib/athena-dependency_injection/src/athena-dependency_injection.cr
+            - ./lib/athena-http/src/athena-http.cr
+            - ./lib/athena-contracts/src/athena-contracts.cr
+            - ./lib/athena-event_dispatcher/src/athena-event_dispatcher.cr
+            - ./lib/athena-http_kernel/src/athena-http_kernel.cr
+            - ./lib/athena-mercure/src/athena-mercure.cr
             - ./lib/athena-mercure_bundle/src/athena-mercure_bundle.cr
           source_locations:
             lib/athena-mercure_bundle: https://github.com/athena-framework/mercure-bundle/blob/v{shard_version}/{file}#L{line}

--- a/src/components/mercure/spec/authorization_spec.cr
+++ b/src/components/mercure/spec/authorization_spec.cr
@@ -9,7 +9,7 @@ struct AuthorizationTest < ASPEC::TestCase
     ) { "ID" })
 
     authorization = AMC::Authorization.new registry
-    cookie = authorization.create_cookie HTTP::Request.new("GET", "https://example.com", headers: HTTP::Headers{"host" => "example.com"})
+    cookie = authorization.create_cookie ::HTTP::Request.new("GET", "https://example.com", headers: ::HTTP::Headers{"host" => "example.com"})
 
     payload, _ = JWT.decode(cookie.value, verify: false, validate: false)
     payload["exp"].as_i?.should be_a Int32
@@ -29,8 +29,8 @@ struct AuthorizationTest < ASPEC::TestCase
       token_factory: token_factory
     ) { "ID" })
 
-    request = HTTP::Request.new("GET", "https://example.com", headers: HTTP::Headers{"host" => "example.com"})
-    response = HTTP::Server::Response.new IO::Memory.new
+    request = ::HTTP::Request.new("GET", "https://example.com", headers: ::HTTP::Headers{"host" => "example.com"})
+    response = ::HTTP::Server::Response.new IO::Memory.new
 
     authorization = AMC::Authorization.new registry, Time::Span.zero, :lax
     authorization.set_cookie request, response, ["foo"], ["bar"], {"x-foo" => "baz"}
@@ -56,8 +56,8 @@ struct AuthorizationTest < ASPEC::TestCase
       token_factory: token_factory
     ) { "ID" })
 
-    request = HTTP::Request.new("GET", "https://example.com", headers: HTTP::Headers{"host" => "example.com"})
-    response = HTTP::Server::Response.new IO::Memory.new
+    request = ::HTTP::Request.new("GET", "https://example.com", headers: ::HTTP::Headers{"host" => "example.com"})
+    response = ::HTTP::Server::Response.new IO::Memory.new
 
     authorization = AMC::Authorization.new registry, cookie_samesite: :lax
     authorization.set_cookie request, response, ["foo"], ["bar"], {"x-foo" => "baz"}
@@ -78,8 +78,8 @@ struct AuthorizationTest < ASPEC::TestCase
       token_factory: token_factory
     ) { "ID" })
 
-    request = HTTP::Request.new("GET", "https://example.com", headers: HTTP::Headers{"host" => "example.com"})
-    response = HTTP::Server::Response.new IO::Memory.new
+    request = ::HTTP::Request.new("GET", "https://example.com", headers: ::HTTP::Headers{"host" => "example.com"})
+    response = ::HTTP::Server::Response.new IO::Memory.new
 
     authorization = AMC::Authorization.new registry
     authorization.clear_cookie request, response
@@ -98,7 +98,7 @@ struct AuthorizationTest < ASPEC::TestCase
     ) { "ID" })
 
     uri = URI.parse request_url
-    request = HTTP::Request.new("GET", uri.path, headers: HTTP::Headers{"host" => uri.hostname || ""})
+    request = ::HTTP::Request.new("GET", uri.path, headers: ::HTTP::Headers{"host" => uri.hostname || ""})
 
     authorization = AMC::Authorization.new registry
 
@@ -126,7 +126,7 @@ struct AuthorizationTest < ASPEC::TestCase
     ) { "ID" })
 
     uri = URI.parse request_url
-    request = HTTP::Request.new("GET", uri.path, headers: HTTP::Headers{"host" => uri.hostname || ""})
+    request = ::HTTP::Request.new("GET", uri.path, headers: ::HTTP::Headers{"host" => uri.hostname || ""})
 
     authorization = AMC::Authorization.new registry
 
@@ -149,8 +149,8 @@ struct AuthorizationTest < ASPEC::TestCase
       token_factory: AMC::TokenFactory::JWT.new("looooooooooooongenoughtestsecret", jwt_lifetime: 4000)
     ) { "ID" })
 
-    request = HTTP::Request.new("GET", "https://example.com", headers: HTTP::Headers{"host" => "example.com"})
-    response = HTTP::Server::Response.new IO::Memory.new
+    request = ::HTTP::Request.new("GET", "https://example.com", headers: ::HTTP::Headers{"host" => "example.com"})
+    response = ::HTTP::Server::Response.new IO::Memory.new
 
     authorization = AMC::Authorization.new registry
 
@@ -174,8 +174,8 @@ struct AuthorizationTest < ASPEC::TestCase
       token_factory: token_factory
     ) { "ID" })
 
-    request = HTTP::Request.new("GET", "https://example.com", headers: HTTP::Headers{"host" => "example.com"})
-    response = HTTP::Server::Response.new IO::Memory.new
+    request = ::HTTP::Request.new("GET", "https://example.com", headers: ::HTTP::Headers{"host" => "example.com"})
+    response = ::HTTP::Server::Response.new IO::Memory.new
 
     authorization = AMC::Authorization.new registry
     authorization.set_cookie request, response, nil, nil, {"x-foo" => "baz"}

--- a/src/components/mercure/spec/discovery_spec.cr
+++ b/src/components/mercure/spec/discovery_spec.cr
@@ -8,8 +8,8 @@ describe AMC::Discovery do
       token_factory: AMC::TokenFactory::JWT.new("looooooooooooongenoughtestsecret", jwt_lifetime: 4000)
     ) { "ID" })
 
-    request = HTTP::Request.new("OPTIONS", "/", headers: HTTP::Headers{"access-control-request-method" => "GET"})
-    response = HTTP::Server::Response.new IO::Memory.new
+    request = ::HTTP::Request.new("OPTIONS", "/", headers: ::HTTP::Headers{"access-control-request-method" => "GET"})
+    response = ::HTTP::Server::Response.new IO::Memory.new
 
     discovery = AMC::Discovery.new registry
     discovery.add_link request, response
@@ -24,8 +24,8 @@ describe AMC::Discovery do
       token_factory: AMC::TokenFactory::JWT.new("looooooooooooongenoughtestsecret", jwt_lifetime: 4000)
     ) { "ID" })
 
-    request = HTTP::Request.new("POST", "/")
-    response = HTTP::Server::Response.new IO::Memory.new
+    request = ::HTTP::Request.new("POST", "/")
+    response = ::HTTP::Server::Response.new IO::Memory.new
 
     discovery = AMC::Discovery.new registry
     discovery.add_link request, response

--- a/src/components/mercure/spec/hub/hub_spec.cr
+++ b/src/components/mercure/spec/hub/hub_spec.cr
@@ -2,19 +2,19 @@ require "../spec_helper"
 
 private URL = "https://demo.mercure.rocks/.well-known/mercure"
 
-private class MockHTTPClient < HTTP::Client
+private class MockHTTPClient < ::HTTP::Client
   setter exception : ::Exception? = nil
 
-  def post(path, headers : HTTP::Headers? = nil, *, form : String | IO) : HTTP::Client::Response
+  def post(path, headers : ::HTTP::Headers? = nil, *, form : String | IO) : ::HTTP::Client::Response
     if ex = @exception
       raise ex
     end
 
     path.should eq "/.well-known/mercure"
-    headers.should eq HTTP::Headers{"authorization" => "Bearer FOO"}
+    headers.should eq ::HTTP::Headers{"authorization" => "Bearer FOO"}
     form.should eq "topic=https%3A%2F%2Fdemo.mercure.rocks%2Fdemo%2Fbooks%2F1.jsonld&data=Hi+from+Athena%21&private=on&id=id&retry=3"
 
-    HTTP::Client::Response.new :ok, "ID"
+    ::HTTP::Client::Response.new :ok, "ID"
   end
 end
 

--- a/src/components/mercure/src/authorization.cr
+++ b/src/components/mercure/src/authorization.cr
@@ -6,28 +6,28 @@ class Athena::Mercure::Authorization
   def initialize(
     @hub_registry : AMC::Hub::Registry,
     @cookie_lifetime : Time::Span = 1.hour,
-    @cookie_samesite : HTTP::Cookie::SameSite = :strict,
+    @cookie_samesite : ::HTTP::Cookie::SameSite = :strict,
   ); end
 
-  # Sets the `mercureAuthorization` cookie on the provided *response* given the provided *request*, optionally for the provided *hub*.
+  # Sets the `mercureAuthorization` cookie on the provided *response* given the provided *request*, optionally for the provided *hub_name*.
   # The JWT cookie value by default does not have access to publish or subscribe to any topic.
   # Be sure to set the *subscribe* and *publish* arrays to the topics you want it to be able to interact with, or `["*"]` to handle all topics.
   # *additional_claims* may also be used to define additional claims to the JWT if needed.
   def set_cookie(
-    request : HTTP::Request,
-    response : HTTP::Server::Response,
+    request : ::HTTP::Request,
+    response : ::HTTP::Server::Response,
     subscribe : Array(String)? = [] of String,
     publish : Array(String)? = [] of String,
     additional_claims : Hash? = nil,
     hub_name : String? = nil,
-  )
+  ) : Nil
     self.update_cookies request, response, hub_name, self.create_cookie(request, subscribe, publish, additional_claims, hub_name)
   end
 
-  # Clears the Mercure cookie from the provided *response*, optionally for the provided *hub*.
+  # Clears the Mercure cookie from the provided *response*, optionally for the provided *hub_name*.
   def clear_cookie(
-    request : HTTP::Request,
-    response : HTTP::Server::Response,
+    request : ::HTTP::Request,
+    response : ::HTTP::Server::Response,
     hub_name : String? = nil,
   ) : Nil
     self.update_cookies request, response, hub_name, self.create_clear_cookie(request, hub_name)
@@ -39,12 +39,12 @@ class Athena::Mercure::Authorization
   # Be sure to set the *subscribe* and *publish* arrays to the topics you want it to be able to interact with, or `["*"]` to handle all topics.
   # *additional_claims* may also be used to define additional claims to the JWT if needed.
   def create_cookie(
-    request : HTTP::Request,
+    request : ::HTTP::Request,
     subscribe : Array(String)? = [] of String,
     publish : Array(String)? = [] of String,
     additional_claims : Hash? = nil,
     hub_name : String? = nil,
-  ) : HTTP::Cookie
+  ) : ::HTTP::Cookie
     hub = @hub_registry.hub hub_name
     unless token_factory = hub.token_factory
       raise AMC::Exception::InvalidArgument.new "The hub '#{hub_name}' does not contain a token factory."
@@ -64,7 +64,7 @@ class Athena::Mercure::Authorization
     token = token_factory.create subscribe, publish, additional_claims
     uri = URI.parse hub.public_url
 
-    HTTP::Cookie.new(
+    ::HTTP::Cookie.new(
       COOKIE_NAME,
       token,
       uri.path || "/",
@@ -76,11 +76,11 @@ class Athena::Mercure::Authorization
     )
   end
 
-  private def create_clear_cookie(request : HTTP::Request, hub_name : String? = nil) : HTTP::Cookie
+  private def create_clear_cookie(request : ::HTTP::Request, hub_name : String? = nil) : ::HTTP::Cookie
     hub = @hub_registry.hub hub_name
     uri = URI.parse hub.public_url
 
-    HTTP::Cookie.new(
+    ::HTTP::Cookie.new(
       COOKIE_NAME,
       "",
       uri.path || "/",
@@ -92,7 +92,7 @@ class Athena::Mercure::Authorization
     )
   end
 
-  private def cookie_domain(request : HTTP::Request, uri : URI) : String?
+  private def cookie_domain(request : ::HTTP::Request, uri : URI) : String?
     return unless uri_host = uri.host
 
     cookie_domain = uri_host.downcase
@@ -120,10 +120,10 @@ class Athena::Mercure::Authorization
   end
 
   private def update_cookies(
-    request : HTTP::Request,
-    response : HTTP::Server::Response,
+    request : ::HTTP::Request,
+    response : ::HTTP::Server::Response,
     hub_name : String?,
-    cookie : HTTP::Cookie,
+    cookie : ::HTTP::Cookie,
   ) : Nil
     unless response.cookies[COOKIE_NAME]?.nil?
       raise AMC::Exception::Runtime.new "The 'mercureAuthorization' cookie for the '#{hub_name ? "#{hub_name} hub" : "default hub"}' has already been set. You cannot set it two times during the same request."

--- a/src/components/mercure/src/discovery.cr
+++ b/src/components/mercure/src/discovery.cr
@@ -8,16 +8,20 @@ class Athena::Mercure::Discovery
   ); end
 
   # Adds the mercure relation `link` header to the provided *response*, optionally for the provided *hub_name*.
-  def add_link(request : HTTP::Request, response : HTTP::Server::Response, hub_name : String? = nil) : Nil
+  def add_link(request : ::HTTP::Request, response : ::HTTP::Server::Response, hub_name : String? = nil) : Nil
     return if self.preflight_request? request
 
     hub = @hub_registry.hub hub_name
 
     # TODO: Create WebLink component?
-    response.headers.add "link", %(<#{hub.public_url}>; rel="mercure")
+    response.headers.add "link", self.generate_link(hub.public_url)
   end
 
-  private def preflight_request?(request : HTTP::Request) : Bool
+  private def generate_link(url : String) : String
+    %(<#{url}>; rel="mercure")
+  end
+
+  private def preflight_request?(request : ::HTTP::Request) : Bool
     "options" == request.method.downcase && request.headers.has_key? "access-control-request-method"
   end
 end

--- a/src/components/mercure/src/hub/hub.cr
+++ b/src/components/mercure/src/hub/hub.cr
@@ -12,17 +12,17 @@ class Athena::Mercure::Hub
 
   @uri : URI
   @public_url : String?
-  @http_client : HTTP::Client
+  @http_client : ::HTTP::Client
 
   def initialize(
     url : String,
     @token_provider : AMC::TokenProvider::Interface,
     @token_factory : AMC::TokenFactory::Interface? = nil,
     @public_url : String? = nil,
-    http_client : HTTP::Client? = nil,
+    http_client : ::HTTP::Client? = nil,
   )
     @uri = URI.parse url
-    @http_client = http_client || HTTP::Client.new @uri
+    @http_client = http_client || ::HTTP::Client.new @uri
   end
 
   # :inherit:
@@ -39,7 +39,7 @@ class Athena::Mercure::Hub
   def publish(update : AMC::Update) : String
     @http_client.post(
       @uri.path,
-      headers: HTTP::Headers{"authorization" => "Bearer #{@token_provider.jwt}"},
+      headers: ::HTTP::Headers{"authorization" => "Bearer #{@token_provider.jwt}"},
       form: URI::Params.build { |form| self.encode form, update }
     ).body
   rescue ex : ::Exception

--- a/uv.lock
+++ b/uv.lock
@@ -36,66 +36,66 @@ wheels = [
 
 [[package]]
 name = "backrefs"
-version = "6.1"
+version = "6.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/e3/bb3a439d5cb255c4774724810ad8073830fac9c9dee123555820c1bcc806/backrefs-6.1.tar.gz", hash = "sha256:3bba1749aafe1db9b915f00e0dd166cba613b6f788ffd63060ac3485dc9be231", size = 7011962, upload-time = "2025-11-15T14:52:08.323Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/e325ec73b638d3ede4421b5445d4a0b8b219481826cc079d510100af356c/backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49", size = 7012303, upload-time = "2026-02-16T19:10:15.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ee/c216d52f58ea75b5e1841022bbae24438b19834a29b163cb32aa3a2a7c6e/backrefs-6.1-py310-none-any.whl", hash = "sha256:2a2ccb96302337ce61ee4717ceacfbf26ba4efb1d55af86564b8bbaeda39cac1", size = 381059, upload-time = "2025-11-15T14:51:59.758Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/9a/8da246d988ded941da96c7ed945d63e94a445637eaad985a0ed88787cb89/backrefs-6.1-py311-none-any.whl", hash = "sha256:e82bba3875ee4430f4de4b6db19429a27275d95a5f3773c57e9e18abc23fd2b7", size = 392854, upload-time = "2025-11-15T14:52:01.194Z" },
-    { url = "https://files.pythonhosted.org/packages/37/c9/fd117a6f9300c62bbc33bc337fd2b3c6bfe28b6e9701de336b52d7a797ad/backrefs-6.1-py312-none-any.whl", hash = "sha256:c64698c8d2269343d88947c0735cb4b78745bd3ba590e10313fbf3f78c34da5a", size = 398770, upload-time = "2025-11-15T14:52:02.584Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/95/7118e935b0b0bd3f94dfec2d852fd4e4f4f9757bdb49850519acd245cd3a/backrefs-6.1-py313-none-any.whl", hash = "sha256:4c9d3dc1e2e558965202c012304f33d4e0e477e1c103663fd2c3cc9bb18b0d05", size = 400726, upload-time = "2025-11-15T14:52:04.093Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/72/6296bad135bfafd3254ae3648cd152980a424bd6fed64a101af00cc7ba31/backrefs-6.1-py314-none-any.whl", hash = "sha256:13eafbc9ccd5222e9c1f0bec563e6d2a6d21514962f11e7fc79872fd56cbc853", size = 412584, upload-time = "2025-11-15T14:52:05.233Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e3/a4fa1946722c4c7b063cc25043a12d9ce9b4323777f89643be74cef2993c/backrefs-6.1-py39-none-any.whl", hash = "sha256:a9e99b8a4867852cad177a6430e31b0f6e495d65f8c6c134b68c14c3c95bf4b0", size = 381058, upload-time = "2025-11-15T14:52:06.698Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/39/3765df263e08a4df37f4f43cb5aa3c6c17a4bdd42ecfe841e04c26037171/backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8", size = 381075, upload-time = "2026-02-16T19:10:04.322Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/f0/35240571e1b67ffb19dafb29ab34150b6f59f93f717b041082cdb1bfceb1/backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be", size = 392874, upload-time = "2026-02-16T19:10:06.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/77e8c9745b4d227cce9f5e0a6f68041278c5f9b18588b35905f5f19c1beb/backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90", size = 398787, upload-time = "2026-02-16T19:10:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747, upload-time = "2026-02-16T19:10:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602, upload-time = "2026-02-16T19:10:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077, upload-time = "2026-02-16T19:10:13.74Z" },
 ]
 
 [[package]]
 name = "certifi"
-version = "2026.1.4"
+version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
 ]
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.4"
+version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/35/02daf95b9cd686320bb622eb148792655c9412dbb9b67abb5694e5910a24/charset_normalizer-3.4.5.tar.gz", hash = "sha256:95adae7b6c42a6c5b5b559b1a99149f090a57128155daeea91732c8d970d8644", size = 134804, upload-time = "2026-03-06T06:03:19.46Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
-    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
-    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
-    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
-    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
-    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
-    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
-    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
-    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
-    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
-    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
-    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/48/9f34ec4bb24aa3fdba1890c1bddb97c8a4be1bd84ef5c42ac2352563ad05/charset_normalizer-3.4.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac59c15e3f1465f722607800c68713f9fbc2f672b9eb649fe831da4019ae9b23", size = 280788, upload-time = "2026-03-06T06:01:37.126Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/09/6003e7ffeb90cc0560da893e3208396a44c210c5ee42efff539639def59b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:165c7b21d19365464e8f70e5ce5e12524c58b48c78c1f5a57524603c1ab003f8", size = 188890, upload-time = "2026-03-06T06:01:38.73Z" },
+    { url = "https://files.pythonhosted.org/packages/42/1e/02706edf19e390680daa694d17e2b8eab4b5f7ac285e2a51168b4b22ee6b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:28269983f25a4da0425743d0d257a2d6921ea7d9b83599d4039486ec5b9f911d", size = 206136, upload-time = "2026-03-06T06:01:40.016Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/87/942c3def1b37baf3cf786bad01249190f3ca3d5e63a84f831e704977de1f/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d27ce22ec453564770d29d03a9506d449efbb9fa13c00842262b2f6801c48cce", size = 202551, upload-time = "2026-03-06T06:01:41.522Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0a/af49691938dfe175d71b8a929bd7e4ace2809c0c5134e28bc535660d5262/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0625665e4ebdddb553ab185de5db7054393af8879fb0c87bd5690d14379d6819", size = 195572, upload-time = "2026-03-06T06:01:43.208Z" },
+    { url = "https://files.pythonhosted.org/packages/20/ea/dfb1792a8050a8e694cfbde1570ff97ff74e48afd874152d38163d1df9ae/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:c23eb3263356d94858655b3e63f85ac5d50970c6e8febcdde7830209139cc37d", size = 184438, upload-time = "2026-03-06T06:01:44.755Z" },
+    { url = "https://files.pythonhosted.org/packages/72/12/c281e2067466e3ddd0595bfaea58a6946765ace5c72dfa3edc2f5f118026/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e6302ca4ae283deb0af68d2fbf467474b8b6aedcd3dab4db187e07f94c109763", size = 193035, upload-time = "2026-03-06T06:01:46.051Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4f/3792c056e7708e10464bad0438a44708886fb8f92e3c3d29ec5e2d964d42/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e51ae7d81c825761d941962450f50d041db028b7278e7b08930b4541b3e45cb9", size = 191340, upload-time = "2026-03-06T06:01:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/86/80ddba897127b5c7a9bccc481b0cd36c8fefa485d113262f0fe4332f0bf4/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:597d10dec876923e5c59e48dbd366e852eacb2b806029491d307daea6b917d7c", size = 185464, upload-time = "2026-03-06T06:01:48.764Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/00/b5eff85ba198faacab83e0e4b6f0648155f072278e3b392a82478f8b988b/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5cffde4032a197bd3b42fd0b9509ec60fb70918d6970e4cc773f20fc9180ca67", size = 208014, upload-time = "2026-03-06T06:01:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/11/d36f70be01597fd30850dde8a1269ebc8efadd23ba5785808454f2389bde/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2da4eedcb6338e2321e831a0165759c0c620e37f8cd044a263ff67493be8ffb3", size = 193297, upload-time = "2026-03-06T06:01:51.933Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1d/259eb0a53d4910536c7c2abb9cb25f4153548efb42800c6a9456764649c0/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:65a126fb4b070d05340a84fc709dd9e7c75d9b063b610ece8a60197a291d0adf", size = 204321, upload-time = "2026-03-06T06:01:53.887Z" },
+    { url = "https://files.pythonhosted.org/packages/84/31/faa6c5b9d3688715e1ed1bb9d124c384fe2fc1633a409e503ffe1c6398c1/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c7a80a9242963416bd81f99349d5f3fce1843c303bd404f204918b6d75a75fd6", size = 197509, upload-time = "2026-03-06T06:01:56.439Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a5/c7d9dd1503ffc08950b3260f5d39ec2366dd08254f0900ecbcf3a6197c7c/charset_normalizer-3.4.5-cp313-cp313-win32.whl", hash = "sha256:f1d725b754e967e648046f00c4facc42d414840f5ccc670c5670f59f83693e4f", size = 132284, upload-time = "2026-03-06T06:01:57.812Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/0f/57072b253af40c8aa6636e6de7d75985624c1eb392815b2f934199340a89/charset_normalizer-3.4.5-cp313-cp313-win_amd64.whl", hash = "sha256:e37bd100d2c5d3ba35db9c7c5ba5a9228cbcffe5c4778dc824b164e5257813d7", size = 142630, upload-time = "2026-03-06T06:01:59.062Z" },
+    { url = "https://files.pythonhosted.org/packages/31/41/1c4b7cc9f13bd9d369ce3bc993e13d374ce25fa38a2663644283ecf422c1/charset_normalizer-3.4.5-cp313-cp313-win_arm64.whl", hash = "sha256:93b3b2cc5cf1b8743660ce77a4f45f3f6d1172068207c1defc779a36eea6bb36", size = 133254, upload-time = "2026-03-06T06:02:00.281Z" },
+    { url = "https://files.pythonhosted.org/packages/43/be/0f0fd9bb4a7fa4fb5067fb7d9ac693d4e928d306f80a0d02bde43a7c4aee/charset_normalizer-3.4.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8197abe5ca1ffb7d91e78360f915eef5addff270f8a71c1fc5be24a56f3e4873", size = 280232, upload-time = "2026-03-06T06:02:01.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/02/983b5445e4bef49cd8c9da73a8e029f0825f39b74a06d201bfaa2e55142a/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2aecdb364b8a1802afdc7f9327d55dad5366bc97d8502d0f5854e50712dbc5f", size = 189688, upload-time = "2026-03-06T06:02:02.857Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/88/152745c5166437687028027dc080e2daed6fe11cfa95a22f4602591c42db/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a66aa5022bf81ab4b1bebfb009db4fd68e0c6d4307a1ce5ef6a26e5878dfc9e4", size = 206833, upload-time = "2026-03-06T06:02:05.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0f/ebc15c8b02af2f19be9678d6eed115feeeccc45ce1f4b098d986c13e8769/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d77f97e515688bd615c1d1f795d540f32542d514242067adcb8ef532504cb9ee", size = 202879, upload-time = "2026-03-06T06:02:06.446Z" },
+    { url = "https://files.pythonhosted.org/packages/38/9c/71336bff6934418dc8d1e8a1644176ac9088068bc571da612767619c97b3/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01a1ed54b953303ca7e310fafe0fe347aab348bd81834a0bcd602eb538f89d66", size = 195764, upload-time = "2026-03-06T06:02:08.763Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/95/ce92fde4f98615661871bc282a856cf9b8a15f686ba0af012984660d480b/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:b2d37d78297b39a9eb9eb92c0f6df98c706467282055419df141389b23f93362", size = 183728, upload-time = "2026-03-06T06:02:10.137Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e7/f5b4588d94e747ce45ae680f0f242bc2d98dbd4eccfab73e6160b6893893/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e71bbb595973622b817c042bd943c3f3667e9c9983ce3d205f973f486fec98a7", size = 192937, upload-time = "2026-03-06T06:02:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/29/9d94ed6b929bf9f48bf6ede6e7474576499f07c4c5e878fb186083622716/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4cd966c2559f501c6fd69294d082c2934c8dd4719deb32c22961a5ac6db0df1d", size = 192040, upload-time = "2026-03-06T06:02:13.489Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d2/1a093a1cf827957f9445f2fe7298bcc16f8fc5e05c1ed2ad1af0b239035e/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d5e52d127045d6ae01a1e821acfad2f3a1866c54d0e837828538fabe8d9d1bd6", size = 184107, upload-time = "2026-03-06T06:02:14.83Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7d/82068ce16bd36135df7b97f6333c5d808b94e01d4599a682e2337ed5fd14/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:30a2b1a48478c3428d047ed9690d57c23038dac838a87ad624c85c0a78ebeb39", size = 208310, upload-time = "2026-03-06T06:02:16.165Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4e/4dfb52307bb6af4a5c9e73e482d171b81d36f522b21ccd28a49656baa680/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d8ed79b8f6372ca4254955005830fd61c1ccdd8c0fac6603e2c145c61dd95db6", size = 192918, upload-time = "2026-03-06T06:02:18.144Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a4/159ff7da662cf7201502ca89980b8f06acf3e887b278956646a8aeb178ab/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:c5af897b45fa606b12464ccbe0014bbf8c09191e0a66aab6aa9d5cf6e77e0c94", size = 204615, upload-time = "2026-03-06T06:02:19.821Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/62/0dd6172203cb6b429ffffc9935001fde42e5250d57f07b0c28c6046deb6b/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1088345bcc93c58d8d8f3d783eca4a6e7a7752bbff26c3eee7e73c597c191c2e", size = 197784, upload-time = "2026-03-06T06:02:21.86Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/5e/1aab5cb737039b9c59e63627dc8bbc0d02562a14f831cc450e5f91d84ce1/charset_normalizer-3.4.5-cp314-cp314-win32.whl", hash = "sha256:ee57b926940ba00bca7ba7041e665cc956e55ef482f851b9b65acb20d867e7a2", size = 133009, upload-time = "2026-03-06T06:02:23.289Z" },
+    { url = "https://files.pythonhosted.org/packages/40/65/e7c6c77d7aaa4c0d7974f2e403e17f0ed2cb0fc135f77d686b916bf1eead/charset_normalizer-3.4.5-cp314-cp314-win_amd64.whl", hash = "sha256:4481e6da1830c8a1cc0b746b47f603b653dadb690bcd851d039ffaefe70533aa", size = 143511, upload-time = "2026-03-06T06:02:26.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/91/52b0841c71f152f563b8e072896c14e3d83b195c188b338d3cc2e582d1d4/charset_normalizer-3.4.5-cp314-cp314-win_arm64.whl", hash = "sha256:97ab7787092eb9b50fb47fa04f24c75b768a606af1bcba1957f07f128a7219e4", size = 133775, upload-time = "2026-03-06T06:02:27.473Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/60/3a621758945513adfd4db86827a5bafcc615f913dbd0b4c2ed64a65731be/charset_normalizer-3.4.5-py3-none-any.whl", hash = "sha256:9db5e3fcdcee89a78c04dffb3fe33c79f77bd741a624946db2591c81b2fc85b0", size = 55455, upload-time = "2026-03-06T06:03:17.827Z" },
 ]
 
 [[package]]
@@ -154,11 +154,11 @@ wheels = [
 
 [[package]]
 name = "markdown"
-version = "3.10.1"
+version = "3.10.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b7/b1/af95bcae8549f1f3fd70faacb29075826a0d689a27f232e8cee315efa053/markdown-3.10.1.tar.gz", hash = "sha256:1c19c10bd5c14ac948c53d0d762a04e2fa35a6d58a6b7b1e6bfcbe6fefc0001a", size = 365402, upload-time = "2026-01-21T18:09:28.206Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/1b/6ef961f543593969d25b2afe57a3564200280528caa9bd1082eecdd7b3bc/markdown-3.10.1-py3-none-any.whl", hash = "sha256:867d788939fe33e4b736426f5b9f651ad0c0ae0ecf89df0ca5d1176c70812fe3", size = 107684, upload-time = "2026-01-21T18:09:27.203Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
 ]
 
 [[package]]
@@ -260,16 +260,16 @@ wheels = [
 
 [[package]]
 name = "mkdocs-autorefs"
-version = "1.4.3"
+version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "markupsafe" },
     { name = "mkdocs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/fa/9124cd63d822e2bcbea1450ae68cdc3faf3655c69b455f3a7ed36ce6c628/mkdocs_autorefs-1.4.3.tar.gz", hash = "sha256:beee715b254455c4aa93b6ef3c67579c399ca092259cc41b7d9342573ff1fc75", size = 55425, upload-time = "2025-08-26T14:23:17.223Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/4d/7123b6fa2278000688ebd338e2a06d16870aaf9eceae6ba047ea05f92df1/mkdocs_autorefs-1.4.3-py3-none-any.whl", hash = "sha256:469d85eb3114801d08e9cc55d102b3ba65917a869b893403b8987b601cf55dc9", size = 25034, upload-time = "2025-08-26T14:23:15.906Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
 ]
 
 [[package]]
@@ -312,7 +312,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.7.1"
+version = "9.7.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -327,9 +327,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/e2/2ffc356cd72f1473d07c7719d82a8f2cbd261666828614ecb95b12169f41/mkdocs_material-9.7.1.tar.gz", hash = "sha256:89601b8f2c3e6c6ee0a918cc3566cb201d40bf37c3cd3c2067e26fadb8cce2b8", size = 4094392, upload-time = "2025-12-18T09:49:00.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/ce/a1cd02ac7448763f0bb56aaf5f23fa2527944ac6df335080c38c2f253165/mkdocs_material-9.7.4.tar.gz", hash = "sha256:711b0ee63aca9a8c7124d4c73e83a25aa996e27e814767c3a3967df1b9e56f32", size = 4097804, upload-time = "2026-03-03T19:57:36.827Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/32/ed071cb721aca8c227718cffcf7bd539620e9799bbf2619e90c757bfd030/mkdocs_material-9.7.1-py3-none-any.whl", hash = "sha256:3f6100937d7d731f87f1e3e3b021c97f7239666b9ba1151ab476cabb96c60d5c", size = 9297166, upload-time = "2025-12-18T09:48:56.664Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/94/e3535a9ed078b238df3df75a44694ca0ff5772fd538df4939c658a58c59d/mkdocs_material-9.7.4-py3-none-any.whl", hash = "sha256:6549ad95e4d130ed5099759dfa76ea34c593eefdb9c18c97273605518e99cfbf", size = 9305224, upload-time = "2026-03-03T19:57:34.063Z" },
 ]
 
 [[package]]
@@ -415,11 +415,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.5.1"
+version = "4.9.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
 ]
 
 [[package]]
@@ -433,15 +433,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.20.1"
+version = "10.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/6c/9e370934bfa30e889d12e61d0dae009991294f40055c238980066a7fbd83/pymdown_extensions-10.20.1.tar.gz", hash = "sha256:e7e39c865727338d434b55f1dd8da51febcffcaebd6e1a0b9c836243f660740a", size = 852860, upload-time = "2026-01-24T05:56:56.758Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/6d/b6ee155462a0156b94312bdd82d2b92ea56e909740045a87ccb98bf52405/pymdown_extensions-10.20.1-py3-none-any.whl", hash = "sha256:24af7feacbca56504b313b7b418c4f5e1317bb5fea60f03d57be7fcc40912aa0", size = 268768, upload-time = "2026-01-24T05:56:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

Defines the first implementation of the mercure bundle; integrates the mercure component into the framework. While not that much actual code, it is the first of its kind, and a precursor to first-class third-party bundle support. E.g. integrating other non-Athena shards into the framework natively.

But also as exciting, Athena also now has a means of dealing with real-time communication that should handle most use cases websockets currently handle. A more proper guide will likely be created at some point.

Closes #114 
Closes #625 

## Changelog

- Integrate Mercure component into the framework optionally via a bundle
- First pass on documentation for new Bundle concepts

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
