### PR TITLE
Fix incorrect macro code coverage line numbers

### DIFF
--- a/.changes/unreleased/spec-Added-20260311-224134.yaml
+++ b/.changes/unreleased/spec-Added-20260311-224134.yaml
@@ -1,0 +1,8 @@
+project: spec
+kind: Added
+body: Add `ASPEC.compile_time_assert` helper function for use with `assert_compiles`
+time: 2026-03-11T22:41:34.862414509-04:00
+custom:
+    Author: George Dietrich
+    PR: "686"
+    Username: blacksmoke16

--- a/.changes/unreleased/spec-Fixed-20260310-184832.yaml
+++ b/.changes/unreleased/spec-Fixed-20260310-184832.yaml
@@ -1,0 +1,8 @@
+project: spec
+kind: Fixed
+body: Fix incorrect macro code coverage line numbers
+time: 2026-03-10T18:48:32.409693383-04:00
+custom:
+    Author: George Dietrich
+    PR: "686"
+    Username: blacksmoke16

--- a/src/components/dependency_injection/spec/compiler_passes/merge_configs_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_configs_spec.cr
@@ -56,10 +56,21 @@ describe ADI::ServiceContainer::MergeConfigs do
           \{%
             config = ADI::CONFIG["test"]
 
-            raise "#{config}" unless config["default_locale"] == "en"
-            raise "#{config}" unless config["cors"]["defaults"]["allow_credentials"] == true
-            raise "#{config}" unless config["cors"]["defaults"]["allow_origin"].size == 1
-            raise "#{config}" unless config["cors"]["defaults"]["allow_origin"][0] == "*"
+            unless config["default_locale"] == "en"
+              raise "#{config}"
+            end
+
+            unless config["cors"]["defaults"]["allow_credentials"] == true
+              raise "#{config}"
+            end
+
+            unless config["cors"]["defaults"]["allow_origin"].size == 1
+              raise "#{config}"
+            end
+
+            unless config["cors"]["defaults"]["allow_origin"][0] == "*"
+              raise "#{config}"
+            end
           %}
         end
       end

--- a/src/components/dependency_injection/spec/compiler_passes/merge_configs_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_configs_spec.cr
@@ -55,23 +55,11 @@ describe ADI::ServiceContainer::MergeConfigs do
         macro finished
           \{%
             config = ADI::CONFIG["test"]
-
-            unless config["default_locale"] == "en"
-              raise "#{config}"
-            end
-
-            unless config["cors"]["defaults"]["allow_credentials"] == true
-              raise "#{config}"
-            end
-
-            unless config["cors"]["defaults"]["allow_origin"].size == 1
-              raise "#{config}"
-            end
-
-            unless config["cors"]["defaults"]["allow_origin"][0] == "*"
-              raise "#{config}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ config["default_locale"] == "en" }}, "Expected default_locale to be en")
+          ASPEC.compile_time_assert(\{{ config["cors"]["defaults"]["allow_credentials"] == true }}, "Expected allow_credentials to be true")
+          ASPEC.compile_time_assert(\{{ config["cors"]["defaults"]["allow_origin"].size == 1 }}, "Expected allow_origin size to be 1")
+          ASPEC.compile_time_assert(\{{ config["cors"]["defaults"]["allow_origin"][0] == "*" }}, "Expected allow_origin[0] to be *")
         end
       end
     CR

--- a/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
@@ -338,47 +338,17 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
         macro finished
           \{%
             config = ADI::CONFIG["blah"]
-
-            unless config["id"] == 123
-              raise "#{config}"
-            end
-
-            unless config["name"] == "fred"
-              raise "#{config}"
-            end
-
-            unless config["float"] == 10.0
-              raise "#{config}"
-            end
-
-            unless config["nilable"].nil?
-              raise "#{config}"
-            end
-
-            unless config["color_type"].stringify == "Color.new(0)"
-              raise "#{config}"
-            end
-
-            unless config["color_sym"].stringify == "Color.new(:blue)"
-              raise "#{config}"
-            end
-
-            unless config["color_default"].stringify == "Color.new(:green)"
-              raise "#{config}"
-            end
-
-            unless config["color_global"].stringify == "::Color.new(:red)"
-              raise "#{config}"
-            end
-
-            unless config["value"] == {"id" => "10", "name" => "fred"}
-              raise "#{config}"
-            end
-
-            unless config["regex"] == /foo/
-              raise "#{config}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ config["id"] == 123 }}, "Expected id to be 123")
+          ASPEC.compile_time_assert(\{{ config["name"] == "fred" }}, "Expected name to be fred")
+          ASPEC.compile_time_assert(\{{ config["float"] == 10.0 }}, "Expected float to be 10.0")
+          ASPEC.compile_time_assert(\{{ config["nilable"].nil? }}, "Expected nilable to be nil")
+          ASPEC.compile_time_assert(\{{ config["color_type"].stringify == "Color.new(0)" }}, "Expected color_type to be Color.new(0)")
+          ASPEC.compile_time_assert(\{{ config["color_sym"].stringify == "Color.new(:blue)" }}, "Expected color_sym to be Color.new(:blue)")
+          ASPEC.compile_time_assert(\{{ config["color_default"].stringify == "Color.new(:green)" }}, "Expected color_default to be Color.new(:green)")
+          ASPEC.compile_time_assert(\{{ config["color_global"].stringify == "::Color.new(:red)" }}, "Expected color_global to be ::Color.new(:red)")
+          ASPEC.compile_time_assert(\{{ config["value"] == {"id" => "10", "name" => "fred"} }}, "Expected value to be the expected hash")
+          ASPEC.compile_time_assert(\{{ config["regex"] == /foo/ }}, "Expected regex to be /foo/")
         end
       end
     CR
@@ -400,11 +370,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
         macro finished
           \{%
             config = ADI::CONFIG["blah"]
-
-            unless config["id"] == 123
-              raise "#{config}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ config["id"] == 123 }}, "Expected id to be 123")
         end
       end
     CR
@@ -432,11 +399,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
         macro finished
           \{%
             config = ADI::CONFIG["test"]
-
-            unless config["foo"] == [1, 2]
-              raise "#{config}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ config["foo"] == [1, 2] }}, "Expected foo to be [1, 2]")
         end
       end
     CR
@@ -458,11 +422,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
         macro finished
           \{%
             config = ADI::CONFIG["test"]
-
-            unless config["foo"].stringify == "Array(Int32 | String).new"
-              raise "#{config}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ config["foo"].stringify == "Array(Int32 | String).new" }}, "Expected foo to stringify as empty array")
         end
       end
     CR
@@ -490,11 +451,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
         macro finished
           \{%
             config = ADI::CONFIG["test"]
-
-            unless config["foo"] == [1, 2]
-              raise "#{config}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ config["foo"] == [1, 2] }}, "Expected foo to be [1, 2]")
         end
       end
     CR
@@ -526,15 +484,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
         macro finished
           \{%
             config = ADI::CONFIG["test"]
-
-            unless config["one"]["enabled"] == false
-              raise "#{config}"
-            end
-
-            unless config["two"]["enabled"] == false
-              raise "#{config}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ config["one"]["enabled"] == false }}, "Expected one.enabled to be false")
+          ASPEC.compile_time_assert(\{{ config["two"]["enabled"] == false }}, "Expected two.enabled to be false")
         end
       end
     CR
@@ -581,23 +533,11 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
         macro finished
           \{%
             config = ADI::CONFIG["test"]
-
-            unless config["one"]["enabled"] == false
-              raise "#{config}"
-            end
-
-            unless config["one"]["id"] == 10
-              raise "#{config}"
-            end
-
-            unless config["two"]["enabled"] == false
-              raise "#{config}"
-            end
-
-            unless config["two"]["three"]["enabled"] == false
-              raise "#{config}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ config["one"]["enabled"] == false }}, "Expected one.enabled to be false")
+          ASPEC.compile_time_assert(\{{ config["one"]["id"] == 10 }}, "Expected one.id to be 10")
+          ASPEC.compile_time_assert(\{{ config["two"]["enabled"] == false }}, "Expected two.enabled to be false")
+          ASPEC.compile_time_assert(\{{ config["two"]["three"]["enabled"] == false }}, "Expected two.three.enabled to be false")
         end
       end
     CR
@@ -626,15 +566,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
         macro finished
           \{%
             config = ADI::CONFIG["test"]
-
-            unless config["rules"][0]["id"] == 10
-              raise "#{config}"
-            end
-
-            unless config["rules"][0]["stop"] == false
-              raise "#{config}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ config["rules"][0]["id"] == 10 }}, "Expected rules[0].id to be 10")
+          ASPEC.compile_time_assert(\{{ config["rules"][0]["stop"] == false }}, "Expected rules[0].stop to be false")
         end
       end
     CR
@@ -676,11 +610,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
         macro finished
           \{%
             parameters = ADI::CONFIG["parameters"]
-
-            unless parameters["stop"] == false
-              raise "#{parameters}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ parameters["stop"] == false }}, "Expected parameters stop to be false")
         end
       end
     CR
@@ -717,31 +648,13 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
         macro finished
           \{%
             config = ADI::CONFIG["test"]
-
-            unless config["items"][0]["name"] == "item1"
-              raise "#{config}"
-            end
-
-            unless config["items"][0]["jwt"]["secret"] == "secret1"
-              raise "#{config}"
-            end
-
-            unless config["items"][0]["jwt"]["algorithm"] == "hmac.sha256"
-              raise "#{config}"
-            end
-
-            unless config["items"][1]["name"] == "item2"
-              raise "#{config}"
-            end
-
-            unless config["items"][1]["jwt"]["secret"] == "secret2"
-              raise "#{config}"
-            end
-
-            unless config["items"][1]["jwt"]["algorithm"] == "hmac.sha256"
-              raise "#{config}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ config["items"][0]["name"] == "item1" }}, "Expected items[0].name to be item1")
+          ASPEC.compile_time_assert(\{{ config["items"][0]["jwt"]["secret"] == "secret1" }}, "Expected items[0].jwt.secret to be secret1")
+          ASPEC.compile_time_assert(\{{ config["items"][0]["jwt"]["algorithm"] == "hmac.sha256" }}, "Expected items[0].jwt.algorithm to be hmac.sha256")
+          ASPEC.compile_time_assert(\{{ config["items"][1]["name"] == "item2" }}, "Expected items[1].name to be item2")
+          ASPEC.compile_time_assert(\{{ config["items"][1]["jwt"]["secret"] == "secret2" }}, "Expected items[1].jwt.secret to be secret2")
+          ASPEC.compile_time_assert(\{{ config["items"][1]["jwt"]["algorithm"] == "hmac.sha256" }}, "Expected items[1].jwt.algorithm to be hmac.sha256")
         end
       end
     CR
@@ -778,19 +691,10 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
         macro finished
           \{%
             config = ADI::CONFIG["test"]
-
-            unless config["connection"]["url"] == "localhost"
-              raise "#{config}"
-            end
-
-            unless config["connection"]["jwt"]["secret"] == "my-secret"
-              raise "#{config}"
-            end
-
-            unless config["connection"]["jwt"]["algorithm"] == "hmac.sha256"
-              raise "#{config}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ config["connection"]["url"] == "localhost" }}, "Expected connection.url to be localhost")
+          ASPEC.compile_time_assert(\{{ config["connection"]["jwt"]["secret"] == "my-secret" }}, "Expected connection.jwt.secret to be my-secret")
+          ASPEC.compile_time_assert(\{{ config["connection"]["jwt"]["algorithm"] == "hmac.sha256" }}, "Expected connection.jwt.algorithm to be hmac.sha256")
         end
       end
     CR
@@ -818,19 +722,10 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
         macro finished
           \{%
             config = ADI::CONFIG["blah"]
-
-            unless config["config"].keys.stringify == %([__nil, id, name])
-              raise "#{config}"
-            end
-
-            unless config["config"]["id"] == 10
-              raise "#{config}"
-            end
-
-            unless config["config"]["name"].nil?
-              raise "#{config}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ config["config"].keys.stringify == %([__nil, id, name]) }}, "Expected config keys to be [__nil, id, name]")
+          ASPEC.compile_time_assert(\{{ config["config"]["id"] == 10 }}, "Expected config.id to be 10")
+          ASPEC.compile_time_assert(\{{ config["config"]["name"].nil? }}, "Expected config.name to be nil")
         end
       end
     CR
@@ -852,19 +747,10 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
         macro finished
           \{%
             config = ADI::CONFIG["blah"]
-
-            unless config["config"].keys.stringify == %([id, name])
-              raise "#{config}"
-            end
-
-            unless config["config"]["id"] == 123
-              raise "#{config}"
-            end
-
-            unless config["config"]["name"].nil?
-              raise "#{config}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ config["config"].keys.stringify == %([id, name]) }}, "Expected config keys to be [id, name]")
+          ASPEC.compile_time_assert(\{{ config["config"]["id"] == 123 }}, "Expected config.id to be 123")
+          ASPEC.compile_time_assert(\{{ config["config"]["name"].nil? }}, "Expected config.name to be nil")
         end
       end
     CR
@@ -895,23 +781,11 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["hubs"]["primary"]["url"] == "localhost"
-                raise "#{config}"
-              end
-
-              unless config["hubs"]["primary"]["port"] == 5432
-                raise "#{config}"
-              end
-
-              unless config["hubs"]["secondary"]["url"] == "remote"
-                raise "#{config}"
-              end
-
-              unless config["hubs"]["secondary"]["port"] == 5433
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["url"] == "localhost" }}, "Expected hubs.primary.url to be localhost")
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["port"] == 5432 }}, "Expected hubs.primary.port to be 5432")
+            ASPEC.compile_time_assert(\{{ config["hubs"]["secondary"]["url"] == "remote" }}, "Expected hubs.secondary.url to be remote")
+            ASPEC.compile_time_assert(\{{ config["hubs"]["secondary"]["port"] == 5433 }}, "Expected hubs.secondary.port to be 5433")
           end
         end
       CR
@@ -939,19 +813,16 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
 
               # Check that hubs key exists and is empty (when converted to string, looks like "{}" or "{hubs => {}}")
               found_hubs = false
+              hubs_empty = false
               config.each do |k, v|
                 if k.stringify == "hubs"
                   found_hubs = true
-                  unless v.keys.reject { |vk| vk.stringify == "__nil" }.empty?
-                    raise "Expected empty hash but got #{v}"
-                  end
+                  hubs_empty = v.keys.reject { |vk| vk.stringify == "__nil" }.empty?
                 end
               end
-
-              unless found_hubs
-                raise "hubs key not found in config: #{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ found_hubs }}, "Expected hubs key to exist in config")
+            ASPEC.compile_time_assert(\{{ hubs_empty }}, "Expected empty hash for hubs")
           end
         end
       CR
@@ -976,11 +847,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["hubs"].nil?
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["hubs"].nil? }}, "Expected hubs to be nil")
           end
         end
       CR
@@ -1019,19 +887,10 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["hubs"]["primary"]["url"] == "localhost"
-                raise "#{config}"
-              end
-
-              unless config["hubs"]["primary"]["jwt"]["secret"] == "my-secret"
-                raise "#{config}"
-              end
-
-              unless config["hubs"]["primary"]["jwt"]["algorithm"] == "hmac.sha256"
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["url"] == "localhost" }}, "Expected hubs.primary.url to be localhost")
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["jwt"]["secret"] == "my-secret" }}, "Expected hubs.primary.jwt.secret to be my-secret")
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["jwt"]["algorithm"] == "hmac.sha256" }}, "Expected hubs.primary.jwt.algorithm to be hmac.sha256")
           end
         end
       CR
@@ -1187,25 +1046,13 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              # Verify both entries get their own independent defaults
-              unless config["hubs"]["primary"]["jwt"]["algorithm"] == "hmac.sha256"
-                raise "#{config}"
-              end
-
-              unless config["hubs"]["secondary"]["jwt"]["algorithm"] == "hmac.sha256"
-                raise "#{config}"
-              end
-
-              # And their unique values are preserved
-              unless config["hubs"]["primary"]["jwt"]["secret"] == "secret1"
-                raise "#{config}"
-              end
-
-              unless config["hubs"]["secondary"]["jwt"]["secret"] == "secret2"
-                raise "#{config}"
-              end
             %}
+            # Verify both entries get their own independent defaults
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["jwt"]["algorithm"] == "hmac.sha256" }}, "Expected hubs.primary.jwt.algorithm to be hmac.sha256")
+            ASPEC.compile_time_assert(\{{ config["hubs"]["secondary"]["jwt"]["algorithm"] == "hmac.sha256" }}, "Expected hubs.secondary.jwt.algorithm to be hmac.sha256")
+            # And their unique values are preserved
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["jwt"]["secret"] == "secret1" }}, "Expected hubs.primary.jwt.secret to be secret1")
+            ASPEC.compile_time_assert(\{{ config["hubs"]["secondary"]["jwt"]["secret"] == "secret2" }}, "Expected hubs.secondary.jwt.secret to be secret2")
           end
         end
       CR
@@ -1286,16 +1133,10 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              # Custom default entry should be present with its values
-              unless config["hubs"]["default"]["url"] == "localhost"
-                raise "#{config}"
-              end
-
-              unless config["hubs"]["default"]["port"] == 8080
-                raise "#{config}"
-              end
             %}
+            # Custom default entry should be present with its values
+            ASPEC.compile_time_assert(\{{ config["hubs"]["default"]["url"] == "localhost" }}, "Expected hubs.default.url to be localhost")
+            ASPEC.compile_time_assert(\{{ config["hubs"]["default"]["port"] == 8080 }}, "Expected hubs.default.port to be 8080")
           end
         end
       CR
@@ -1340,19 +1181,10 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["hubs"]["primary"]["url"] == "localhost"
-                raise "#{config}"
-              end
-
-              unless config["hubs"]["primary"]["jwt"]["secret"] == "my-secret"
-                raise "#{config}"
-              end
-
-              unless config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs256)"
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["url"] == "localhost" }}, "Expected hubs.primary.url to be localhost")
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["jwt"]["secret"] == "my-secret" }}, "Expected hubs.primary.jwt.secret to be my-secret")
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs256)" }}, "Expected hubs.primary.jwt.algorithm to be Algorithm.new(:hs256)")
           end
         end
       CR
@@ -1397,19 +1229,10 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["hubs"]["primary"]["url"] == "localhost"
-                raise "#{config}"
-              end
-
-              unless config["hubs"]["primary"]["jwt"]["secret"] == "my-secret"
-                raise "#{config}"
-              end
-
-              unless config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs512)"
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["url"] == "localhost" }}, "Expected hubs.primary.url to be localhost")
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["jwt"]["secret"] == "my-secret" }}, "Expected hubs.primary.jwt.secret to be my-secret")
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs512)" }}, "Expected hubs.primary.jwt.algorithm to be Algorithm.new(:hs512)")
           end
         end
       CR
@@ -1454,11 +1277,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "::Algorithm.new(:hs256)"
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "::Algorithm.new(:hs256)" }}, "Expected hubs.primary.jwt.algorithm to be ::Algorithm.new(:hs256)")
           end
         end
       CR
@@ -1570,19 +1390,10 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["items"][0]["name"] == "item1"
-                raise "#{config}"
-              end
-
-              unless config["items"][0]["jwt"]["secret"] == "my-secret"
-                raise "#{config}"
-              end
-
-              unless config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs256)"
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["items"][0]["name"] == "item1" }}, "Expected items[0].name to be item1")
+            ASPEC.compile_time_assert(\{{ config["items"][0]["jwt"]["secret"] == "my-secret" }}, "Expected items[0].jwt.secret to be my-secret")
+            ASPEC.compile_time_assert(\{{ config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs256)" }}, "Expected items[0].jwt.algorithm to be Algorithm.new(:hs256)")
           end
         end
       CR
@@ -1624,11 +1435,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs512)"
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs512)" }}, "Expected items[0].jwt.algorithm to be Algorithm.new(:hs512)")
           end
         end
       CR
@@ -1735,19 +1543,10 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["connection"]["url"] == "localhost"
-                raise "#{config}"
-              end
-
-              unless config["connection"]["jwt"]["secret"] == "my-secret"
-                raise "#{config}"
-              end
-
-              unless config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs256)"
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["connection"]["url"] == "localhost" }}, "Expected connection.url to be localhost")
+            ASPEC.compile_time_assert(\{{ config["connection"]["jwt"]["secret"] == "my-secret" }}, "Expected connection.jwt.secret to be my-secret")
+            ASPEC.compile_time_assert(\{{ config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs256)" }}, "Expected connection.jwt.algorithm to be Algorithm.new(:hs256)")
           end
         end
       CR
@@ -1790,11 +1589,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs512)"
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs512)" }}, "Expected connection.jwt.algorithm to be Algorithm.new(:hs512)")
           end
         end
       CR
@@ -1905,11 +1701,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(0)"
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(0)" }}, "Expected hubs.primary.jwt.algorithm to be Algorithm.new(0)")
           end
         end
       CR
@@ -1954,11 +1747,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(2)"
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(2)" }}, "Expected hubs.primary.jwt.algorithm to be Algorithm.new(2)")
           end
         end
       CR
@@ -2000,11 +1790,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(0)"
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(0)" }}, "Expected items[0].jwt.algorithm to be Algorithm.new(0)")
           end
         end
       CR
@@ -2046,11 +1833,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(2)"
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(2)" }}, "Expected items[0].jwt.algorithm to be Algorithm.new(2)")
           end
         end
       CR
@@ -2093,11 +1877,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(0)"
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(0)" }}, "Expected connection.jwt.algorithm to be Algorithm.new(0)")
           end
         end
       CR
@@ -2140,11 +1921,8 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           macro finished
             \{%
               config = ADI::CONFIG["test"]
-
-              unless config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(2)"
-                raise "#{config}"
-              end
             %}
+            ASPEC.compile_time_assert(\{{ config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(2)" }}, "Expected connection.jwt.algorithm to be Algorithm.new(2)")
           end
         end
       CR
@@ -2183,23 +1961,11 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           \{%
             first_config = ADI::CONFIG["first"]
             second_config = ADI::CONFIG["second"]
-
-            unless first_config["root_prop"] == "root"
-              raise "#{first_config}"
-            end
-
-            unless first_config["nested"]["nested_prop"] == 42
-              raise "#{first_config}"
-            end
-
-            unless second_config["other_prop"] == true
-              raise "#{second_config}"
-            end
-
-            if second_config["nested"] != nil
-              raise "second should not have 'nested' key: #{second_config}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ first_config["root_prop"] == "root" }}, "Expected first.root_prop to be root")
+          ASPEC.compile_time_assert(\{{ first_config["nested"]["nested_prop"] == 42 }}, "Expected first.nested.nested_prop to be 42")
+          ASPEC.compile_time_assert(\{{ second_config["other_prop"] == true }}, "Expected second.other_prop to be true")
+          ASPEC.compile_time_assert(\{{ second_config["nested"] == nil }}, "Expected second to not have nested key")
         end
       end
     CR

--- a/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
@@ -339,16 +339,45 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           \{%
             config = ADI::CONFIG["blah"]
 
-            raise "#{config}" unless config["id"] == 123
-            raise "#{config}" unless config["name"] == "fred"
-            raise "#{config}" unless config["float"] == 10.0
-            raise "#{config}" unless config["nilable"].nil?
-            raise "#{config}" unless config["color_type"].stringify == "Color.new(0)"
-            raise "#{config}" unless config["color_sym"].stringify == "Color.new(:blue)"
-            raise "#{config}" unless config["color_default"].stringify == "Color.new(:green)"
-            raise "#{config}" unless config["color_global"].stringify == "::Color.new(:red)"
-            raise "#{config}" unless config["value"] == {"id" => "10", "name" => "fred"}
-            raise "#{config}" unless config["regex"] == /foo/
+            unless config["id"] == 123
+              raise "#{config}"
+            end
+
+            unless config["name"] == "fred"
+              raise "#{config}"
+            end
+
+            unless config["float"] == 10.0
+              raise "#{config}"
+            end
+
+            unless config["nilable"].nil?
+              raise "#{config}"
+            end
+
+            unless config["color_type"].stringify == "Color.new(0)"
+              raise "#{config}"
+            end
+
+            unless config["color_sym"].stringify == "Color.new(:blue)"
+              raise "#{config}"
+            end
+
+            unless config["color_default"].stringify == "Color.new(:green)"
+              raise "#{config}"
+            end
+
+            unless config["color_global"].stringify == "::Color.new(:red)"
+              raise "#{config}"
+            end
+
+            unless config["value"] == {"id" => "10", "name" => "fred"}
+              raise "#{config}"
+            end
+
+            unless config["regex"] == /foo/
+              raise "#{config}"
+            end
           %}
         end
       end
@@ -372,7 +401,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           \{%
             config = ADI::CONFIG["blah"]
 
-            raise "#{config}" unless config["id"] == 123
+            unless config["id"] == 123
+              raise "#{config}"
+            end
           %}
         end
       end
@@ -402,7 +433,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           \{%
             config = ADI::CONFIG["test"]
 
-            raise "#{config}" unless config["foo"] == [1, 2]
+            unless config["foo"] == [1, 2]
+              raise "#{config}"
+            end
           %}
         end
       end
@@ -426,7 +459,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           \{%
             config = ADI::CONFIG["test"]
 
-            raise "#{config}" unless config["foo"].stringify == "Array(Int32 | String).new"
+            unless config["foo"].stringify == "Array(Int32 | String).new"
+              raise "#{config}"
+            end
           %}
         end
       end
@@ -456,7 +491,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           \{%
             config = ADI::CONFIG["test"]
 
-            raise "#{config}" unless config["foo"] == [1, 2]
+            unless config["foo"] == [1, 2]
+              raise "#{config}"
+            end
           %}
         end
       end
@@ -490,8 +527,13 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           \{%
             config = ADI::CONFIG["test"]
 
-            raise "#{config}" unless config["one"]["enabled"] == false
-            raise "#{config}" unless config["two"]["enabled"] == false
+            unless config["one"]["enabled"] == false
+              raise "#{config}"
+            end
+
+            unless config["two"]["enabled"] == false
+              raise "#{config}"
+            end
           %}
         end
       end
@@ -540,11 +582,21 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           \{%
             config = ADI::CONFIG["test"]
 
-            raise "#{config}" unless config["one"]["enabled"] == false
-            raise "#{config}" unless config["one"]["id"] == 10
+            unless config["one"]["enabled"] == false
+              raise "#{config}"
+            end
 
-            raise "#{config}" unless config["two"]["enabled"] == false
-            raise "#{config}" unless config["two"]["three"]["enabled"] == false
+            unless config["one"]["id"] == 10
+              raise "#{config}"
+            end
+
+            unless config["two"]["enabled"] == false
+              raise "#{config}"
+            end
+
+            unless config["two"]["three"]["enabled"] == false
+              raise "#{config}"
+            end
           %}
         end
       end
@@ -575,8 +627,13 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           \{%
             config = ADI::CONFIG["test"]
 
-            raise "#{config}" unless config["rules"][0]["id"] == 10
-            raise "#{config}" unless config["rules"][0]["stop"] == false
+            unless config["rules"][0]["id"] == 10
+              raise "#{config}"
+            end
+
+            unless config["rules"][0]["stop"] == false
+              raise "#{config}"
+            end
           %}
         end
       end
@@ -620,7 +677,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           \{%
             parameters = ADI::CONFIG["parameters"]
 
-            raise "#{parameters}" unless parameters["stop"] == false
+            unless parameters["stop"] == false
+              raise "#{parameters}"
+            end
           %}
         end
       end
@@ -659,13 +718,29 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           \{%
             config = ADI::CONFIG["test"]
 
-            raise "#{config}" unless config["items"][0]["name"] == "item1"
-            raise "#{config}" unless config["items"][0]["jwt"]["secret"] == "secret1"
-            raise "#{config}" unless config["items"][0]["jwt"]["algorithm"] == "hmac.sha256"
+            unless config["items"][0]["name"] == "item1"
+              raise "#{config}"
+            end
 
-            raise "#{config}" unless config["items"][1]["name"] == "item2"
-            raise "#{config}" unless config["items"][1]["jwt"]["secret"] == "secret2"
-            raise "#{config}" unless config["items"][1]["jwt"]["algorithm"] == "hmac.sha256"
+            unless config["items"][0]["jwt"]["secret"] == "secret1"
+              raise "#{config}"
+            end
+
+            unless config["items"][0]["jwt"]["algorithm"] == "hmac.sha256"
+              raise "#{config}"
+            end
+
+            unless config["items"][1]["name"] == "item2"
+              raise "#{config}"
+            end
+
+            unless config["items"][1]["jwt"]["secret"] == "secret2"
+              raise "#{config}"
+            end
+
+            unless config["items"][1]["jwt"]["algorithm"] == "hmac.sha256"
+              raise "#{config}"
+            end
           %}
         end
       end
@@ -704,9 +779,17 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           \{%
             config = ADI::CONFIG["test"]
 
-            raise "#{config}" unless config["connection"]["url"] == "localhost"
-            raise "#{config}" unless config["connection"]["jwt"]["secret"] == "my-secret"
-            raise "#{config}" unless config["connection"]["jwt"]["algorithm"] == "hmac.sha256"
+            unless config["connection"]["url"] == "localhost"
+              raise "#{config}"
+            end
+
+            unless config["connection"]["jwt"]["secret"] == "my-secret"
+              raise "#{config}"
+            end
+
+            unless config["connection"]["jwt"]["algorithm"] == "hmac.sha256"
+              raise "#{config}"
+            end
           %}
         end
       end
@@ -736,9 +819,17 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           \{%
             config = ADI::CONFIG["blah"]
 
-            raise "#{config}" unless config["config"].keys.stringify == %([__nil, id, name])
-            raise "#{config}" unless config["config"]["id"] == 10
-            raise "#{config}" unless config["config"]["name"].nil?
+            unless config["config"].keys.stringify == %([__nil, id, name])
+              raise "#{config}"
+            end
+
+            unless config["config"]["id"] == 10
+              raise "#{config}"
+            end
+
+            unless config["config"]["name"].nil?
+              raise "#{config}"
+            end
           %}
         end
       end
@@ -762,9 +853,17 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
           \{%
             config = ADI::CONFIG["blah"]
 
-            raise "#{config}" unless config["config"].keys.stringify == %([id, name])
-            raise "#{config}" unless config["config"]["id"] == 123
-            raise "#{config}" unless config["config"]["name"].nil?
+            unless config["config"].keys.stringify == %([id, name])
+              raise "#{config}"
+            end
+
+            unless config["config"]["id"] == 123
+              raise "#{config}"
+            end
+
+            unless config["config"]["name"].nil?
+              raise "#{config}"
+            end
           %}
         end
       end
@@ -797,10 +896,21 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["hubs"]["primary"]["url"] == "localhost"
-              raise "#{config}" unless config["hubs"]["primary"]["port"] == 5432
-              raise "#{config}" unless config["hubs"]["secondary"]["url"] == "remote"
-              raise "#{config}" unless config["hubs"]["secondary"]["port"] == 5433
+              unless config["hubs"]["primary"]["url"] == "localhost"
+                raise "#{config}"
+              end
+
+              unless config["hubs"]["primary"]["port"] == 5432
+                raise "#{config}"
+              end
+
+              unless config["hubs"]["secondary"]["url"] == "remote"
+                raise "#{config}"
+              end
+
+              unless config["hubs"]["secondary"]["port"] == 5433
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -832,10 +942,15 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
               config.each do |k, v|
                 if k.stringify == "hubs"
                   found_hubs = true
-                  raise "Expected empty hash but got #{v}" unless v.keys.reject { |vk| vk.stringify == "__nil" }.empty?
+                  unless v.keys.reject { |vk| vk.stringify == "__nil" }.empty?
+                    raise "Expected empty hash but got #{v}"
+                  end
                 end
               end
-              raise "hubs key not found in config: #{config}" unless found_hubs
+
+              unless found_hubs
+                raise "hubs key not found in config: #{config}"
+              end
             %}
           end
         end
@@ -862,7 +977,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["hubs"].nil?
+              unless config["hubs"].nil?
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -903,9 +1020,17 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["hubs"]["primary"]["url"] == "localhost"
-              raise "#{config}" unless config["hubs"]["primary"]["jwt"]["secret"] == "my-secret"
-              raise "#{config}" unless config["hubs"]["primary"]["jwt"]["algorithm"] == "hmac.sha256"
+              unless config["hubs"]["primary"]["url"] == "localhost"
+                raise "#{config}"
+              end
+
+              unless config["hubs"]["primary"]["jwt"]["secret"] == "my-secret"
+                raise "#{config}"
+              end
+
+              unless config["hubs"]["primary"]["jwt"]["algorithm"] == "hmac.sha256"
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1064,12 +1189,22 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
               config = ADI::CONFIG["test"]
 
               # Verify both entries get their own independent defaults
-              raise "#{config}" unless config["hubs"]["primary"]["jwt"]["algorithm"] == "hmac.sha256"
-              raise "#{config}" unless config["hubs"]["secondary"]["jwt"]["algorithm"] == "hmac.sha256"
+              unless config["hubs"]["primary"]["jwt"]["algorithm"] == "hmac.sha256"
+                raise "#{config}"
+              end
+
+              unless config["hubs"]["secondary"]["jwt"]["algorithm"] == "hmac.sha256"
+                raise "#{config}"
+              end
 
               # And their unique values are preserved
-              raise "#{config}" unless config["hubs"]["primary"]["jwt"]["secret"] == "secret1"
-              raise "#{config}" unless config["hubs"]["secondary"]["jwt"]["secret"] == "secret2"
+              unless config["hubs"]["primary"]["jwt"]["secret"] == "secret1"
+                raise "#{config}"
+              end
+
+              unless config["hubs"]["secondary"]["jwt"]["secret"] == "secret2"
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1153,8 +1288,13 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
               config = ADI::CONFIG["test"]
 
               # Custom default entry should be present with its values
-              raise "#{config}" unless config["hubs"]["default"]["url"] == "localhost"
-              raise "#{config}" unless config["hubs"]["default"]["port"] == 8080
+              unless config["hubs"]["default"]["url"] == "localhost"
+                raise "#{config}"
+              end
+
+              unless config["hubs"]["default"]["port"] == 8080
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1201,9 +1341,17 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["hubs"]["primary"]["url"] == "localhost"
-              raise "#{config}" unless config["hubs"]["primary"]["jwt"]["secret"] == "my-secret"
-              raise "#{config}" unless config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs256)"
+              unless config["hubs"]["primary"]["url"] == "localhost"
+                raise "#{config}"
+              end
+
+              unless config["hubs"]["primary"]["jwt"]["secret"] == "my-secret"
+                raise "#{config}"
+              end
+
+              unless config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs256)"
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1250,9 +1398,17 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["hubs"]["primary"]["url"] == "localhost"
-              raise "#{config}" unless config["hubs"]["primary"]["jwt"]["secret"] == "my-secret"
-              raise "#{config}" unless config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs512)"
+              unless config["hubs"]["primary"]["url"] == "localhost"
+                raise "#{config}"
+              end
+
+              unless config["hubs"]["primary"]["jwt"]["secret"] == "my-secret"
+                raise "#{config}"
+              end
+
+              unless config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs512)"
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1299,7 +1455,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "::Algorithm.new(:hs256)"
+              unless config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "::Algorithm.new(:hs256)"
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1413,9 +1571,17 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["items"][0]["name"] == "item1"
-              raise "#{config}" unless config["items"][0]["jwt"]["secret"] == "my-secret"
-              raise "#{config}" unless config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs256)"
+              unless config["items"][0]["name"] == "item1"
+                raise "#{config}"
+              end
+
+              unless config["items"][0]["jwt"]["secret"] == "my-secret"
+                raise "#{config}"
+              end
+
+              unless config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs256)"
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1459,7 +1625,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs512)"
+              unless config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs512)"
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1568,9 +1736,17 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["connection"]["url"] == "localhost"
-              raise "#{config}" unless config["connection"]["jwt"]["secret"] == "my-secret"
-              raise "#{config}" unless config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs256)"
+              unless config["connection"]["url"] == "localhost"
+                raise "#{config}"
+              end
+
+              unless config["connection"]["jwt"]["secret"] == "my-secret"
+                raise "#{config}"
+              end
+
+              unless config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs256)"
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1615,7 +1791,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs512)"
+              unless config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(:hs512)"
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1728,7 +1906,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(0)"
+              unless config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(0)"
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1775,7 +1955,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(2)"
+              unless config["hubs"]["primary"]["jwt"]["algorithm"].stringify == "Algorithm.new(2)"
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1819,7 +2001,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(0)"
+              unless config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(0)"
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1863,7 +2047,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(2)"
+              unless config["items"][0]["jwt"]["algorithm"].stringify == "Algorithm.new(2)"
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1908,7 +2094,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(0)"
+              unless config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(0)"
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1953,7 +2141,9 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             \{%
               config = ADI::CONFIG["test"]
 
-              raise "#{config}" unless config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(2)"
+              unless config["connection"]["jwt"]["algorithm"].stringify == "Algorithm.new(2)"
+                raise "#{config}"
+              end
             %}
           end
         end
@@ -1994,9 +2184,17 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             first_config = ADI::CONFIG["first"]
             second_config = ADI::CONFIG["second"]
 
-            raise "#{first_config}" unless first_config["root_prop"] == "root"
-            raise "#{first_config}" unless first_config["nested"]["nested_prop"] == 42
-            raise "#{second_config}" unless second_config["other_prop"] == true
+            unless first_config["root_prop"] == "root"
+              raise "#{first_config}"
+            end
+
+            unless first_config["nested"]["nested_prop"] == 42
+              raise "#{first_config}"
+            end
+
+            unless second_config["other_prop"] == true
+              raise "#{second_config}"
+            end
             raise "second should not have 'nested' key: #{second_config}" if second_config["nested"] != nil
           %}
         end

--- a/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
@@ -2195,7 +2195,10 @@ describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do
             unless second_config["other_prop"] == true
               raise "#{second_config}"
             end
-            raise "second should not have 'nested' key: #{second_config}" if second_config["nested"] != nil
+
+            if second_config["nested"] != nil
+              raise "second should not have 'nested' key: #{second_config}"
+            end
           %}
         end
       end

--- a/src/components/dependency_injection/spec/compiler_passes/normalize_definitions_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/normalize_definitions_spec.cr
@@ -75,39 +75,15 @@ describe ADI::ServiceContainer::NormalizeDefinitions, tags: "compiled" do
         macro finished
           \{%
             some_service = ADI::ServiceContainer::SERVICE_HASH["some_service"]
-
-            unless some_service["class"] == SomeService
-              raise "#{some_service}"
-            end
-
-            unless some_service["public"] == true
-              raise "#{some_service}"
-            end
-
-            unless some_service["calls"].size == 0
-              raise "#{some_service}"
-            end
-
-            unless some_service["tags"].size == 0
-              raise "#{some_service}"
-            end
-
-            unless some_service["generics"].size == 0
-              raise "#{some_service}"
-            end
-
-            unless some_service["parameters"].size == 0
-              raise "#{some_service}"
-            end
-
-            unless some_service["shared"] == true
-              raise "#{some_service}"
-            end
-
-            unless some_service["referenced_services"].size == 0
-              raise "#{some_service}"
-            end
           %}
+          ASPEC.compile_time_assert(\{{ some_service["class"] == SomeService }}, "Expected class to be SomeService")
+          ASPEC.compile_time_assert(\{{ some_service["public"] == true }}, "Expected public to be true")
+          ASPEC.compile_time_assert(\{{ some_service["calls"].size == 0 }}, "Expected calls to be empty")
+          ASPEC.compile_time_assert(\{{ some_service["tags"].size == 0 }}, "Expected tags to be empty")
+          ASPEC.compile_time_assert(\{{ some_service["generics"].size == 0 }}, "Expected generics to be empty")
+          ASPEC.compile_time_assert(\{{ some_service["parameters"].size == 0 }}, "Expected parameters to be empty")
+          ASPEC.compile_time_assert(\{{ some_service["shared"] == true }}, "Expected shared to be true")
+          ASPEC.compile_time_assert(\{{ some_service["referenced_services"].size == 0 }}, "Expected referenced_services to be empty")
         end
       end
     CR

--- a/src/components/dependency_injection/spec/compiler_passes/normalize_definitions_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/normalize_definitions_spec.cr
@@ -76,14 +76,37 @@ describe ADI::ServiceContainer::NormalizeDefinitions, tags: "compiled" do
           \{%
             some_service = ADI::ServiceContainer::SERVICE_HASH["some_service"]
 
-            raise "#{some_service}" unless some_service["class"] == SomeService
-            raise "#{some_service}" unless some_service["public"] == true
-            raise "#{some_service}" unless some_service["calls"].size == 0
-            raise "#{some_service}" unless some_service["tags"].size == 0
-            raise "#{some_service}" unless some_service["generics"].size == 0
-            raise "#{some_service}" unless some_service["parameters"].size == 0
-            raise "#{some_service}" unless some_service["shared"] == true
-            raise "#{some_service}" unless some_service["referenced_services"].size == 0
+            unless some_service["class"] == SomeService
+              raise "#{some_service}"
+            end
+
+            unless some_service["public"] == true
+              raise "#{some_service}"
+            end
+
+            unless some_service["calls"].size == 0
+              raise "#{some_service}"
+            end
+
+            unless some_service["tags"].size == 0
+              raise "#{some_service}"
+            end
+
+            unless some_service["generics"].size == 0
+              raise "#{some_service}"
+            end
+
+            unless some_service["parameters"].size == 0
+              raise "#{some_service}"
+            end
+
+            unless some_service["shared"] == true
+              raise "#{some_service}"
+            end
+
+            unless some_service["referenced_services"].size == 0
+              raise "#{some_service}"
+            end
           %}
         end
       end

--- a/src/components/dependency_injection/spec/compiler_passes/process_aliases_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/process_aliases_spec.cr
@@ -39,27 +39,11 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
 
       macro finished
         macro finished
-          \{%
-            unless ADI::ServiceContainer::ALIASES.keys == ["bar"]
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES["bar"].size == 1
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES["bar"][0]["id"] == "foo"
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES["bar"][0]["public"] == false
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES["bar"][0]["name"].nil?
-              raise ""
-            end
-          %}
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES.keys == ["bar"] }}, "Expected alias keys to be [bar]")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES["bar"].size == 1 }}, "Expected bar alias size to be 1")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES["bar"][0]["id"] == "foo" }}, "Expected bar alias id to be foo")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES["bar"][0]["public"] == false }}, "Expected bar alias public to be false")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES["bar"][0]["name"].nil? }}, "Expected bar alias name to be nil")
         end
       end
     CR
@@ -75,27 +59,11 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
 
       macro finished
         macro finished
-          \{%
-            unless ADI::ServiceContainer::ALIASES.keys == ["bar"]
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES["bar"].size == 1
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES["bar"][0]["id"] == "foo"
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES["bar"][0]["public"] == false
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES["bar"][0]["name"].nil?
-              raise ""
-            end
-          %}
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES.keys == ["bar"] }}, "Expected alias keys to be [bar]")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES["bar"].size == 1 }}, "Expected bar alias size to be 1")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES["bar"][0]["id"] == "foo" }}, "Expected bar alias id to be foo")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES["bar"][0]["public"] == false }}, "Expected bar alias public to be false")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES["bar"][0]["name"].nil? }}, "Expected bar alias name to be nil")
         end
       end
     CR
@@ -113,27 +81,11 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
 
       macro finished
         macro finished
-          \{%
-            unless ADI::ServiceContainer::ALIASES.keys == [SomeInterface]
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 1
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["id"] == "foo"
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["public"] == true
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].nil?
-              raise ""
-            end
-          %}
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES.keys == [SomeInterface] }}, "Expected alias keys to be [SomeInterface]")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface].size == 1 }}, "Expected SomeInterface alias size to be 1")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface][0]["id"] == "foo" }}, "Expected SomeInterface alias id to be foo")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface][0]["public"] == true }}, "Expected SomeInterface alias public to be true")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].nil? }}, "Expected SomeInterface alias name to be nil")
         end
       end
     CR
@@ -151,27 +103,11 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
 
       macro finished
         macro finished
-          \{%
-            unless ADI::ServiceContainer::ALIASES.keys == [SomeInterface]
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 1
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["id"] == "foo"
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["public"] == false
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].nil?
-              raise ""
-            end
-          %}
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES.keys == [SomeInterface] }}, "Expected alias keys to be [SomeInterface]")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface].size == 1 }}, "Expected SomeInterface alias size to be 1")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface][0]["id"] == "foo" }}, "Expected SomeInterface alias id to be foo")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface][0]["public"] == false }}, "Expected SomeInterface alias public to be false")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].nil? }}, "Expected SomeInterface alias name to be nil")
         end
       end
     CR
@@ -192,19 +128,9 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
 
       macro finished
         macro finished
-          \{%
-            unless ADI::ServiceContainer::ALIASES.keys == [SomeInterface, OtherInterface]
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 1
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES[OtherInterface].size == 1
-              raise ""
-            end
-          %}
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES.keys == [SomeInterface, OtherInterface] }}, "Expected alias keys to be [SomeInterface, OtherInterface]")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface].size == 1 }}, "Expected SomeInterface alias size to be 1")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[OtherInterface].size == 1 }}, "Expected OtherInterface alias size to be 1")
         end
       end
     CR
@@ -222,23 +148,10 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
 
       macro finished
         macro finished
-          \{%
-            unless ADI::ServiceContainer::ALIASES.keys == [SomeInterface]
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 1
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["id"] == "foo"
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].id == "my_param"
-              raise ""
-            end
-          %}
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES.keys == [SomeInterface] }}, "Expected alias keys to be [SomeInterface]")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface].size == 1 }}, "Expected SomeInterface alias size to be 1")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface][0]["id"] == "foo" }}, "Expected SomeInterface alias id to be foo")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].id == "my_param" }}, "Expected SomeInterface alias name to be my_param")
         end
       end
     CR
@@ -262,19 +175,9 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
 
       macro finished
         macro finished
-          \{%
-            unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 2
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].id == "first"
-              raise ""
-            end
-
-            unless ADI::ServiceContainer::ALIASES[SomeInterface][1]["name"].id == "second"
-              raise ""
-            end
-          %}
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface].size == 2 }}, "Expected SomeInterface alias size to be 2")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].id == "first" }}, "Expected SomeInterface alias[0] name to be first")
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface][1]["name"].id == "second" }}, "Expected SomeInterface alias[1] name to be second")
         end
       end
     CR
@@ -298,21 +201,13 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
 
       macro finished
         macro finished
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::ALIASES[SomeInterface].size == 2 }}, "Expected SomeInterface alias size to be 2")
           \{%
-            unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 2
-              raise ""
-            end
-
             named = ADI::ServiceContainer::ALIASES[SomeInterface].find { |a| !a["name"].nil? }
             type_only = ADI::ServiceContainer::ALIASES[SomeInterface].find { |a| a["name"].nil? }
-            unless named["id"] == "specific"
-              raise ""
-            end
-
-            unless type_only["id"] == "default"
-              raise ""
-            end
           %}
+          ASPEC.compile_time_assert(\{{ named["id"] == "specific" }}, "Expected named alias id to be specific")
+          ASPEC.compile_time_assert(\{{ type_only["id"] == "default" }}, "Expected type-only alias id to be default")
         end
       end
     CR

--- a/src/components/dependency_injection/spec/compiler_passes/process_aliases_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/process_aliases_spec.cr
@@ -40,11 +40,25 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
       macro finished
         macro finished
           \{%
-            raise "" unless ADI::ServiceContainer::ALIASES.keys == ["bar"]
-            raise "" unless ADI::ServiceContainer::ALIASES["bar"].size == 1
-            raise "" unless ADI::ServiceContainer::ALIASES["bar"][0]["id"] == "foo"
-            raise "" unless ADI::ServiceContainer::ALIASES["bar"][0]["public"] == false
-            raise "" unless ADI::ServiceContainer::ALIASES["bar"][0]["name"].nil?
+            unless ADI::ServiceContainer::ALIASES.keys == ["bar"]
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES["bar"].size == 1
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES["bar"][0]["id"] == "foo"
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES["bar"][0]["public"] == false
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES["bar"][0]["name"].nil?
+              raise ""
+            end
           %}
         end
       end
@@ -62,11 +76,25 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
       macro finished
         macro finished
           \{%
-            raise "" unless ADI::ServiceContainer::ALIASES.keys == ["bar"]
-            raise "" unless ADI::ServiceContainer::ALIASES["bar"].size == 1
-            raise "" unless ADI::ServiceContainer::ALIASES["bar"][0]["id"] == "foo"
-            raise "" unless ADI::ServiceContainer::ALIASES["bar"][0]["public"] == false
-            raise "" unless ADI::ServiceContainer::ALIASES["bar"][0]["name"].nil?
+            unless ADI::ServiceContainer::ALIASES.keys == ["bar"]
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES["bar"].size == 1
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES["bar"][0]["id"] == "foo"
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES["bar"][0]["public"] == false
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES["bar"][0]["name"].nil?
+              raise ""
+            end
           %}
         end
       end
@@ -86,11 +114,25 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
       macro finished
         macro finished
           \{%
-            raise "" unless ADI::ServiceContainer::ALIASES.keys == [SomeInterface]
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 1
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["id"] == "foo"
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["public"] == true
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].nil?
+            unless ADI::ServiceContainer::ALIASES.keys == [SomeInterface]
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 1
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["id"] == "foo"
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["public"] == true
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].nil?
+              raise ""
+            end
           %}
         end
       end
@@ -110,11 +152,25 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
       macro finished
         macro finished
           \{%
-            raise "" unless ADI::ServiceContainer::ALIASES.keys == [SomeInterface]
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 1
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["id"] == "foo"
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["public"] == false
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].nil?
+            unless ADI::ServiceContainer::ALIASES.keys == [SomeInterface]
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 1
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["id"] == "foo"
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["public"] == false
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].nil?
+              raise ""
+            end
           %}
         end
       end
@@ -137,9 +193,17 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
       macro finished
         macro finished
           \{%
-            raise "" unless ADI::ServiceContainer::ALIASES.keys == [SomeInterface, OtherInterface]
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 1
-            raise "" unless ADI::ServiceContainer::ALIASES[OtherInterface].size == 1
+            unless ADI::ServiceContainer::ALIASES.keys == [SomeInterface, OtherInterface]
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 1
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES[OtherInterface].size == 1
+              raise ""
+            end
           %}
         end
       end
@@ -159,10 +223,21 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
       macro finished
         macro finished
           \{%
-            raise "" unless ADI::ServiceContainer::ALIASES.keys == [SomeInterface]
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 1
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["id"] == "foo"
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].id == "my_param"
+            unless ADI::ServiceContainer::ALIASES.keys == [SomeInterface]
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 1
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["id"] == "foo"
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].id == "my_param"
+              raise ""
+            end
           %}
         end
       end
@@ -188,9 +263,17 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
       macro finished
         macro finished
           \{%
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 2
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].id == "first"
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface][1]["name"].id == "second"
+            unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 2
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES[SomeInterface][0]["name"].id == "first"
+              raise ""
+            end
+
+            unless ADI::ServiceContainer::ALIASES[SomeInterface][1]["name"].id == "second"
+              raise ""
+            end
           %}
         end
       end
@@ -216,11 +299,19 @@ describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do
       macro finished
         macro finished
           \{%
-            raise "" unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 2
+            unless ADI::ServiceContainer::ALIASES[SomeInterface].size == 2
+              raise ""
+            end
+
             named = ADI::ServiceContainer::ALIASES[SomeInterface].find { |a| !a["name"].nil? }
             type_only = ADI::ServiceContainer::ALIASES[SomeInterface].find { |a| a["name"].nil? }
-            raise "" unless named["id"] == "specific"
-            raise "" unless type_only["id"] == "default"
+            unless named["id"] == "specific"
+              raise ""
+            end
+
+            unless type_only["id"] == "default"
+              raise ""
+            end
           %}
         end
       end

--- a/src/components/dependency_injection/spec/compiler_passes/process_aliases_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/process_aliases_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
 private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compiles <<-CR, line: line
+  ASPEC::Methods.assert_compiles <<-CR, line: line - 1 # Account for spec_helper require
     require "../spec_helper.cr"
     #{code}
     ADI::ServiceContainer.new
@@ -9,7 +9,7 @@ private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
 end
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
+  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line - 1 # Account for spec_helper require
     require "../spec_helper.cr"
     #{code}
     ADI::ServiceContainer.new

--- a/src/components/dependency_injection/spec/compiler_passes/process_parameters_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/process_parameters_spec.cr
@@ -16,43 +16,17 @@ describe ADI::ServiceContainer::ProcessParameters, tags: "compiled" do
         macro finished
           \{%
             parameters = ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]
-            unless parameters.size == 1
-              raise "#{parameters}"
-            end
-
             id = parameters["id"]
-            unless id["declaration"].stringify == "id : Int32"
-              raise "#{id}"
-            end
-
-            unless id["name"] == "id"
-              raise "#{id}"
-            end
-
-            unless id["internal_name"] == "id"
-              raise "#{id}"
-            end
-
-            unless id["idx"] == 0
-              raise "#{id}"
-            end
-
-            unless id["restriction"].stringify == "Int32"
-              raise "#{id}"
-            end
-
-            unless id["resolved_restriction"].stringify == "Int32"
-              raise "#{id}"
-            end
-
-            unless id["default_value"].nil?
-              raise "#{id}"
-            end
-
-            unless id["value"] == 123
-              raise "#{id}"
-            end
-            %}
+          %}
+          ASPEC.compile_time_assert(\{{ parameters.size == 1 }}, "Expected parameters size to be 1")
+          ASPEC.compile_time_assert(\{{ id["declaration"].stringify == "id : Int32" }}, "Expected declaration to be id : Int32")
+          ASPEC.compile_time_assert(\{{ id["name"] == "id" }}, "Expected name to be id")
+          ASPEC.compile_time_assert(\{{ id["internal_name"] == "id" }}, "Expected internal_name to be id")
+          ASPEC.compile_time_assert(\{{ id["idx"] == 0 }}, "Expected idx to be 0")
+          ASPEC.compile_time_assert(\{{ id["restriction"].stringify == "Int32" }}, "Expected restriction to be Int32")
+          ASPEC.compile_time_assert(\{{ id["resolved_restriction"].stringify == "Int32" }}, "Expected resolved_restriction to be Int32")
+          ASPEC.compile_time_assert(\{{ id["default_value"].nil? }}, "Expected default_value to be nil")
+          ASPEC.compile_time_assert(\{{ id["value"] == 123 }}, "Expected value to be 123")
         end
       end
     CR
@@ -89,11 +63,7 @@ describe ADI::ServiceContainer::ProcessParameters, tags: "compiled" do
 
       macro finished
         macro finished
-          \{%
-            unless ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["value"] == 999
-              raise ""
-            end
-          %}
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["value"] == 999 }}, "Expected value to be 999")
         end
       end
     CR
@@ -130,11 +100,7 @@ describe ADI::ServiceContainer::ProcessParameters, tags: "compiled" do
 
       macro finished
         macro finished
-          \{%
-            unless ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["value"] == 999
-              raise ""
-            end
-          %}
+          ASPEC.compile_time_assert(\{{ ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["value"] == 999 }}, "Expected value to be 999")
         end
       end
     CR

--- a/src/components/dependency_injection/spec/compiler_passes/process_parameters_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/process_parameters_spec.cr
@@ -16,17 +16,42 @@ describe ADI::ServiceContainer::ProcessParameters, tags: "compiled" do
         macro finished
           \{%
             parameters = ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]
-            raise "#{parameters}" unless parameters.size == 1
+            unless parameters.size == 1
+              raise "#{parameters}"
+            end
 
             id = parameters["id"]
-            raise "#{id}" unless id["declaration"].stringify == "id : Int32"
-            raise "#{id}" unless id["name"] == "id"
-            raise "#{id}" unless id["internal_name"] == "id"
-            raise "#{id}" unless id["idx"] == 0
-            raise "#{id}" unless id["restriction"].stringify == "Int32"
-            raise "#{id}" unless id["resolved_restriction"].stringify == "Int32"
-            raise "#{id}" unless id["default_value"].nil?
-            raise "#{id}" unless id["value"] == 123
+            unless id["declaration"].stringify == "id : Int32"
+              raise "#{id}"
+            end
+
+            unless id["name"] == "id"
+              raise "#{id}"
+            end
+
+            unless id["internal_name"] == "id"
+              raise "#{id}"
+            end
+
+            unless id["idx"] == 0
+              raise "#{id}"
+            end
+
+            unless id["restriction"].stringify == "Int32"
+              raise "#{id}"
+            end
+
+            unless id["resolved_restriction"].stringify == "Int32"
+              raise "#{id}"
+            end
+
+            unless id["default_value"].nil?
+              raise "#{id}"
+            end
+
+            unless id["value"] == 123
+              raise "#{id}"
+            end
             %}
         end
       end
@@ -64,7 +89,11 @@ describe ADI::ServiceContainer::ProcessParameters, tags: "compiled" do
 
       macro finished
         macro finished
-          \{% raise "" unless ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["value"] == 999 %}
+          \{%
+            unless ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["value"] == 999
+              raise ""
+            end
+          %}
         end
       end
     CR
@@ -101,7 +130,11 @@ describe ADI::ServiceContainer::ProcessParameters, tags: "compiled" do
 
       macro finished
         macro finished
-          \{% raise "" unless ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["value"] == 999 %}
+          \{%
+            unless ADI::ServiceContainer::SERVICE_HASH["some_service"]["parameters"]["id"]["value"] == 999
+              raise ""
+            end
+          %}
         end
       end
     CR

--- a/src/components/dependency_injection/spec/compiler_passes/register_services_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/register_services_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
+  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line - 1 # Account for spec_helper require
     require "../spec_helper.cr"
     #{code}
     ADI::ServiceContainer.new

--- a/src/components/dependency_injection/spec/compiler_passes/validate_arguments_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/validate_arguments_spec.cr
@@ -209,7 +209,11 @@ describe ADI::ServiceContainer::ValidateArguments, tags: "compiled" do
 
       macro finished
         macro finished
-          \{% raise "" unless ADI::CONFIG["test"]["connection"]["port"].nil? %}
+          \{%
+            unless ADI::CONFIG["test"]["connection"]["port"].nil?
+              raise ""
+            end
+          %}
         end
       end
     CR

--- a/src/components/dependency_injection/spec/compiler_passes/validate_arguments_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/validate_arguments_spec.cr
@@ -209,11 +209,7 @@ describe ADI::ServiceContainer::ValidateArguments, tags: "compiled" do
 
       macro finished
         macro finished
-          \{%
-            unless ADI::CONFIG["test"]["connection"]["port"].nil?
-              raise ""
-            end
-          %}
+          ASPEC.compile_time_assert(\{{ ADI::CONFIG["test"]["connection"]["port"].nil? }}, "Expected port to be nil")
         end
       end
     CR

--- a/src/components/dependency_injection/spec/extension_spec.cr
+++ b/src/components/dependency_injection/spec/extension_spec.cr
@@ -36,17 +36,37 @@ describe ADI::Extension, tags: "compiled" do
           \{%
              options = Schema::OPTIONS
 
-             raise "#{options}" unless options.size == 2
+             unless options.size == 2
+               raise "#{options}"
+             end
 
-             raise "#{options}" unless options[0]["name"] == "id"
-             raise "#{options}" unless options[0]["type"] == Int32
-             raise "#{options}" unless options[0]["default"].nil?
+             unless options[0]["name"] == "id"
+               raise "#{options}"
+             end
 
-             raise "#{options}" unless options[1]["name"] == "name"
-             raise "#{options}" unless options[1]["type"] == String
-             raise "#{options}" unless options[1]["default"] == "Fred"
+             unless options[0]["type"] == Int32
+               raise "#{options}"
+             end
 
-             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"id","type":"`Int32`","default":"``"}, {"name":"name","type":"`String`","default":"`Fred`"}] of Nil)
+             unless options[0]["default"].nil?
+               raise "#{options}"
+             end
+
+             unless options[1]["name"] == "name"
+               raise "#{options}"
+             end
+
+             unless options[1]["type"] == String
+               raise "#{options}"
+             end
+
+             unless options[1]["default"] == "Fred"
+               raise "#{options}"
+             end
+
+             unless Schema::CONFIG_DOCS.stringify == %([{"name":"id","type":"`Int32`","default":"``"}, {"name":"name","type":"`String`","default":"`Fred`"}] of Nil)
+               raise "#{Schema::CONFIG_DOCS}"
+             end
           %}
         end
       end
@@ -67,13 +87,25 @@ describe ADI::Extension, tags: "compiled" do
           \{%
              options = Schema::OPTIONS
 
-             raise "#{options}" unless options.size == 1
+             unless options.size == 1
+               raise "#{options}"
+             end
 
-             raise "#{options}" unless options[0]["name"] == "values"
-             raise "#{options}" unless options[0]["type"] == Array(Int32 | String)
-             raise "#{options}" unless options[0]["default"].stringify == "Array(Int32 | String).new"
+             unless options[0]["name"] == "values"
+               raise "#{options}"
+             end
 
-             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"values","type":"`Array(Int32 | String)`","default":"`Array(Int32 | String).new`"}] of Nil)
+             unless options[0]["type"] == Array(Int32 | String)
+               raise "#{options}"
+             end
+
+             unless options[0]["default"].stringify == "Array(Int32 | String).new"
+               raise "#{options}"
+             end
+
+             unless Schema::CONFIG_DOCS.stringify == %([{"name":"values","type":"`Array(Int32 | String)`","default":"`Array(Int32 | String).new`"}] of Nil)
+               raise "#{Schema::CONFIG_DOCS}"
+             end
           %}
         end
       end
@@ -107,9 +139,17 @@ describe ADI::Extension, tags: "compiled" do
             \{%
                config = ADI::CONFIG["test"]
 
-               raise "#{config}" unless config["connection"]["username"] == "addminn"
-               raise "#{config}" unless config["connection"]["password"] == "abc123"
-               raise "#{config}" unless config["connection"]["port"] == 1234
+               unless config["connection"]["username"] == "addminn"
+                 raise "#{config}"
+               end
+
+               unless config["connection"]["password"] == "abc123"
+                 raise "#{config}"
+               end
+
+               unless config["connection"]["port"] == 1234
+                 raise "#{config}"
+               end
             %}
           end
         end
@@ -181,21 +221,46 @@ describe ADI::Extension, tags: "compiled" do
             \{%
              options = Schema::OPTIONS
 
-             raise "#{options}" unless options.size == 1
+             unless options.size == 1
+               raise "#{options}"
+             end
 
-             raise "#{options}" unless options[0]["name"] == "rule"
-             raise "#{options}" unless options[0]["type"].stringify == "NamedTuple(T)"
-             raise "#{options}" unless options[0]["default"].nil?
+             unless options[0]["name"] == "rule"
+               raise "#{options}"
+             end
+
+             unless options[0]["type"].stringify == "NamedTuple(T)"
+               raise "#{options}"
+             end
+
+             unless options[0]["default"].nil?
+               raise "#{options}"
+             end
 
              members = options[0]["members"]
-             raise "#{members}" unless members.size == 3 # Account for __nil
+             unless members.size == 3 # Account for __nil
+               raise "#{members}"
+             end
 
-             raise "#{members}" unless members["id"].type.stringify == "Int32"
-             raise "#{members}" unless members["id"].value.nil?
-             raise "#{members}" unless members["stop"].type.stringify == "Bool"
-             raise "#{members}" unless members["stop"].value == false
+             unless members["id"].type.stringify == "Int32"
+               raise "#{members}"
+             end
 
-             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`NamedTuple(T)`","default":"``","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+             unless members["id"].value.nil?
+               raise "#{members}"
+             end
+
+             unless members["stop"].type.stringify == "Bool"
+               raise "#{members}"
+             end
+
+             unless members["stop"].value == false
+               raise "#{members}"
+             end
+
+             unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`NamedTuple(T)`","default":"``","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+               raise "#{Schema::CONFIG_DOCS}"
+             end
             %}
           end
         end
@@ -216,21 +281,46 @@ describe ADI::Extension, tags: "compiled" do
             \{%
              options = Schema::OPTIONS
 
-             raise "#{options}" unless options.size == 1
+             unless options.size == 1
+               raise "#{options}"
+             end
 
-             raise "#{options}" unless options[0]["name"] == "rule"
-             raise "#{options}" unless options[0]["type"].stringify == "NamedTuple(T)"
-             raise "#{options}" unless options[0]["default"] == {id: 999, stop: false}
+             unless options[0]["name"] == "rule"
+               raise "#{options}"
+             end
+
+             unless options[0]["type"].stringify == "NamedTuple(T)"
+               raise "#{options}"
+             end
+
+             unless options[0]["default"] == {id: 999, stop: false}
+               raise "#{options}"
+             end
 
              members = options[0]["members"]
-             raise "#{members}" unless members.size == 3 # Account for __nil
+             unless members.size == 3 # Account for __nil
+               raise "#{members}"
+             end
 
-             raise "#{members}" unless members["id"].type.stringify == "Int32"
-             raise "#{members}" unless members["id"].value.nil?
-             raise "#{members}" unless members["stop"].type.stringify == "Bool"
-             raise "#{members}" unless members["stop"].value == false
+             unless members["id"].type.stringify == "Int32"
+               raise "#{members}"
+             end
 
-             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`NamedTuple(T)`","default":"`{id: 999}`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+             unless members["id"].value.nil?
+               raise "#{members}"
+             end
+
+             unless members["stop"].type.stringify == "Bool"
+               raise "#{members}"
+             end
+
+             unless members["stop"].value == false
+               raise "#{members}"
+             end
+
+             unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`NamedTuple(T)`","default":"`{id: 999}`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+               raise "#{Schema::CONFIG_DOCS}"
+             end
             %}
           end
         end
@@ -251,21 +341,46 @@ describe ADI::Extension, tags: "compiled" do
             \{%
              options = Schema::OPTIONS
 
-             raise "#{options}" unless options.size == 1
+             unless options.size == 1
+               raise "#{options}"
+             end
 
-             raise "#{options}" unless options[0]["name"] == "rule"
-             raise "#{options}" unless options[0]["type"].stringify == "(NamedTuple(T) | Nil)"
-             raise "#{options}" unless options[0]["default"].nil?
+             unless options[0]["name"] == "rule"
+               raise "#{options}"
+             end
+
+             unless options[0]["type"].stringify == "(NamedTuple(T) | Nil)"
+               raise "#{options}"
+             end
+
+             unless options[0]["default"].nil?
+               raise "#{options}"
+             end
 
              members = options[0]["members"]
-             raise "#{members}" unless members.size == 3 # Account for __nil
+             unless members.size == 3 # Account for __nil
+               raise "#{members}"
+             end
 
-             raise "#{members}" unless members["id"].type.stringify == "Int32"
-             raise "#{members}" unless members["id"].value.nil?
-             raise "#{members}" unless members["stop"].type.stringify == "Bool"
-             raise "#{members}" unless members["stop"].value == false
+             unless members["id"].type.stringify == "Int32"
+               raise "#{members}"
+             end
 
-             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`(NamedTuple(T) | Nil)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+             unless members["id"].value.nil?
+               raise "#{members}"
+             end
+
+             unless members["stop"].type.stringify == "Bool"
+               raise "#{members}"
+             end
+
+             unless members["stop"].value == false
+               raise "#{members}"
+             end
+
+             unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`(NamedTuple(T) | Nil)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+               raise "#{Schema::CONFIG_DOCS}"
+             end
             %}
           end
         end
@@ -286,21 +401,46 @@ describe ADI::Extension, tags: "compiled" do
             \{%
              options = Schema::OPTIONS
 
-             raise "#{options}" unless options.size == 1
+             unless options.size == 1
+               raise "#{options}"
+             end
 
-             raise "#{options}" unless options[0]["name"] == "rule"
-             raise "#{options}" unless options[0]["type"].stringify == "(NamedTuple(T) | Nil)"
-             raise "#{options}" unless options[0]["default"].nil?
+             unless options[0]["name"] == "rule"
+               raise "#{options}"
+             end
+
+             unless options[0]["type"].stringify == "(NamedTuple(T) | Nil)"
+               raise "#{options}"
+             end
+
+             unless options[0]["default"].nil?
+               raise "#{options}"
+             end
 
              members = options[0]["members"]
-             raise "#{members}" unless members.size == 3 # Account for __nil
+             unless members.size == 3 # Account for __nil
+               raise "#{members}"
+             end
 
-             raise "#{members}" unless members["id"].type.stringify == "Int32"
-             raise "#{members}" unless members["id"].value.nil?
-             raise "#{members}" unless members["stop"].type.stringify == "Bool"
-             raise "#{members}" unless members["stop"].value == false
+             unless members["id"].type.stringify == "Int32"
+               raise "#{members}"
+             end
 
-             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`(NamedTuple(T) | Nil)`","default":"`{id: 999}`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+             unless members["id"].value.nil?
+               raise "#{members}"
+             end
+
+             unless members["stop"].type.stringify == "Bool"
+               raise "#{members}"
+             end
+
+             unless members["stop"].value == false
+               raise "#{members}"
+             end
+
+             unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`(NamedTuple(T) | Nil)`","default":"`{id: 999}`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+               raise "#{Schema::CONFIG_DOCS}"
+             end
             %}
           end
         end
@@ -323,19 +463,42 @@ describe ADI::Extension, tags: "compiled" do
             \{%
              options = Schema::OPTIONS
 
-             raise "#{options}" unless options.size == 1
+             unless options.size == 1
+               raise "#{options}"
+             end
 
-             raise "#{options}" unless options[0]["name"] == "rules"
-             raise "#{options}" unless options[0]["type"].stringify == "Array(T)"
-             raise "#{options}" unless options[0]["default"].stringify == "[]"
+             unless options[0]["name"] == "rules"
+               raise "#{options}"
+             end
+
+             unless options[0]["type"].stringify == "Array(T)"
+               raise "#{options}"
+             end
+
+             unless options[0]["default"].stringify == "[]"
+               raise "#{options}"
+             end
 
              members = options[0]["members"]
-             raise "#{members}" unless members.size == 3 # Account for __nil
+             unless members.size == 3 # Account for __nil
+               raise "#{members}"
+             end
 
-             raise "#{members}" unless members["id"].type.stringify == "Int32"
-             raise "#{members}" unless members["id"].value.nil?
-             raise "#{members}" unless members["stop"].type.stringify == "Bool"
-             raise "#{members}" unless members["stop"].value == false
+             unless members["id"].type.stringify == "Int32"
+               raise "#{members}"
+             end
+
+             unless members["id"].value.nil?
+               raise "#{members}"
+             end
+
+             unless members["stop"].type.stringify == "Bool"
+               raise "#{members}"
+             end
+
+             unless members["stop"].value == false
+               raise "#{members}"
+             end
             %}
           end
         end
@@ -356,21 +519,46 @@ describe ADI::Extension, tags: "compiled" do
             \{%
              options = Schema::OPTIONS
 
-             raise "#{options}" unless options.size == 1
+             unless options.size == 1
+               raise "#{options}"
+             end
 
-             raise "#{options}" unless options[0]["name"] == "rules"
-             raise "#{options}" unless options[0]["type"].stringify == "Array(T)"
-             raise "#{options}" unless options[0]["default"] == [{id: 10, stop: false}]
+             unless options[0]["name"] == "rules"
+               raise "#{options}"
+             end
+
+             unless options[0]["type"].stringify == "Array(T)"
+               raise "#{options}"
+             end
+
+             unless options[0]["default"] == [{id: 10, stop: false}]
+               raise "#{options}"
+             end
 
              members = options[0]["members"]
-             raise "#{members}" unless members.size == 3 # Account for __nil
+             unless members.size == 3 # Account for __nil
+               raise "#{members}"
+             end
 
-             raise "#{members}" unless members["id"].type.stringify == "Int32"
-             raise "#{members}" unless members["id"].value.nil?
-             raise "#{members}" unless members["stop"].type.stringify == "Bool"
-             raise "#{members}" unless members["stop"].value == false
+             unless members["id"].type.stringify == "Int32"
+               raise "#{members}"
+             end
 
-             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"rules","type":"`Array(T)`","default":"`[{id: 10}]`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+             unless members["id"].value.nil?
+               raise "#{members}"
+             end
+
+             unless members["stop"].type.stringify == "Bool"
+               raise "#{members}"
+             end
+
+             unless members["stop"].value == false
+               raise "#{members}"
+             end
+
+             unless Schema::CONFIG_DOCS.stringify == %([{"name":"rules","type":"`Array(T)`","default":"`[{id: 10}]`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+               raise "#{Schema::CONFIG_DOCS}"
+             end
             %}
           end
         end
@@ -391,21 +579,46 @@ describe ADI::Extension, tags: "compiled" do
             \{%
              options = Schema::OPTIONS
 
-             raise "#{options}" unless options.size == 1
+             unless options.size == 1
+               raise "#{options}"
+             end
 
-             raise "#{options}" unless options[0]["name"] == "rules"
-             raise "#{options}" unless options[0]["type"].stringify == "(Array(T) | Nil)"
-             raise "#{options}" unless options[0]["default"].nil?
+             unless options[0]["name"] == "rules"
+               raise "#{options}"
+             end
+
+             unless options[0]["type"].stringify == "(Array(T) | Nil)"
+               raise "#{options}"
+             end
+
+             unless options[0]["default"].nil?
+               raise "#{options}"
+             end
 
              members = options[0]["members"]
-             raise "#{members}" unless members.size == 3 # Account for __nil
+             unless members.size == 3 # Account for __nil
+               raise "#{members}"
+             end
 
-             raise "#{members}" unless members["id"].type.stringify == "Int32"
-             raise "#{members}" unless members["id"].value.nil?
-             raise "#{members}" unless members["stop"].type.stringify == "Bool"
-             raise "#{members}" unless members["stop"].value == false
+             unless members["id"].type.stringify == "Int32"
+               raise "#{members}"
+             end
 
-             raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"rules","type":"`(Array(T) | Nil)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+             unless members["id"].value.nil?
+               raise "#{members}"
+             end
+
+             unless members["stop"].type.stringify == "Bool"
+               raise "#{members}"
+             end
+
+             unless members["stop"].value == false
+               raise "#{members}"
+             end
+
+             unless Schema::CONFIG_DOCS.stringify == %([{"name":"rules","type":"`(Array(T) | Nil)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
+               raise "#{Schema::CONFIG_DOCS}"
+             end
             %}
           end
         end
@@ -431,16 +644,34 @@ describe ADI::Extension, tags: "compiled" do
             \{%
                schemas = Schema::OBJECT_SCHEMAS
 
-               raise "#{schemas}" unless schemas.size == 1
-               raise "#{schemas}" unless schemas["JwtConfig"] != nil
+               unless schemas.size == 1
+                 raise "#{schemas}"
+               end
+
+               unless schemas["JwtConfig"] != nil
+                 raise "#{schemas}"
+               end
 
                jwt_schema = schemas["JwtConfig"]
-               raise "#{jwt_schema}" unless jwt_schema["members"].size == 3 # Account for __nil
+               unless jwt_schema["members"].size == 3 # Account for __nil
+                 raise "#{jwt_schema}"
+               end
 
-               raise "#{jwt_schema}" unless jwt_schema["members"]["secret"].type.stringify == "String"
-               raise "#{jwt_schema}" unless jwt_schema["members"]["secret"].value.nil?
-               raise "#{jwt_schema}" unless jwt_schema["members"]["algorithm"].type.stringify == "String"
-               raise "#{jwt_schema}" unless jwt_schema["members"]["algorithm"].value == "hmac.sha256"
+               unless jwt_schema["members"]["secret"].type.stringify == "String"
+                 raise "#{jwt_schema}"
+               end
+
+               unless jwt_schema["members"]["secret"].value.nil?
+                 raise "#{jwt_schema}"
+               end
+
+               unless jwt_schema["members"]["algorithm"].type.stringify == "String"
+                 raise "#{jwt_schema}"
+               end
+
+               unless jwt_schema["members"]["algorithm"].value == "hmac.sha256"
+                 raise "#{jwt_schema}"
+               end
             %}
           end
         end
@@ -470,11 +701,18 @@ describe ADI::Extension, tags: "compiled" do
 
                # The inner member should have nested members from InnerConfig
                inner_member = outer_schema["members"]["inner"]
-               raise "#{inner_member}" unless inner_member["members"] != nil
-               raise "#{inner_member}" unless inner_member["members"]["value"].type.stringify == "String"
+               unless inner_member["members"] != nil
+                 raise "#{inner_member}"
+               end
+
+               unless inner_member["members"]["value"].type.stringify == "String"
+                 raise "#{inner_member}"
+               end
 
                # OuterConfig's members_string should include InnerConfig's nested members
-               raise "#{outer_schema["members_string"]}" unless outer_schema["members_string"] == %([{"name":"name","type":"`String`","default":"``","doc":""},{"name":"inner","type":"`InnerConfig`","default":"``","doc":"","members":[{"name":"value","type":"`String`","default":"``","doc":""}]}])
+               unless outer_schema["members_string"] == %([{"name":"name","type":"`String`","default":"``","doc":""},{"name":"inner","type":"`InnerConfig`","default":"``","doc":"","members":[{"name":"value","type":"`String`","default":"``","doc":""}]}])
+                 raise "#{outer_schema["members_string"]}"
+               end
             %}
           end
         end
@@ -497,21 +735,46 @@ describe ADI::Extension, tags: "compiled" do
             \{%
                options = Schema::OPTIONS
 
-               raise "#{options}" unless options.size == 1
+               unless options.size == 1
+                 raise "#{options}"
+               end
 
-               raise "#{options}" unless options[0]["name"] == "hubs"
-               raise "#{options}" unless options[0]["type"].stringify == "Hash(K, V)"
-               raise "#{options}" unless options[0]["default"].stringify == "{__nil: nil}"
+               unless options[0]["name"] == "hubs"
+                 raise "#{options}"
+               end
+
+               unless options[0]["type"].stringify == "Hash(K, V)"
+                 raise "#{options}"
+               end
+
+               unless options[0]["default"].stringify == "{__nil: nil}"
+                 raise "#{options}"
+               end
 
                members = options[0]["members"]
-               raise "#{members}" unless members.size == 3 # Account for __nil
+               unless members.size == 3 # Account for __nil
+                 raise "#{members}"
+               end
 
-               raise "#{members}" unless members["url"].type.stringify == "String"
-               raise "#{members}" unless members["url"].value.nil?
-               raise "#{members}" unless members["port"].type.stringify == "Int32"
-               raise "#{members}" unless members["port"].value == 5432
+               unless members["url"].type.stringify == "String"
+                 raise "#{members}"
+               end
 
-               raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"hubs","type":"`Hash(K, V)`","default":"`{__nil: nil}`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"port","type":"`Int32`","default":"`5432`","doc":""}]}] of Nil)
+               unless members["url"].value.nil?
+                 raise "#{members}"
+               end
+
+               unless members["port"].type.stringify == "Int32"
+                 raise "#{members}"
+               end
+
+               unless members["port"].value == 5432
+                 raise "#{members}"
+               end
+
+               unless Schema::CONFIG_DOCS.stringify == %([{"name":"hubs","type":"`Hash(K, V)`","default":"`{__nil: nil}`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"port","type":"`Int32`","default":"`5432`","doc":""}]}] of Nil)
+                 raise "#{Schema::CONFIG_DOCS}"
+               end
             %}
           end
         end
@@ -532,19 +795,38 @@ describe ADI::Extension, tags: "compiled" do
             \{%
                options = Schema::OPTIONS
 
-               raise "#{options}" unless options.size == 1
+               unless options.size == 1
+                 raise "#{options}"
+               end
 
-               raise "#{options}" unless options[0]["name"] == "hubs"
-               raise "#{options}" unless options[0]["type"].stringify == "(Hash(K, V) | Nil)"
-               raise "#{options}" unless options[0]["default"].nil?
+               unless options[0]["name"] == "hubs"
+                 raise "#{options}"
+               end
+
+               unless options[0]["type"].stringify == "(Hash(K, V) | Nil)"
+                 raise "#{options}"
+               end
+
+               unless options[0]["default"].nil?
+                 raise "#{options}"
+               end
 
                members = options[0]["members"]
-               raise "#{members}" unless members.size == 3 # Account for __nil
+               unless members.size == 3 # Account for __nil
+                 raise "#{members}"
+               end
 
-               raise "#{members}" unless members["url"].type.stringify == "String"
-               raise "#{members}" unless members["port"].type.stringify == "Int32"
+               unless members["url"].type.stringify == "String"
+                 raise "#{members}"
+               end
 
-               raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"hubs","type":"`(Hash(K, V) | Nil)`","default":"`nil`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"port","type":"`Int32`","default":"`5432`","doc":""}]}] of Nil)
+               unless members["port"].type.stringify == "Int32"
+                 raise "#{members}"
+               end
+
+               unless Schema::CONFIG_DOCS.stringify == %([{"name":"hubs","type":"`(Hash(K, V) | Nil)`","default":"`nil`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"port","type":"`Int32`","default":"`5432`","doc":""}]}] of Nil)
+                 raise "#{Schema::CONFIG_DOCS}"
+               end
             %}
           end
         end
@@ -572,14 +854,26 @@ describe ADI::Extension, tags: "compiled" do
             \{%
                options = Schema::OPTIONS
 
-               raise "#{options}" unless options.size == 1
+               unless options.size == 1
+                 raise "#{options}"
+               end
 
                jwt_member = options[0]["members"]["jwt"]
-               raise "#{jwt_member}" unless jwt_member["members"] != nil
-               raise "#{jwt_member}" unless jwt_member["members"]["secret"].type.stringify == "String"
-               raise "#{jwt_member}" unless jwt_member["members"]["algorithm"].value == "hmac.sha256"
+               unless jwt_member["members"] != nil
+                 raise "#{jwt_member}"
+               end
 
-               raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"hubs","type":"`Hash(K, V)`","default":"`{__nil: nil}`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"jwt","type":"`JwtConfig`","default":"``","doc":"","members":[{"name":"secret","type":"`String`","default":"``","doc":""},{"name":"algorithm","type":"`String`","default":"`hmac.sha256`","doc":""}]}]}] of Nil)
+               unless jwt_member["members"]["secret"].type.stringify == "String"
+                 raise "#{jwt_member}"
+               end
+
+               unless jwt_member["members"]["algorithm"].value == "hmac.sha256"
+                 raise "#{jwt_member}"
+               end
+
+               unless Schema::CONFIG_DOCS.stringify == %([{"name":"hubs","type":"`Hash(K, V)`","default":"`{__nil: nil}`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"jwt","type":"`JwtConfig`","default":"``","doc":"","members":[{"name":"secret","type":"`String`","default":"``","doc":""},{"name":"algorithm","type":"`String`","default":"`hmac.sha256`","doc":""}]}]}] of Nil)
+                 raise "#{Schema::CONFIG_DOCS}"
+               end
             %}
           end
         end
@@ -600,14 +894,27 @@ describe ADI::Extension, tags: "compiled" do
             \{%
                options = Schema::OPTIONS
 
-               raise "#{options}" unless options.size == 1
-               raise "#{options}" unless options[0]["name"] == "hubs"
-               raise "#{options}" unless options[0]["type"].stringify == "Hash(K, V)"
+               unless options.size == 1
+                 raise "#{options}"
+               end
+
+               unless options[0]["name"] == "hubs"
+                 raise "#{options}"
+               end
+
+               unless options[0]["type"].stringify == "Hash(K, V)"
+                 raise "#{options}"
+               end
 
                # Custom default should be preserved
                default = options[0]["default"]
-               raise "#{default}" unless default["default"]["url"] == "localhost"
-               raise "#{default}" unless default["default"]["port"] == 8080
+               unless default["default"]["url"] == "localhost"
+                 raise "#{default}"
+               end
+
+               unless default["default"]["port"] == 8080
+                 raise "#{default}"
+               end
             %}
           end
         end
@@ -637,14 +944,26 @@ describe ADI::Extension, tags: "compiled" do
             \{%
                options = Schema::OPTIONS
 
-               raise "#{options}" unless options.size == 1
+               unless options.size == 1
+                 raise "#{options}"
+               end
 
                jwt_member = options[0]["members"]["jwt"]
-               raise "#{jwt_member}" unless jwt_member["members"] != nil
-               raise "#{jwt_member}" unless jwt_member["members"]["secret"].type.stringify == "String"
-               raise "#{jwt_member}" unless jwt_member["members"]["algorithm"].value == "hmac.sha256"
+               unless jwt_member["members"] != nil
+                 raise "#{jwt_member}"
+               end
 
-               raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"items","type":"`Array(T)`","default":"`[]`","members":[{"name":"name","type":"`String`","default":"``","doc":""},{"name":"jwt","type":"`JwtConfig`","default":"``","doc":"","members":[{"name":"secret","type":"`String`","default":"``","doc":""},{"name":"algorithm","type":"`String`","default":"`hmac.sha256`","doc":""}]}]}] of Nil)
+               unless jwt_member["members"]["secret"].type.stringify == "String"
+                 raise "#{jwt_member}"
+               end
+
+               unless jwt_member["members"]["algorithm"].value == "hmac.sha256"
+                 raise "#{jwt_member}"
+               end
+
+               unless Schema::CONFIG_DOCS.stringify == %([{"name":"items","type":"`Array(T)`","default":"`[]`","members":[{"name":"name","type":"`String`","default":"``","doc":""},{"name":"jwt","type":"`JwtConfig`","default":"``","doc":"","members":[{"name":"secret","type":"`String`","default":"``","doc":""},{"name":"algorithm","type":"`String`","default":"`hmac.sha256`","doc":""}]}]}] of Nil)
+                 raise "#{Schema::CONFIG_DOCS}"
+               end
             %}
           end
         end
@@ -675,14 +994,26 @@ describe ADI::Extension, tags: "compiled" do
             \{%
                options = Schema::OPTIONS
 
-               raise "#{options}" unless options.size == 1
+               unless options.size == 1
+                 raise "#{options}"
+               end
 
                jwt_member = options[0]["members"]["jwt"]
-               raise "#{jwt_member}" unless jwt_member["members"] != nil
-               raise "#{jwt_member}" unless jwt_member["members"]["secret"].type.stringify == "String"
-               raise "#{jwt_member}" unless jwt_member["members"]["algorithm"].value == "hmac.sha256"
+               unless jwt_member["members"] != nil
+                 raise "#{jwt_member}"
+               end
 
-               raise "#{Schema::CONFIG_DOCS}" unless Schema::CONFIG_DOCS.stringify == %([{"name":"connection","type":"`(NamedTuple(T) | Nil)`","default":"`nil`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"jwt","type":"`JwtConfig`","default":"``","doc":"","members":[{"name":"secret","type":"`String`","default":"``","doc":""},{"name":"algorithm","type":"`String`","default":"`hmac.sha256`","doc":""}]}]}] of Nil)
+               unless jwt_member["members"]["secret"].type.stringify == "String"
+                 raise "#{jwt_member}"
+               end
+
+               unless jwt_member["members"]["algorithm"].value == "hmac.sha256"
+                 raise "#{jwt_member}"
+               end
+
+               unless Schema::CONFIG_DOCS.stringify == %([{"name":"connection","type":"`(NamedTuple(T) | Nil)`","default":"`nil`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"jwt","type":"`JwtConfig`","default":"``","doc":"","members":[{"name":"secret","type":"`String`","default":"``","doc":""},{"name":"algorithm","type":"`String`","default":"`hmac.sha256`","doc":""}]}]}] of Nil)
+                 raise "#{Schema::CONFIG_DOCS}"
+               end
             %}
           end
         end

--- a/src/components/dependency_injection/spec/extension_spec.cr
+++ b/src/components/dependency_injection/spec/extension_spec.cr
@@ -35,39 +35,15 @@ describe ADI::Extension, tags: "compiled" do
         macro finished
           \{%
              options = Schema::OPTIONS
-
-             unless options.size == 2
-               raise "#{options}"
-             end
-
-             unless options[0]["name"] == "id"
-               raise "#{options}"
-             end
-
-             unless options[0]["type"] == Int32
-               raise "#{options}"
-             end
-
-             unless options[0]["default"].nil?
-               raise "#{options}"
-             end
-
-             unless options[1]["name"] == "name"
-               raise "#{options}"
-             end
-
-             unless options[1]["type"] == String
-               raise "#{options}"
-             end
-
-             unless options[1]["default"] == "Fred"
-               raise "#{options}"
-             end
-
-             unless Schema::CONFIG_DOCS.stringify == %([{"name":"id","type":"`Int32`","default":"``"}, {"name":"name","type":"`String`","default":"`Fred`"}] of Nil)
-               raise "#{Schema::CONFIG_DOCS}"
-             end
           %}
+          ASPEC.compile_time_assert(\{{ options.size == 2 }}, "Expected options size to be 2")
+          ASPEC.compile_time_assert(\{{ options[0]["name"] == "id" }}, "Expected first option name to be id")
+          ASPEC.compile_time_assert(\{{ options[0]["type"] == Int32 }}, "Expected first option type to be Int32")
+          ASPEC.compile_time_assert(\{{ options[0]["default"].nil? }}, "Expected first option default to be nil")
+          ASPEC.compile_time_assert(\{{ options[1]["name"] == "name" }}, "Expected second option name to be name")
+          ASPEC.compile_time_assert(\{{ options[1]["type"] == String }}, "Expected second option type to be String")
+          ASPEC.compile_time_assert(\{{ options[1]["default"] == "Fred" }}, "Expected second option default to be Fred")
+          ASPEC.compile_time_assert(\{{ Schema::CONFIG_DOCS.stringify == %([{"name":"id","type":"`Int32`","default":"``"}, {"name":"name","type":"`String`","default":"`Fred`"}] of Nil) }}, "Expected CONFIG_DOCS to match")
         end
       end
     CR
@@ -86,27 +62,12 @@ describe ADI::Extension, tags: "compiled" do
         macro finished
           \{%
              options = Schema::OPTIONS
-
-             unless options.size == 1
-               raise "#{options}"
-             end
-
-             unless options[0]["name"] == "values"
-               raise "#{options}"
-             end
-
-             unless options[0]["type"] == Array(Int32 | String)
-               raise "#{options}"
-             end
-
-             unless options[0]["default"].stringify == "Array(Int32 | String).new"
-               raise "#{options}"
-             end
-
-             unless Schema::CONFIG_DOCS.stringify == %([{"name":"values","type":"`Array(Int32 | String)`","default":"`Array(Int32 | String).new`"}] of Nil)
-               raise "#{Schema::CONFIG_DOCS}"
-             end
           %}
+          ASPEC.compile_time_assert(\{{ options.size == 1 }}, "Expected options size to be 1")
+          ASPEC.compile_time_assert(\{{ options[0]["name"] == "values" }}, "Expected option name to be values")
+          ASPEC.compile_time_assert(\{{ options[0]["type"] == Array(Int32 | String) }}, "Expected option type to be Array(Int32 | String)")
+          ASPEC.compile_time_assert(\{{ options[0]["default"].stringify == "Array(Int32 | String).new" }}, "Expected option default to be Array(Int32 | String).new")
+          ASPEC.compile_time_assert(\{{ Schema::CONFIG_DOCS.stringify == %([{"name":"values","type":"`Array(Int32 | String)`","default":"`Array(Int32 | String).new`"}] of Nil) }}, "Expected CONFIG_DOCS to match")
         end
       end
     CR
@@ -138,19 +99,10 @@ describe ADI::Extension, tags: "compiled" do
           macro finished
             \{%
                config = ADI::CONFIG["test"]
-
-               unless config["connection"]["username"] == "addminn"
-                 raise "#{config}"
-               end
-
-               unless config["connection"]["password"] == "abc123"
-                 raise "#{config}"
-               end
-
-               unless config["connection"]["port"] == 1234
-                 raise "#{config}"
-               end
             %}
+            ASPEC.compile_time_assert(\{{ config["connection"]["username"] == "addminn" }}, "Expected connection username to be addminn")
+            ASPEC.compile_time_assert(\{{ config["connection"]["password"] == "abc123" }}, "Expected connection password to be abc123")
+            ASPEC.compile_time_assert(\{{ config["connection"]["port"] == 1234 }}, "Expected connection port to be 1234")
           end
         end
       CR
@@ -220,48 +172,18 @@ describe ADI::Extension, tags: "compiled" do
           macro finished
             \{%
              options = Schema::OPTIONS
-
-             unless options.size == 1
-               raise "#{options}"
-             end
-
-             unless options[0]["name"] == "rule"
-               raise "#{options}"
-             end
-
-             unless options[0]["type"].stringify == "NamedTuple(T)"
-               raise "#{options}"
-             end
-
-             unless options[0]["default"].nil?
-               raise "#{options}"
-             end
-
              members = options[0]["members"]
-             unless members.size == 3 # Account for __nil
-               raise "#{members}"
-             end
-
-             unless members["id"].type.stringify == "Int32"
-               raise "#{members}"
-             end
-
-             unless members["id"].value.nil?
-               raise "#{members}"
-             end
-
-             unless members["stop"].type.stringify == "Bool"
-               raise "#{members}"
-             end
-
-             unless members["stop"].value == false
-               raise "#{members}"
-             end
-
-             unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`NamedTuple(T)`","default":"``","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
-               raise "#{Schema::CONFIG_DOCS}"
-             end
             %}
+            ASPEC.compile_time_assert(\{{ options.size == 1 }}, "Expected options size to be 1")
+            ASPEC.compile_time_assert(\{{ options[0]["name"] == "rule" }}, "Expected option name to be rule")
+            ASPEC.compile_time_assert(\{{ options[0]["type"].stringify == "NamedTuple(T)" }}, "Expected option type to be NamedTuple(T)")
+            ASPEC.compile_time_assert(\{{ options[0]["default"].nil? }}, "Expected option default to be nil")
+            ASPEC.compile_time_assert(\{{ members.size == 3 }}, "Expected members size to be 3") # Account for __nil
+            ASPEC.compile_time_assert(\{{ members["id"].type.stringify == "Int32" }}, "Expected id type to be Int32")
+            ASPEC.compile_time_assert(\{{ members["id"].value.nil? }}, "Expected id value to be nil")
+            ASPEC.compile_time_assert(\{{ members["stop"].type.stringify == "Bool" }}, "Expected stop type to be Bool")
+            ASPEC.compile_time_assert(\{{ members["stop"].value == false }}, "Expected stop value to be false")
+            ASPEC.compile_time_assert(\{{ Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`NamedTuple(T)`","default":"``","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil) }}, "Expected CONFIG_DOCS to match")
           end
         end
       CR
@@ -280,48 +202,18 @@ describe ADI::Extension, tags: "compiled" do
           macro finished
             \{%
              options = Schema::OPTIONS
-
-             unless options.size == 1
-               raise "#{options}"
-             end
-
-             unless options[0]["name"] == "rule"
-               raise "#{options}"
-             end
-
-             unless options[0]["type"].stringify == "NamedTuple(T)"
-               raise "#{options}"
-             end
-
-             unless options[0]["default"] == {id: 999, stop: false}
-               raise "#{options}"
-             end
-
              members = options[0]["members"]
-             unless members.size == 3 # Account for __nil
-               raise "#{members}"
-             end
-
-             unless members["id"].type.stringify == "Int32"
-               raise "#{members}"
-             end
-
-             unless members["id"].value.nil?
-               raise "#{members}"
-             end
-
-             unless members["stop"].type.stringify == "Bool"
-               raise "#{members}"
-             end
-
-             unless members["stop"].value == false
-               raise "#{members}"
-             end
-
-             unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`NamedTuple(T)`","default":"`{id: 999}`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
-               raise "#{Schema::CONFIG_DOCS}"
-             end
             %}
+            ASPEC.compile_time_assert(\{{ options.size == 1 }}, "Expected options size to be 1")
+            ASPEC.compile_time_assert(\{{ options[0]["name"] == "rule" }}, "Expected option name to be rule")
+            ASPEC.compile_time_assert(\{{ options[0]["type"].stringify == "NamedTuple(T)" }}, "Expected option type to be NamedTuple(T)")
+            ASPEC.compile_time_assert(\{{ options[0]["default"] == {id: 999, stop: false} }}, "Expected option default to match")
+            ASPEC.compile_time_assert(\{{ members.size == 3 }}, "Expected members size to be 3") # Account for __nil
+            ASPEC.compile_time_assert(\{{ members["id"].type.stringify == "Int32" }}, "Expected id type to be Int32")
+            ASPEC.compile_time_assert(\{{ members["id"].value.nil? }}, "Expected id value to be nil")
+            ASPEC.compile_time_assert(\{{ members["stop"].type.stringify == "Bool" }}, "Expected stop type to be Bool")
+            ASPEC.compile_time_assert(\{{ members["stop"].value == false }}, "Expected stop value to be false")
+            ASPEC.compile_time_assert(\{{ Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`NamedTuple(T)`","default":"`{id: 999}`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil) }}, "Expected CONFIG_DOCS to match")
           end
         end
       CR
@@ -340,48 +232,18 @@ describe ADI::Extension, tags: "compiled" do
           macro finished
             \{%
              options = Schema::OPTIONS
-
-             unless options.size == 1
-               raise "#{options}"
-             end
-
-             unless options[0]["name"] == "rule"
-               raise "#{options}"
-             end
-
-             unless options[0]["type"].stringify == "(NamedTuple(T) | Nil)"
-               raise "#{options}"
-             end
-
-             unless options[0]["default"].nil?
-               raise "#{options}"
-             end
-
              members = options[0]["members"]
-             unless members.size == 3 # Account for __nil
-               raise "#{members}"
-             end
-
-             unless members["id"].type.stringify == "Int32"
-               raise "#{members}"
-             end
-
-             unless members["id"].value.nil?
-               raise "#{members}"
-             end
-
-             unless members["stop"].type.stringify == "Bool"
-               raise "#{members}"
-             end
-
-             unless members["stop"].value == false
-               raise "#{members}"
-             end
-
-             unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`(NamedTuple(T) | Nil)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
-               raise "#{Schema::CONFIG_DOCS}"
-             end
             %}
+            ASPEC.compile_time_assert(\{{ options.size == 1 }}, "Expected options size to be 1")
+            ASPEC.compile_time_assert(\{{ options[0]["name"] == "rule" }}, "Expected option name to be rule")
+            ASPEC.compile_time_assert(\{{ options[0]["type"].stringify == "(NamedTuple(T) | Nil)" }}, "Expected option type to be (NamedTuple(T) | Nil)")
+            ASPEC.compile_time_assert(\{{ options[0]["default"].nil? }}, "Expected option default to be nil")
+            ASPEC.compile_time_assert(\{{ members.size == 3 }}, "Expected members size to be 3") # Account for __nil
+            ASPEC.compile_time_assert(\{{ members["id"].type.stringify == "Int32" }}, "Expected id type to be Int32")
+            ASPEC.compile_time_assert(\{{ members["id"].value.nil? }}, "Expected id value to be nil")
+            ASPEC.compile_time_assert(\{{ members["stop"].type.stringify == "Bool" }}, "Expected stop type to be Bool")
+            ASPEC.compile_time_assert(\{{ members["stop"].value == false }}, "Expected stop value to be false")
+            ASPEC.compile_time_assert(\{{ Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`(NamedTuple(T) | Nil)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil) }}, "Expected CONFIG_DOCS to match")
           end
         end
       CR
@@ -400,48 +262,18 @@ describe ADI::Extension, tags: "compiled" do
           macro finished
             \{%
              options = Schema::OPTIONS
-
-             unless options.size == 1
-               raise "#{options}"
-             end
-
-             unless options[0]["name"] == "rule"
-               raise "#{options}"
-             end
-
-             unless options[0]["type"].stringify == "(NamedTuple(T) | Nil)"
-               raise "#{options}"
-             end
-
-             unless options[0]["default"].nil?
-               raise "#{options}"
-             end
-
              members = options[0]["members"]
-             unless members.size == 3 # Account for __nil
-               raise "#{members}"
-             end
-
-             unless members["id"].type.stringify == "Int32"
-               raise "#{members}"
-             end
-
-             unless members["id"].value.nil?
-               raise "#{members}"
-             end
-
-             unless members["stop"].type.stringify == "Bool"
-               raise "#{members}"
-             end
-
-             unless members["stop"].value == false
-               raise "#{members}"
-             end
-
-             unless Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`(NamedTuple(T) | Nil)`","default":"`{id: 999}`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
-               raise "#{Schema::CONFIG_DOCS}"
-             end
             %}
+            ASPEC.compile_time_assert(\{{ options.size == 1 }}, "Expected options size to be 1")
+            ASPEC.compile_time_assert(\{{ options[0]["name"] == "rule" }}, "Expected option name to be rule")
+            ASPEC.compile_time_assert(\{{ options[0]["type"].stringify == "(NamedTuple(T) | Nil)" }}, "Expected option type to be (NamedTuple(T) | Nil)")
+            ASPEC.compile_time_assert(\{{ options[0]["default"].nil? }}, "Expected option default to be nil")
+            ASPEC.compile_time_assert(\{{ members.size == 3 }}, "Expected members size to be 3") # Account for __nil
+            ASPEC.compile_time_assert(\{{ members["id"].type.stringify == "Int32" }}, "Expected id type to be Int32")
+            ASPEC.compile_time_assert(\{{ members["id"].value.nil? }}, "Expected id value to be nil")
+            ASPEC.compile_time_assert(\{{ members["stop"].type.stringify == "Bool" }}, "Expected stop type to be Bool")
+            ASPEC.compile_time_assert(\{{ members["stop"].value == false }}, "Expected stop value to be false")
+            ASPEC.compile_time_assert(\{{ Schema::CONFIG_DOCS.stringify == %([{"name":"rule","type":"`(NamedTuple(T) | Nil)`","default":"`{id: 999}`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil) }}, "Expected CONFIG_DOCS to match")
           end
         end
       CR
@@ -462,44 +294,17 @@ describe ADI::Extension, tags: "compiled" do
           macro finished
             \{%
              options = Schema::OPTIONS
-
-             unless options.size == 1
-               raise "#{options}"
-             end
-
-             unless options[0]["name"] == "rules"
-               raise "#{options}"
-             end
-
-             unless options[0]["type"].stringify == "Array(T)"
-               raise "#{options}"
-             end
-
-             unless options[0]["default"].stringify == "[]"
-               raise "#{options}"
-             end
-
              members = options[0]["members"]
-             unless members.size == 3 # Account for __nil
-               raise "#{members}"
-             end
-
-             unless members["id"].type.stringify == "Int32"
-               raise "#{members}"
-             end
-
-             unless members["id"].value.nil?
-               raise "#{members}"
-             end
-
-             unless members["stop"].type.stringify == "Bool"
-               raise "#{members}"
-             end
-
-             unless members["stop"].value == false
-               raise "#{members}"
-             end
             %}
+            ASPEC.compile_time_assert(\{{ options.size == 1 }}, "Expected options size to be 1")
+            ASPEC.compile_time_assert(\{{ options[0]["name"] == "rules" }}, "Expected option name to be rules")
+            ASPEC.compile_time_assert(\{{ options[0]["type"].stringify == "Array(T)" }}, "Expected option type to be Array(T)")
+            ASPEC.compile_time_assert(\{{ options[0]["default"].stringify == "[]" }}, "Expected option default to be empty array")
+            ASPEC.compile_time_assert(\{{ members.size == 3 }}, "Expected members size to be 3") # Account for __nil
+            ASPEC.compile_time_assert(\{{ members["id"].type.stringify == "Int32" }}, "Expected id type to be Int32")
+            ASPEC.compile_time_assert(\{{ members["id"].value.nil? }}, "Expected id value to be nil")
+            ASPEC.compile_time_assert(\{{ members["stop"].type.stringify == "Bool" }}, "Expected stop type to be Bool")
+            ASPEC.compile_time_assert(\{{ members["stop"].value == false }}, "Expected stop value to be false")
           end
         end
       CR
@@ -518,48 +323,18 @@ describe ADI::Extension, tags: "compiled" do
           macro finished
             \{%
              options = Schema::OPTIONS
-
-             unless options.size == 1
-               raise "#{options}"
-             end
-
-             unless options[0]["name"] == "rules"
-               raise "#{options}"
-             end
-
-             unless options[0]["type"].stringify == "Array(T)"
-               raise "#{options}"
-             end
-
-             unless options[0]["default"] == [{id: 10, stop: false}]
-               raise "#{options}"
-             end
-
              members = options[0]["members"]
-             unless members.size == 3 # Account for __nil
-               raise "#{members}"
-             end
-
-             unless members["id"].type.stringify == "Int32"
-               raise "#{members}"
-             end
-
-             unless members["id"].value.nil?
-               raise "#{members}"
-             end
-
-             unless members["stop"].type.stringify == "Bool"
-               raise "#{members}"
-             end
-
-             unless members["stop"].value == false
-               raise "#{members}"
-             end
-
-             unless Schema::CONFIG_DOCS.stringify == %([{"name":"rules","type":"`Array(T)`","default":"`[{id: 10}]`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
-               raise "#{Schema::CONFIG_DOCS}"
-             end
             %}
+            ASPEC.compile_time_assert(\{{ options.size == 1 }}, "Expected options size to be 1")
+            ASPEC.compile_time_assert(\{{ options[0]["name"] == "rules" }}, "Expected option name to be rules")
+            ASPEC.compile_time_assert(\{{ options[0]["type"].stringify == "Array(T)" }}, "Expected option type to be Array(T)")
+            ASPEC.compile_time_assert(\{{ options[0]["default"] == [{id: 10, stop: false}] }}, "Expected option default to match")
+            ASPEC.compile_time_assert(\{{ members.size == 3 }}, "Expected members size to be 3") # Account for __nil
+            ASPEC.compile_time_assert(\{{ members["id"].type.stringify == "Int32" }}, "Expected id type to be Int32")
+            ASPEC.compile_time_assert(\{{ members["id"].value.nil? }}, "Expected id value to be nil")
+            ASPEC.compile_time_assert(\{{ members["stop"].type.stringify == "Bool" }}, "Expected stop type to be Bool")
+            ASPEC.compile_time_assert(\{{ members["stop"].value == false }}, "Expected stop value to be false")
+            ASPEC.compile_time_assert(\{{ Schema::CONFIG_DOCS.stringify == %([{"name":"rules","type":"`Array(T)`","default":"`[{id: 10}]`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil) }}, "Expected CONFIG_DOCS to match")
           end
         end
       CR
@@ -578,48 +353,18 @@ describe ADI::Extension, tags: "compiled" do
           macro finished
             \{%
              options = Schema::OPTIONS
-
-             unless options.size == 1
-               raise "#{options}"
-             end
-
-             unless options[0]["name"] == "rules"
-               raise "#{options}"
-             end
-
-             unless options[0]["type"].stringify == "(Array(T) | Nil)"
-               raise "#{options}"
-             end
-
-             unless options[0]["default"].nil?
-               raise "#{options}"
-             end
-
              members = options[0]["members"]
-             unless members.size == 3 # Account for __nil
-               raise "#{members}"
-             end
-
-             unless members["id"].type.stringify == "Int32"
-               raise "#{members}"
-             end
-
-             unless members["id"].value.nil?
-               raise "#{members}"
-             end
-
-             unless members["stop"].type.stringify == "Bool"
-               raise "#{members}"
-             end
-
-             unless members["stop"].value == false
-               raise "#{members}"
-             end
-
-             unless Schema::CONFIG_DOCS.stringify == %([{"name":"rules","type":"`(Array(T) | Nil)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil)
-               raise "#{Schema::CONFIG_DOCS}"
-             end
             %}
+            ASPEC.compile_time_assert(\{{ options.size == 1 }}, "Expected options size to be 1")
+            ASPEC.compile_time_assert(\{{ options[0]["name"] == "rules" }}, "Expected option name to be rules")
+            ASPEC.compile_time_assert(\{{ options[0]["type"].stringify == "(Array(T) | Nil)" }}, "Expected option type to be (Array(T) | Nil)")
+            ASPEC.compile_time_assert(\{{ options[0]["default"].nil? }}, "Expected option default to be nil")
+            ASPEC.compile_time_assert(\{{ members.size == 3 }}, "Expected members size to be 3") # Account for __nil
+            ASPEC.compile_time_assert(\{{ members["id"].type.stringify == "Int32" }}, "Expected id type to be Int32")
+            ASPEC.compile_time_assert(\{{ members["id"].value.nil? }}, "Expected id value to be nil")
+            ASPEC.compile_time_assert(\{{ members["stop"].type.stringify == "Bool" }}, "Expected stop type to be Bool")
+            ASPEC.compile_time_assert(\{{ members["stop"].value == false }}, "Expected stop value to be false")
+            ASPEC.compile_time_assert(\{{ Schema::CONFIG_DOCS.stringify == %([{"name":"rules","type":"`(Array(T) | Nil)`","default":"`nil`","members":[{"name":"id","type":"`Int32`","default":"``","doc":""},{"name":"stop","type":"`Bool`","default":"`false`","doc":""}]}] of Nil) }}, "Expected CONFIG_DOCS to match")
           end
         end
       CR
@@ -643,36 +388,15 @@ describe ADI::Extension, tags: "compiled" do
           macro finished
             \{%
                schemas = Schema::OBJECT_SCHEMAS
-
-               unless schemas.size == 1
-                 raise "#{schemas}"
-               end
-
-               unless schemas["JwtConfig"] != nil
-                 raise "#{schemas}"
-               end
-
                jwt_schema = schemas["JwtConfig"]
-               unless jwt_schema["members"].size == 3 # Account for __nil
-                 raise "#{jwt_schema}"
-               end
-
-               unless jwt_schema["members"]["secret"].type.stringify == "String"
-                 raise "#{jwt_schema}"
-               end
-
-               unless jwt_schema["members"]["secret"].value.nil?
-                 raise "#{jwt_schema}"
-               end
-
-               unless jwt_schema["members"]["algorithm"].type.stringify == "String"
-                 raise "#{jwt_schema}"
-               end
-
-               unless jwt_schema["members"]["algorithm"].value == "hmac.sha256"
-                 raise "#{jwt_schema}"
-               end
             %}
+            ASPEC.compile_time_assert(\{{ schemas.size == 1 }}, "Expected schemas size to be 1")
+            ASPEC.compile_time_assert(\{{ schemas["JwtConfig"] != nil }}, "Expected JwtConfig schema to exist")
+            ASPEC.compile_time_assert(\{{ jwt_schema["members"].size == 3 }}, "Expected jwt_schema members size to be 3") # Account for __nil
+            ASPEC.compile_time_assert(\{{ jwt_schema["members"]["secret"].type.stringify == "String" }}, "Expected secret type to be String")
+            ASPEC.compile_time_assert(\{{ jwt_schema["members"]["secret"].value.nil? }}, "Expected secret value to be nil")
+            ASPEC.compile_time_assert(\{{ jwt_schema["members"]["algorithm"].type.stringify == "String" }}, "Expected algorithm type to be String")
+            ASPEC.compile_time_assert(\{{ jwt_schema["members"]["algorithm"].value == "hmac.sha256" }}, "Expected algorithm value to be hmac.sha256")
           end
         end
       CR
@@ -698,22 +422,13 @@ describe ADI::Extension, tags: "compiled" do
             \{%
                schemas = Schema::OBJECT_SCHEMAS
                outer_schema = schemas["OuterConfig"]
-
-               # The inner member should have nested members from InnerConfig
                inner_member = outer_schema["members"]["inner"]
-               unless inner_member["members"] != nil
-                 raise "#{inner_member}"
-               end
-
-               unless inner_member["members"]["value"].type.stringify == "String"
-                 raise "#{inner_member}"
-               end
-
-               # OuterConfig's members_string should include InnerConfig's nested members
-               unless outer_schema["members_string"] == %([{"name":"name","type":"`String`","default":"``","doc":""},{"name":"inner","type":"`InnerConfig`","default":"``","doc":"","members":[{"name":"value","type":"`String`","default":"``","doc":""}]}])
-                 raise "#{outer_schema["members_string"]}"
-               end
             %}
+            # The inner member should have nested members from InnerConfig
+            ASPEC.compile_time_assert(\{{ inner_member["members"] != nil }}, "Expected inner member to have members")
+            ASPEC.compile_time_assert(\{{ inner_member["members"]["value"].type.stringify == "String" }}, "Expected inner value type to be String")
+            # OuterConfig's members_string should include InnerConfig's nested members
+            ASPEC.compile_time_assert(\{{ outer_schema["members_string"] == %([{"name":"name","type":"`String`","default":"``","doc":""},{"name":"inner","type":"`InnerConfig`","default":"``","doc":"","members":[{"name":"value","type":"`String`","default":"``","doc":""}]}]) }}, "Expected members_string to match")
           end
         end
       CR
@@ -734,48 +449,18 @@ describe ADI::Extension, tags: "compiled" do
           macro finished
             \{%
                options = Schema::OPTIONS
-
-               unless options.size == 1
-                 raise "#{options}"
-               end
-
-               unless options[0]["name"] == "hubs"
-                 raise "#{options}"
-               end
-
-               unless options[0]["type"].stringify == "Hash(K, V)"
-                 raise "#{options}"
-               end
-
-               unless options[0]["default"].stringify == "{__nil: nil}"
-                 raise "#{options}"
-               end
-
                members = options[0]["members"]
-               unless members.size == 3 # Account for __nil
-                 raise "#{members}"
-               end
-
-               unless members["url"].type.stringify == "String"
-                 raise "#{members}"
-               end
-
-               unless members["url"].value.nil?
-                 raise "#{members}"
-               end
-
-               unless members["port"].type.stringify == "Int32"
-                 raise "#{members}"
-               end
-
-               unless members["port"].value == 5432
-                 raise "#{members}"
-               end
-
-               unless Schema::CONFIG_DOCS.stringify == %([{"name":"hubs","type":"`Hash(K, V)`","default":"`{__nil: nil}`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"port","type":"`Int32`","default":"`5432`","doc":""}]}] of Nil)
-                 raise "#{Schema::CONFIG_DOCS}"
-               end
             %}
+            ASPEC.compile_time_assert(\{{ options.size == 1 }}, "Expected options size to be 1")
+            ASPEC.compile_time_assert(\{{ options[0]["name"] == "hubs" }}, "Expected option name to be hubs")
+            ASPEC.compile_time_assert(\{{ options[0]["type"].stringify == "Hash(K, V)" }}, "Expected option type to be Hash(K, V)")
+            ASPEC.compile_time_assert(\{{ options[0]["default"].stringify == "{__nil: nil}" }}, "Expected option default to be {__nil: nil}")
+            ASPEC.compile_time_assert(\{{ members.size == 3 }}, "Expected members size to be 3") # Account for __nil
+            ASPEC.compile_time_assert(\{{ members["url"].type.stringify == "String" }}, "Expected url type to be String")
+            ASPEC.compile_time_assert(\{{ members["url"].value.nil? }}, "Expected url value to be nil")
+            ASPEC.compile_time_assert(\{{ members["port"].type.stringify == "Int32" }}, "Expected port type to be Int32")
+            ASPEC.compile_time_assert(\{{ members["port"].value == 5432 }}, "Expected port value to be 5432")
+            ASPEC.compile_time_assert(\{{ Schema::CONFIG_DOCS.stringify == %([{"name":"hubs","type":"`Hash(K, V)`","default":"`{__nil: nil}`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"port","type":"`Int32`","default":"`5432`","doc":""}]}] of Nil) }}, "Expected CONFIG_DOCS to match")
           end
         end
       CR
@@ -794,40 +479,16 @@ describe ADI::Extension, tags: "compiled" do
           macro finished
             \{%
                options = Schema::OPTIONS
-
-               unless options.size == 1
-                 raise "#{options}"
-               end
-
-               unless options[0]["name"] == "hubs"
-                 raise "#{options}"
-               end
-
-               unless options[0]["type"].stringify == "(Hash(K, V) | Nil)"
-                 raise "#{options}"
-               end
-
-               unless options[0]["default"].nil?
-                 raise "#{options}"
-               end
-
                members = options[0]["members"]
-               unless members.size == 3 # Account for __nil
-                 raise "#{members}"
-               end
-
-               unless members["url"].type.stringify == "String"
-                 raise "#{members}"
-               end
-
-               unless members["port"].type.stringify == "Int32"
-                 raise "#{members}"
-               end
-
-               unless Schema::CONFIG_DOCS.stringify == %([{"name":"hubs","type":"`(Hash(K, V) | Nil)`","default":"`nil`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"port","type":"`Int32`","default":"`5432`","doc":""}]}] of Nil)
-                 raise "#{Schema::CONFIG_DOCS}"
-               end
             %}
+            ASPEC.compile_time_assert(\{{ options.size == 1 }}, "Expected options size to be 1")
+            ASPEC.compile_time_assert(\{{ options[0]["name"] == "hubs" }}, "Expected option name to be hubs")
+            ASPEC.compile_time_assert(\{{ options[0]["type"].stringify == "(Hash(K, V) | Nil)" }}, "Expected option type to be (Hash(K, V) | Nil)")
+            ASPEC.compile_time_assert(\{{ options[0]["default"].nil? }}, "Expected option default to be nil")
+            ASPEC.compile_time_assert(\{{ members.size == 3 }}, "Expected members size to be 3") # Account for __nil
+            ASPEC.compile_time_assert(\{{ members["url"].type.stringify == "String" }}, "Expected url type to be String")
+            ASPEC.compile_time_assert(\{{ members["port"].type.stringify == "Int32" }}, "Expected port type to be Int32")
+            ASPEC.compile_time_assert(\{{ Schema::CONFIG_DOCS.stringify == %([{"name":"hubs","type":"`(Hash(K, V) | Nil)`","default":"`nil`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"port","type":"`Int32`","default":"`5432`","doc":""}]}] of Nil) }}, "Expected CONFIG_DOCS to match")
           end
         end
       CR
@@ -853,28 +514,13 @@ describe ADI::Extension, tags: "compiled" do
           macro finished
             \{%
                options = Schema::OPTIONS
-
-               unless options.size == 1
-                 raise "#{options}"
-               end
-
                jwt_member = options[0]["members"]["jwt"]
-               unless jwt_member["members"] != nil
-                 raise "#{jwt_member}"
-               end
-
-               unless jwt_member["members"]["secret"].type.stringify == "String"
-                 raise "#{jwt_member}"
-               end
-
-               unless jwt_member["members"]["algorithm"].value == "hmac.sha256"
-                 raise "#{jwt_member}"
-               end
-
-               unless Schema::CONFIG_DOCS.stringify == %([{"name":"hubs","type":"`Hash(K, V)`","default":"`{__nil: nil}`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"jwt","type":"`JwtConfig`","default":"``","doc":"","members":[{"name":"secret","type":"`String`","default":"``","doc":""},{"name":"algorithm","type":"`String`","default":"`hmac.sha256`","doc":""}]}]}] of Nil)
-                 raise "#{Schema::CONFIG_DOCS}"
-               end
             %}
+            ASPEC.compile_time_assert(\{{ options.size == 1 }}, "Expected options size to be 1")
+            ASPEC.compile_time_assert(\{{ jwt_member["members"] != nil }}, "Expected jwt member to have members")
+            ASPEC.compile_time_assert(\{{ jwt_member["members"]["secret"].type.stringify == "String" }}, "Expected secret type to be String")
+            ASPEC.compile_time_assert(\{{ jwt_member["members"]["algorithm"].value == "hmac.sha256" }}, "Expected algorithm value to be hmac.sha256")
+            ASPEC.compile_time_assert(\{{ Schema::CONFIG_DOCS.stringify == %([{"name":"hubs","type":"`Hash(K, V)`","default":"`{__nil: nil}`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"jwt","type":"`JwtConfig`","default":"``","doc":"","members":[{"name":"secret","type":"`String`","default":"``","doc":""},{"name":"algorithm","type":"`String`","default":"`hmac.sha256`","doc":""}]}]}] of Nil) }}, "Expected CONFIG_DOCS to match")
           end
         end
       CR
@@ -893,29 +539,14 @@ describe ADI::Extension, tags: "compiled" do
           macro finished
             \{%
                options = Schema::OPTIONS
-
-               unless options.size == 1
-                 raise "#{options}"
-               end
-
-               unless options[0]["name"] == "hubs"
-                 raise "#{options}"
-               end
-
-               unless options[0]["type"].stringify == "Hash(K, V)"
-                 raise "#{options}"
-               end
-
-               # Custom default should be preserved
                default = options[0]["default"]
-               unless default["default"]["url"] == "localhost"
-                 raise "#{default}"
-               end
-
-               unless default["default"]["port"] == 8080
-                 raise "#{default}"
-               end
             %}
+            ASPEC.compile_time_assert(\{{ options.size == 1 }}, "Expected options size to be 1")
+            ASPEC.compile_time_assert(\{{ options[0]["name"] == "hubs" }}, "Expected option name to be hubs")
+            ASPEC.compile_time_assert(\{{ options[0]["type"].stringify == "Hash(K, V)" }}, "Expected option type to be Hash(K, V)")
+            # Custom default should be preserved
+            ASPEC.compile_time_assert(\{{ default["default"]["url"] == "localhost" }}, "Expected default url to be localhost")
+            ASPEC.compile_time_assert(\{{ default["default"]["port"] == 8080 }}, "Expected default port to be 8080")
           end
         end
       CR
@@ -943,28 +574,13 @@ describe ADI::Extension, tags: "compiled" do
           macro finished
             \{%
                options = Schema::OPTIONS
-
-               unless options.size == 1
-                 raise "#{options}"
-               end
-
                jwt_member = options[0]["members"]["jwt"]
-               unless jwt_member["members"] != nil
-                 raise "#{jwt_member}"
-               end
-
-               unless jwt_member["members"]["secret"].type.stringify == "String"
-                 raise "#{jwt_member}"
-               end
-
-               unless jwt_member["members"]["algorithm"].value == "hmac.sha256"
-                 raise "#{jwt_member}"
-               end
-
-               unless Schema::CONFIG_DOCS.stringify == %([{"name":"items","type":"`Array(T)`","default":"`[]`","members":[{"name":"name","type":"`String`","default":"``","doc":""},{"name":"jwt","type":"`JwtConfig`","default":"``","doc":"","members":[{"name":"secret","type":"`String`","default":"``","doc":""},{"name":"algorithm","type":"`String`","default":"`hmac.sha256`","doc":""}]}]}] of Nil)
-                 raise "#{Schema::CONFIG_DOCS}"
-               end
             %}
+            ASPEC.compile_time_assert(\{{ options.size == 1 }}, "Expected options size to be 1")
+            ASPEC.compile_time_assert(\{{ jwt_member["members"] != nil }}, "Expected jwt member to have members")
+            ASPEC.compile_time_assert(\{{ jwt_member["members"]["secret"].type.stringify == "String" }}, "Expected secret type to be String")
+            ASPEC.compile_time_assert(\{{ jwt_member["members"]["algorithm"].value == "hmac.sha256" }}, "Expected algorithm value to be hmac.sha256")
+            ASPEC.compile_time_assert(\{{ Schema::CONFIG_DOCS.stringify == %([{"name":"items","type":"`Array(T)`","default":"`[]`","members":[{"name":"name","type":"`String`","default":"``","doc":""},{"name":"jwt","type":"`JwtConfig`","default":"``","doc":"","members":[{"name":"secret","type":"`String`","default":"``","doc":""},{"name":"algorithm","type":"`String`","default":"`hmac.sha256`","doc":""}]}]}] of Nil) }}, "Expected CONFIG_DOCS to match")
           end
         end
       CR
@@ -993,28 +609,13 @@ describe ADI::Extension, tags: "compiled" do
           macro finished
             \{%
                options = Schema::OPTIONS
-
-               unless options.size == 1
-                 raise "#{options}"
-               end
-
                jwt_member = options[0]["members"]["jwt"]
-               unless jwt_member["members"] != nil
-                 raise "#{jwt_member}"
-               end
-
-               unless jwt_member["members"]["secret"].type.stringify == "String"
-                 raise "#{jwt_member}"
-               end
-
-               unless jwt_member["members"]["algorithm"].value == "hmac.sha256"
-                 raise "#{jwt_member}"
-               end
-
-               unless Schema::CONFIG_DOCS.stringify == %([{"name":"connection","type":"`(NamedTuple(T) | Nil)`","default":"`nil`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"jwt","type":"`JwtConfig`","default":"``","doc":"","members":[{"name":"secret","type":"`String`","default":"``","doc":""},{"name":"algorithm","type":"`String`","default":"`hmac.sha256`","doc":""}]}]}] of Nil)
-                 raise "#{Schema::CONFIG_DOCS}"
-               end
             %}
+            ASPEC.compile_time_assert(\{{ options.size == 1 }}, "Expected options size to be 1")
+            ASPEC.compile_time_assert(\{{ jwt_member["members"] != nil }}, "Expected jwt member to have members")
+            ASPEC.compile_time_assert(\{{ jwt_member["members"]["secret"].type.stringify == "String" }}, "Expected secret type to be String")
+            ASPEC.compile_time_assert(\{{ jwt_member["members"]["algorithm"].value == "hmac.sha256" }}, "Expected algorithm value to be hmac.sha256")
+            ASPEC.compile_time_assert(\{{ Schema::CONFIG_DOCS.stringify == %([{"name":"connection","type":"`(NamedTuple(T) | Nil)`","default":"`nil`","members":[{"name":"url","type":"`String`","default":"``","doc":""},{"name":"jwt","type":"`JwtConfig`","default":"``","doc":"","members":[{"name":"secret","type":"`String`","default":"``","doc":""},{"name":"algorithm","type":"`String`","default":"`hmac.sha256`","doc":""}]}]}] of Nil) }}, "Expected CONFIG_DOCS to match")
           end
         end
       CR

--- a/src/components/dependency_injection/spec/extension_spec.cr
+++ b/src/components/dependency_injection/spec/extension_spec.cr
@@ -1,14 +1,14 @@
 require "./spec_helper"
 
 private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compiles <<-CR, line: line
+  ASPEC::Methods.assert_compiles <<-CR, line: line - 1 # Account for spec_helper require
     require "./spec_helper.cr"
     #{code}
   CR
 end
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
+  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line - 1 # Account for spec_helper require
     require "./spec_helper.cr"
     #{code}
     ADI::ServiceContainer.new

--- a/src/components/framework/spec/bundle_spec.cr
+++ b/src/components/framework/spec/bundle_spec.cr
@@ -62,12 +62,29 @@ describe ATH::Bundle, tags: "compiled" do
                  service = ADI::ServiceContainer::SERVICE_HASH["athena_framework_listeners_cors"]
                  arg = service["parameters"]["config"]["value"]
 
-                 raise "#{arg}" unless arg =~ /allow_credentials: true/
-                 raise "#{arg}" unless arg =~ /allow_origin: \["allow_origin", \/foo\/\]/
-                 raise "#{arg}" unless arg =~ /allow_headers: \["allow_headers", "x-my-header"]/
-                 raise "#{arg}" unless arg =~ /allow_methods: \["allow_methods"]/
-                 raise "#{arg}" unless arg =~ /expose_headers: \["expose_headers", "x-my-header"]/
-                 raise "#{arg}" unless arg =~ /max_age: 123/
+                 unless arg =~ /allow_credentials: true/
+                   raise "#{arg}"
+                 end
+
+                 unless arg =~ /allow_origin: \["allow_origin", \/foo\/\]/
+                   raise "#{arg}"
+                 end
+
+                 unless arg =~ /allow_headers: \["allow_headers", "x-my-header"]/
+                   raise "#{arg}"
+                 end
+
+                 unless arg =~ /allow_methods: \["allow_methods"]/
+                   raise "#{arg}"
+                 end
+
+                 unless arg =~ /expose_headers: \["expose_headers", "x-my-header"]/
+                   raise "#{arg}"
+                 end
+
+                 unless arg =~ /max_age: 123/
+                   raise "#{arg}"
+                 end
               %}
             end
           end
@@ -96,51 +113,105 @@ describe ATH::Bundle, tags: "compiled" do
           macro finished
             \{%
                service = ADI::ServiceContainer::SERVICE_HASH["athena_framework_listeners_format"]
-               raise "" unless service["parameters"]["format_negotiator"]["value"].stringify == "athena_framework_view_format_negotiator"
+               unless service["parameters"]["format_negotiator"]["value"].stringify == "athena_framework_view_format_negotiator"
+                 raise ""
+               end
             %}
 
             \{%
                service = ADI::ServiceContainer::SERVICE_HASH["athena_framework_view_format_negotiator"]
                map = service["calls"]
 
-               raise "#{map}" unless map.size == 4
+               unless map.size == 4
+                 raise "#{map}"
+               end
 
                # Hostname rule
                m0, rule = map[0][1]
                matcher = ADI::ServiceContainer::SERVICE_HASH[m0.stringify]["parameters"]["matchers"]["value"]
-               raise "#{matcher}" unless matcher.includes? %(AHTTP::RequestMatcher::Hostname.new(/api\\.example\\.com/))
+               unless matcher.includes? %(AHTTP::RequestMatcher::Hostname.new(/api\\.example\\.com/))
+                 raise "#{matcher}"
+               end
 
-               raise "#{rule}" unless rule.includes? "ATH::View::FormatNegotiator::Rule.new"
-               raise "#{rule}" unless rule =~ /fallback_format: "json"/
-               raise "#{rule}" unless rule =~ /prefer_extension: true/
-               raise "#{rule}" unless rule =~ /priorities: \["json", "xml"\]/
-               raise "#{rule}" unless rule =~ /stop: false/
+               unless rule.includes? "ATH::View::FormatNegotiator::Rule.new"
+                 raise "#{rule}"
+               end
+
+               unless rule =~ /fallback_format: "json"/
+                 raise "#{rule}"
+               end
+
+               unless rule =~ /prefer_extension: true/
+                 raise "#{rule}"
+               end
+
+               unless rule =~ /priorities: \["json", "xml"\]/
+                 raise "#{rule}"
+               end
+
+               unless rule =~ /stop: false/
+                 raise "#{rule}"
+               end
 
                # Path rule
                m1, rule = map[1][1]
                matcher = ADI::ServiceContainer::SERVICE_HASH[m1.stringify]["parameters"]["matchers"]["value"]
-               raise "#{matcher}" unless matcher.includes? %(AHTTP::RequestMatcher::Path.new(/^\\/image/))
+               unless matcher.includes? %(AHTTP::RequestMatcher::Path.new(/^\\/image/))
+                 raise "#{matcher}"
+               end
 
-               raise "#{rule}" unless rule.includes? "ATH::View::FormatNegotiator::Rule.new"
-               raise "#{rule}" unless rule =~ /fallback_format: false/
-               raise "#{rule}" unless rule =~ /prefer_extension: true/
-               raise "#{rule}" unless rule =~ /priorities: \["jpeg", "gif"\]/
-               raise "#{rule}" unless rule =~ /stop: true/
+               unless rule.includes? "ATH::View::FormatNegotiator::Rule.new"
+                 raise "#{rule}"
+               end
+
+               unless rule =~ /fallback_format: false/
+                 raise "#{rule}"
+               end
+
+               unless rule =~ /prefer_extension: true/
+                 raise "#{rule}"
+               end
+
+               unless rule =~ /priorities: \["jpeg", "gif"\]/
+                 raise "#{rule}"
+               end
+
+               unless rule =~ /stop: true/
+                 raise "#{rule}"
+               end
 
                # Methods rule
                m2, rule = map[2][1]
                matcher = ADI::ServiceContainer::SERVICE_HASH[m2.stringify]["parameters"]["matchers"]["value"]
-               raise "#{matcher}" unless matcher.includes? %(AHTTP::RequestMatcher::Method.new(["HEAD"]))
+               unless matcher.includes? %(AHTTP::RequestMatcher::Method.new(["HEAD"]))
+                 raise "#{matcher}"
+               end
 
-               raise "#{rule}" unless rule.includes? "ATH::View::FormatNegotiator::Rule.new"
-               raise "#{rule}" unless rule =~ /fallback_format: "json"/
-               raise "#{rule}" unless rule =~ /prefer_extension: false/
-               raise "#{rule}" unless rule =~ /priorities: \["xml", "html"\]/
-               raise "#{rule}" unless rule =~ /stop: false/
+               unless rule.includes? "ATH::View::FormatNegotiator::Rule.new"
+                 raise "#{rule}"
+               end
+
+               unless rule =~ /fallback_format: "json"/
+                 raise "#{rule}"
+               end
+
+               unless rule =~ /prefer_extension: false/
+                 raise "#{rule}"
+               end
+
+               unless rule =~ /priorities: \["xml", "html"\]/
+                 raise "#{rule}"
+               end
+
+               unless rule =~ /stop: false/
+                 raise "#{rule}"
+               end
 
                # Tests matcher reuse logic
                m3, rule = map[3][1]
-               raise "#{m3} == #{m1}" unless m3 == m1
+               unless m3 == m1
+                 raise "#{m3} == #{m1}"
+               end
             %}
           end
         end
@@ -166,16 +237,28 @@ describe ATH::Bundle, tags: "compiled" do
           macro finished
             \{%
                service = ADI::ServiceContainer::SERVICE_HASH["athena_framework_listeners_file"]
-               raise "" unless service
+               unless service
+                 raise ""
+               end
 
                service = ADI::ServiceContainer::SERVICE_HASH["athena_framework_file_parser"]
-               raise "" unless service
+               unless service
+                 raise ""
+               end
 
                parameters = service["parameters"]
 
-               raise "#{parameters["temp_dir"]}" unless parameters["temp_dir"]["value"] == "/tmp/dir"
-               raise "#{parameters["max_uploads"]}" unless parameters["max_uploads"]["value"] == 12
-               raise "#{parameters["max_file_size"]}" unless parameters["max_file_size"]["value"] == 1000_i64
+               unless parameters["temp_dir"]["value"] == "/tmp/dir"
+                 raise "#{parameters["temp_dir"]}"
+               end
+
+               unless parameters["max_uploads"]["value"] == 12
+                 raise "#{parameters["max_uploads"]}"
+               end
+
+               unless parameters["max_file_size"]["value"] == 1000_i64
+                 raise "#{parameters["max_file_size"]}"
+               end
             %}
           end
         end

--- a/src/components/framework/spec/bundle_spec.cr
+++ b/src/components/framework/spec/bundle_spec.cr
@@ -61,31 +61,13 @@ describe ATH::Bundle, tags: "compiled" do
               \{%
                  service = ADI::ServiceContainer::SERVICE_HASH["athena_framework_listeners_cors"]
                  arg = service["parameters"]["config"]["value"]
-
-                 unless arg =~ /allow_credentials: true/
-                   raise "#{arg}"
-                 end
-
-                 unless arg =~ /allow_origin: \["allow_origin", \/foo\/\]/
-                   raise "#{arg}"
-                 end
-
-                 unless arg =~ /allow_headers: \["allow_headers", "x-my-header"]/
-                   raise "#{arg}"
-                 end
-
-                 unless arg =~ /allow_methods: \["allow_methods"]/
-                   raise "#{arg}"
-                 end
-
-                 unless arg =~ /expose_headers: \["expose_headers", "x-my-header"]/
-                   raise "#{arg}"
-                 end
-
-                 unless arg =~ /max_age: 123/
-                   raise "#{arg}"
-                 end
               %}
+              ASPEC.compile_time_assert(\{{ arg =~ /allow_credentials: true/ }}, "Expected allow_credentials: true")
+              ASPEC.compile_time_assert(\{{ arg =~ /allow_origin: \["allow_origin", \/foo\/\]/ }}, "Expected allow_origin")
+              ASPEC.compile_time_assert(\{{ arg =~ /allow_headers: \["allow_headers", "x-my-header"]/ }}, "Expected allow_headers")
+              ASPEC.compile_time_assert(\{{ arg =~ /allow_methods: \["allow_methods"]/ }}, "Expected allow_methods")
+              ASPEC.compile_time_assert(\{{ arg =~ /expose_headers: \["expose_headers", "x-my-header"]/ }}, "Expected expose_headers")
+              ASPEC.compile_time_assert(\{{ arg =~ /max_age: 123/ }}, "Expected max_age: 123")
             end
           end
         CR
@@ -113,106 +95,56 @@ describe ATH::Bundle, tags: "compiled" do
           macro finished
             \{%
                service = ADI::ServiceContainer::SERVICE_HASH["athena_framework_listeners_format"]
-               unless service["parameters"]["format_negotiator"]["value"].stringify == "athena_framework_view_format_negotiator"
-                 raise ""
-               end
             %}
+            ASPEC.compile_time_assert(\{{ service["parameters"]["format_negotiator"]["value"].stringify == "athena_framework_view_format_negotiator" }}, "Expected format_negotiator to be athena_framework_view_format_negotiator")
 
             \{%
                service = ADI::ServiceContainer::SERVICE_HASH["athena_framework_view_format_negotiator"]
                map = service["calls"]
+            %}
+            ASPEC.compile_time_assert(\{{ map.size == 4 }}, "Expected 4 format negotiator rules")
 
-               unless map.size == 4
-                 raise "#{map}"
-               end
-
-               # Hostname rule
+            # Hostname rule
+            \{%
                m0, rule = map[0][1]
                matcher = ADI::ServiceContainer::SERVICE_HASH[m0.stringify]["parameters"]["matchers"]["value"]
-               unless matcher.includes? %(AHTTP::RequestMatcher::Hostname.new(/api\\.example\\.com/))
-                 raise "#{matcher}"
-               end
+            %}
+            ASPEC.compile_time_assert(\{{ matcher.includes? %(AHTTP::RequestMatcher::Hostname.new(/api\\.example\\.com/)) }}, "Expected hostname matcher for api.example.com")
+            ASPEC.compile_time_assert(\{{ rule.includes? "ATH::View::FormatNegotiator::Rule.new" }}, "Expected hostname rule to be a FormatNegotiator::Rule")
+            ASPEC.compile_time_assert(\{{ rule =~ /fallback_format: "json"/ }}, "Expected hostname rule fallback_format: json")
+            ASPEC.compile_time_assert(\{{ rule =~ /prefer_extension: true/ }}, "Expected hostname rule prefer_extension: true")
+            ASPEC.compile_time_assert(\{{ rule =~ /priorities: \["json", "xml"\]/ }}, "Expected hostname rule priorities: json, xml")
+            ASPEC.compile_time_assert(\{{ rule =~ /stop: false/ }}, "Expected hostname rule stop: false")
 
-               unless rule.includes? "ATH::View::FormatNegotiator::Rule.new"
-                 raise "#{rule}"
-               end
-
-               unless rule =~ /fallback_format: "json"/
-                 raise "#{rule}"
-               end
-
-               unless rule =~ /prefer_extension: true/
-                 raise "#{rule}"
-               end
-
-               unless rule =~ /priorities: \["json", "xml"\]/
-                 raise "#{rule}"
-               end
-
-               unless rule =~ /stop: false/
-                 raise "#{rule}"
-               end
-
-               # Path rule
+            # Path rule
+            \{%
                m1, rule = map[1][1]
                matcher = ADI::ServiceContainer::SERVICE_HASH[m1.stringify]["parameters"]["matchers"]["value"]
-               unless matcher.includes? %(AHTTP::RequestMatcher::Path.new(/^\\/image/))
-                 raise "#{matcher}"
-               end
+            %}
+            ASPEC.compile_time_assert(\{{ matcher.includes? %(AHTTP::RequestMatcher::Path.new(/^\\/image/)) }}, "Expected path matcher for /image")
+            ASPEC.compile_time_assert(\{{ rule.includes? "ATH::View::FormatNegotiator::Rule.new" }}, "Expected path rule to be a FormatNegotiator::Rule")
+            ASPEC.compile_time_assert(\{{ rule =~ /fallback_format: false/ }}, "Expected path rule fallback_format: false")
+            ASPEC.compile_time_assert(\{{ rule =~ /prefer_extension: true/ }}, "Expected path rule prefer_extension: true")
+            ASPEC.compile_time_assert(\{{ rule =~ /priorities: \["jpeg", "gif"\]/ }}, "Expected path rule priorities: jpeg, gif")
+            ASPEC.compile_time_assert(\{{ rule =~ /stop: true/ }}, "Expected path rule stop: true")
 
-               unless rule.includes? "ATH::View::FormatNegotiator::Rule.new"
-                 raise "#{rule}"
-               end
-
-               unless rule =~ /fallback_format: false/
-                 raise "#{rule}"
-               end
-
-               unless rule =~ /prefer_extension: true/
-                 raise "#{rule}"
-               end
-
-               unless rule =~ /priorities: \["jpeg", "gif"\]/
-                 raise "#{rule}"
-               end
-
-               unless rule =~ /stop: true/
-                 raise "#{rule}"
-               end
-
-               # Methods rule
+            # Methods rule
+            \{%
                m2, rule = map[2][1]
                matcher = ADI::ServiceContainer::SERVICE_HASH[m2.stringify]["parameters"]["matchers"]["value"]
-               unless matcher.includes? %(AHTTP::RequestMatcher::Method.new(["HEAD"]))
-                 raise "#{matcher}"
-               end
-
-               unless rule.includes? "ATH::View::FormatNegotiator::Rule.new"
-                 raise "#{rule}"
-               end
-
-               unless rule =~ /fallback_format: "json"/
-                 raise "#{rule}"
-               end
-
-               unless rule =~ /prefer_extension: false/
-                 raise "#{rule}"
-               end
-
-               unless rule =~ /priorities: \["xml", "html"\]/
-                 raise "#{rule}"
-               end
-
-               unless rule =~ /stop: false/
-                 raise "#{rule}"
-               end
-
-               # Tests matcher reuse logic
-               m3, rule = map[3][1]
-               unless m3 == m1
-                 raise "#{m3} == #{m1}"
-               end
             %}
+            ASPEC.compile_time_assert(\{{ matcher.includes? %(AHTTP::RequestMatcher::Method.new(["HEAD"])) }}, "Expected method matcher for HEAD")
+            ASPEC.compile_time_assert(\{{ rule.includes? "ATH::View::FormatNegotiator::Rule.new" }}, "Expected methods rule to be a FormatNegotiator::Rule")
+            ASPEC.compile_time_assert(\{{ rule =~ /fallback_format: "json"/ }}, "Expected methods rule fallback_format: json")
+            ASPEC.compile_time_assert(\{{ rule =~ /prefer_extension: false/ }}, "Expected methods rule prefer_extension: false")
+            ASPEC.compile_time_assert(\{{ rule =~ /priorities: \["xml", "html"\]/ }}, "Expected methods rule priorities: xml, html")
+            ASPEC.compile_time_assert(\{{ rule =~ /stop: false/ }}, "Expected methods rule stop: false")
+
+            # Tests matcher reuse logic
+            \{%
+               m3, rule = map[3][1]
+            %}
+            ASPEC.compile_time_assert(\{{ m3 == m1 }}, "Expected matcher reuse for path rules")
           end
         end
       CR
@@ -237,29 +169,20 @@ describe ATH::Bundle, tags: "compiled" do
           macro finished
             \{%
                service = ADI::ServiceContainer::SERVICE_HASH["athena_framework_listeners_file"]
-               unless service
-                 raise ""
-               end
-
-               service = ADI::ServiceContainer::SERVICE_HASH["athena_framework_file_parser"]
-               unless service
-                 raise ""
-               end
-
-               parameters = service["parameters"]
-
-               unless parameters["temp_dir"]["value"] == "/tmp/dir"
-                 raise "#{parameters["temp_dir"]}"
-               end
-
-               unless parameters["max_uploads"]["value"] == 12
-                 raise "#{parameters["max_uploads"]}"
-               end
-
-               unless parameters["max_file_size"]["value"] == 1000_i64
-                 raise "#{parameters["max_file_size"]}"
-               end
             %}
+            ASPEC.compile_time_assert(\{{ !service.nil? }}, "Expected athena_framework_listeners_file service to exist")
+
+            \{%
+               service = ADI::ServiceContainer::SERVICE_HASH["athena_framework_file_parser"]
+            %}
+            ASPEC.compile_time_assert(\{{ !service.nil? }}, "Expected athena_framework_file_parser service to exist")
+
+            \{%
+               parameters = service["parameters"]
+            %}
+            ASPEC.compile_time_assert(\{{ parameters["temp_dir"]["value"] == "/tmp/dir" }}, "Expected temp_dir to be /tmp/dir")
+            ASPEC.compile_time_assert(\{{ parameters["max_uploads"]["value"] == 12 }}, "Expected max_uploads to be 12")
+            ASPEC.compile_time_assert(\{{ parameters["max_file_size"]["value"] == 1000_i64 }}, "Expected max_file_size to be 1000")
           end
         end
       CR

--- a/src/components/framework/spec/bundle_spec.cr
+++ b/src/components/framework/spec/bundle_spec.cr
@@ -1,14 +1,14 @@
 require "./spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
+  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line - 1 # Account for spec_helper require
     require "./spec_helper.cr"
     #{code}
   CR
 end
 
 private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compiles <<-CR, line: line
+  ASPEC::Methods.assert_compiles <<-CR, line: line - 1 # Account for spec_helper require
     require "./spec_helper.cr"
     #{code}
   CR

--- a/src/components/spec/spec/methods_spec.cr
+++ b/src/components/spec/spec/methods_spec.cr
@@ -49,33 +49,31 @@ describe ASPEC::Methods do
 
       ENV["ATHENA_SPEC_COVERAGE_OUTPUT_DIR"] = temp_dir
 
-      begin
-        # We expect the line `{% x = 1 %}` to be called. Using __LINE__ and adding 3 keeps this robust if other tests are added/removed/re-arranged.
-        expected_line = __LINE__ + 3
-        ASPEC::Methods.assert_compiles <<-'CR'
+      # We expect the line `{% x = 1 %}` to be called. Using __LINE__ and adding 3 keeps this robust if other tests are added/removed/re-arranged.
+      expected_line = __LINE__ + 3
+      ASPEC::Methods.assert_compiles <<-'CR'
           macro finished
             {% x = 1 %}
           end
         CR
 
-        coverage_file = Dir.glob(File.join(temp_dir, "macro_coverage.*.codecov.json")).first
+      coverage_file = Dir.glob(File.join(temp_dir, "macro_coverage.*.codecov.json")).first
 
-        File.open coverage_file do |file|
-          coverage = JSON.parse file
+      File.open coverage_file do |file|
+        coverage = JSON.parse file
 
-          # Should be 1 coverage file.
-          coverages = coverage.as_h["coverage"].as_h
-          coverages.size.should eq 1
+        # Should be 1 coverage file.
+        coverages = coverage.as_h["coverage"].as_h
+        coverages.size.should eq 1
 
-          coverages.each_value do |file_coverage|
-            # The expected line number should be called once
-            file_coverage.as_h.should eq({expected_line.to_s => 1})
-          end
+        coverages.each_value do |file_coverage|
+          # The expected line number should be called once
+          file_coverage.as_h.should eq({expected_line.to_s => 1})
         end
-      ensure
-        ENV.delete("ATHENA_SPEC_COVERAGE_OUTPUT_DIR")
-        FileUtils.rm_rf(temp_dir)
       end
+    ensure
+      ENV.delete("ATHENA_SPEC_COVERAGE_OUTPUT_DIR")
+      FileUtils.rm_rf(temp_dir)
     end
   end
 

--- a/src/components/spec/spec/methods_spec.cr
+++ b/src/components/spec/spec/methods_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "file_utils"
 
 describe ASPEC::Methods do
   describe ".assert_compile_time_error", tags: "compiled" do
@@ -40,6 +41,41 @@ describe ASPEC::Methods do
       assert_compiles <<-CR
           raise "Oh no"
         CR
+    end
+
+    it "adjusts macro coverage line numbers for the stdin file" do
+      temp_dir = File.tempname
+      Dir.mkdir_p(temp_dir)
+
+      ENV["ATHENA_SPEC_COVERAGE_OUTPUT_DIR"] = temp_dir
+
+      begin
+        # We expect the line `{% x = 1 %}` to be called. Using __LINE__ and adding 3 keeps this robust if other tests are added/removed/re-arranged.
+        expected_line = __LINE__ + 3
+        ASPEC::Methods.assert_compiles <<-'CR'
+          macro finished
+            {% x = 1 %}
+          end
+        CR
+
+        coverage_file = Dir.glob(File.join(temp_dir, "macro_coverage.*.codecov.json")).first
+
+        File.open coverage_file do |file|
+          coverage = JSON.parse file
+
+          # Should be 1 coverage file.
+          coverages = coverage.as_h["coverage"].as_h
+          coverages.size.should eq 1
+
+          coverages.each_value do |file_coverage|
+            # The expected line number should be called once
+            file_coverage.as_h.should eq({expected_line.to_s => 1})
+          end
+        end
+      ensure
+        ENV.delete("ATHENA_SPEC_COVERAGE_OUTPUT_DIR")
+        FileUtils.rm_rf(temp_dir)
+      end
     end
   end
 

--- a/src/components/spec/spec/methods_spec.cr
+++ b/src/components/spec/spec/methods_spec.cr
@@ -73,7 +73,7 @@ describe ASPEC::Methods do
       end
     ensure
       ENV.delete("ATHENA_SPEC_COVERAGE_OUTPUT_DIR")
-      FileUtils.rm_rf(temp_dir)
+      FileUtils.rm_rf(temp_dir) if temp_dir
     end
   end
 

--- a/src/components/spec/src/athena-spec.cr
+++ b/src/components/spec/src/athena-spec.cr
@@ -9,6 +9,31 @@ require "./test_case"
 module Athena::Spec
   VERSION = "0.4.1"
 
+  # Asserts a *condition*, raising *message* if it is falsey.
+  # This is primarily intended to be used with `ASPEC::Methods.assert_compiles` to assert state that exists at compile time.
+  # An example of this is how internally Athena's specs do something like this to assert aspects of wired up services are correct:
+  #
+  # ```
+  # ASPEC::Methods.assert_compiles <<-'CR'
+  #   require "../spec_helper"
+  #
+  #   @[ADI::Register(public: true)]
+  #   record MyService
+  #
+  #   macro finished
+  #     macro finished
+  #       \{%
+  #         service = ADI::ServiceContainer::SERVICE_HASH["my_service"]
+  #       %}
+  #       ASPEC.compile_time_assert(\{{ service["public"] == true }}, "Expected service to be public")
+  #     end
+  #   end
+  # CR
+  # ```
+  macro compile_time_assert(condition, message = "Compile-time assertion failed")
+    {% condition.raise message unless condition %}
+  end
+
   # Runs all `ASPEC::TestCase`s.
   #
   # Is equivalent to manually calling `.run` on each test case.

--- a/src/components/spec/src/athena-spec.cr
+++ b/src/components/spec/src/athena-spec.cr
@@ -1,6 +1,7 @@
 # Convenience alias to make referencing `Athena::Spec` types easier.
 alias ASPEC = Athena::Spec
 
+require "json"
 require "./methods"
 require "./test_case"
 

--- a/src/components/spec/src/methods.cr
+++ b/src/components/spec/src/methods.cr
@@ -33,7 +33,7 @@ module Athena::Spec::Methods
     # TODO: Maybe default this to something?
     if !std_out.empty? && (macro_coverage_output_dir = ENV["ATHENA_SPEC_COVERAGE_OUTPUT_DIR"]?.presence)
       File.open ::Path[macro_coverage_output_dir, "macro_coverage.#{Path[file].stem}:#{line}.codecov.json"], "w" do |coverage_report|
-        IO.copy std_out.rewind, coverage_report
+        coverage_report.print adjust_coverage_line_numbers(std_out, file, line)
       end
     end
 
@@ -81,7 +81,7 @@ module Athena::Spec::Methods
     # TODO: Maybe default this to something?
     if !std_out.empty? && (macro_coverage_output_dir = ENV["ATHENA_SPEC_COVERAGE_OUTPUT_DIR"]?.presence)
       File.open ::Path[macro_coverage_output_dir, "macro_coverage.#{Path[file].stem}:#{line}.codecov.json"], "w" do |coverage_report|
-        IO.copy std_out.rewind, coverage_report
+        coverage_report.print adjust_coverage_line_numbers(std_out, file, line)
       end
     end
 
@@ -103,6 +103,19 @@ module Athena::Spec::Methods
 
     fail buffer.to_s, line: line unless result.success?
     buffer.close
+  end
+
+  # Adjusts line numbers in the coverage JSON for the stdin file entry.
+  # When code is piped via stdin with --stdin-filename, Crystal reports line numbers relative to the stdin content rather than the actual file.
+  private def adjust_coverage_line_numbers(coverage_output : IO, stdin_filename : String, line_offset : Int32) : String
+    coverage = JSON.parse(coverage_output.rewind.gets_to_end)
+
+    coverage.as_h["coverage"].as_h.each do |filename, file_coverage|
+      next unless stdin_filename.ends_with? filename
+      file_coverage.as_h.transform_keys! { |key| (key.to_i + line_offset).to_s }
+    end
+
+    coverage.to_pretty_json
   end
 
   private def execute(code : String, std_out : IO, std_err : IO, file : String, codegen : Bool, macro_code_coverage : Bool = false) : Process::Status


### PR DESCRIPTION
## Context

The macro code coverage reports generated via `.assert_compiles` or `.assert_compile_time_error`, given the following example, would generate something like `{"2" => 1}` because the macro expression is on line 2 of the provided code. However this is _NOT_ correct as we want the report to say line 5 in the spec file was hit.

```cr
require "athena-spec"

ASPEC::Methods.assert_compiles <<-'CR'
  macro finished
    {% x = 1 %}
  end
CR
```

This PR pre-processes the coverage report to adjust the line numbers based on `__LINE__` of the test case, ensuring things are reported properly. Imagine we'll see quite a few indirect changes in the coverage reporting as things start reporting the proper line numbers. When using helper `private def` wrappers, will just need to remember to subtract the amount of lines being passed to the actual method to account for extra code before the provided code is interpolated.

I also added a helper `ASPEC.compile_time_assert`, the main purpose of which is to still have a way to fail `.assert_compiles` specs when checking the state of the container and such, but have it treated as a hit. The previous approach of suffixed `unless` or block `unless` would result in partial/misses which skews coverage info.

## Changelog

- Fix incorrect macro code coverage line numbers
- Add `ASPEC.compile_time_assert` helper function for use with `assert_compiles`

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
