### PR TITLE
Add ability to add code before/after the actual code of `ASPEC::Methods.assert_compiles` and `ASPEC::Methods.assert_compile_time_error`

### DIFF
--- a/.changes/unreleased/spec-Added-20260312-213746.yaml
+++ b/.changes/unreleased/spec-Added-20260312-213746.yaml
@@ -1,0 +1,8 @@
+project: spec
+kind: Added
+body: Add ability to add code before/after the actual code of `ASPEC::Methods.assert_compiles` and `ASPEC::Methods.assert_compile_time_error`
+time: 2026-03-12T21:37:46.918445149-04:00
+custom:
+    Author: George Dietrich
+    PR: "687"
+    Username: blacksmoke16

--- a/src/components/dependency_injection/spec/compiler_passes/auto_wire_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/auto_wire_spec.cr
@@ -1,10 +1,7 @@
 require "../spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
-    require "../spec_helper.cr"
-    #{code}
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: %(require "../spec_helper.cr")
 end
 
 module AutoWireInterface; end

--- a/src/components/dependency_injection/spec/compiler_passes/define_getters_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/define_getters_spec.cr
@@ -1,17 +1,11 @@
 require "../spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
-    require "../spec_helper.cr"
-    #{code}
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: %(require "../spec_helper.cr")
 end
 
 private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compiles <<-CR, line: line
-    require "../spec_helper.cr"
-    #{code}
-  CR
+  ASPEC::Methods.assert_compiles code, line: line, preamble: %(require "../spec_helper.cr")
 end
 
 module PublicStringAliasInterface; end

--- a/src/components/dependency_injection/spec/compiler_passes/inline_service_definitions_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/inline_service_definitions_spec.cr
@@ -1,10 +1,7 @@
 require "../spec_helper"
 
 private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compiles <<-CR, line: line
-    require "../spec_helper.cr"
-    #{code}
-  CR
+  ASPEC::Methods.assert_compiles code, line: line, preamble: %(require "../spec_helper.cr")
 end
 
 # 1. Basic inlining: single-use private service

--- a/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/merge_extension_config_spec.cr
@@ -1,11 +1,7 @@
 require "../spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
-    require "../spec_helper.cr"
-    #{code}
-    ADI::ServiceContainer.new
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: %(require "../spec_helper.cr"), postamble: "ADI::ServiceContainer.new"
 end
 
 describe ADI::ServiceContainer::MergeExtensionConfig, tags: "compiled" do

--- a/src/components/dependency_injection/spec/compiler_passes/normalize_definitions_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/normalize_definitions_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: <<-'CRYSTAL', postamble: <<-'CR'
     require "../spec_helper.cr"
     module MySchema
       include ADI::Extension::Schema
@@ -16,7 +16,7 @@ private def assert_compile_time_error(message : String, code : String, *, line :
           macro finished
             {% verbatim do %}
               {%
-                #{code}
+  CRYSTAL
               %}
             {% end %}
           end

--- a/src/components/dependency_injection/spec/compiler_passes/process_aliases_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/process_aliases_spec.cr
@@ -1,19 +1,11 @@
 require "../spec_helper"
 
 private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compiles <<-CR, line: line - 1 # Account for spec_helper require
-    require "../spec_helper.cr"
-    #{code}
-    ADI::ServiceContainer.new
-  CR
+  ASPEC::Methods.assert_compiles code, line: line, preamble: %(require "../spec_helper.cr"), postamble: "ADI::ServiceContainer.new"
 end
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line - 1 # Account for spec_helper require
-    require "../spec_helper.cr"
-    #{code}
-    ADI::ServiceContainer.new
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: %(require "../spec_helper.cr"), postamble: "ADI::ServiceContainer.new"
 end
 
 describe ADI::ServiceContainer::ProcessAliases, tags: "compiled" do

--- a/src/components/dependency_injection/spec/compiler_passes/process_auto_configurations_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/process_auto_configurations_spec.cr
@@ -1,11 +1,7 @@
 require "../spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
-    require "../spec_helper.cr"
-    #{code}
-    ADI::ServiceContainer.new
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: %(require "../spec_helper.cr"), postamble: "ADI::ServiceContainer.new"
 end
 
 private PARTNER_TAG = "partner"

--- a/src/components/dependency_injection/spec/compiler_passes/register_services_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/register_services_spec.cr
@@ -1,11 +1,7 @@
 require "../spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line - 1 # Account for spec_helper require
-    require "../spec_helper.cr"
-    #{code}
-    ADI::ServiceContainer.new
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: %(require "../spec_helper.cr"), postamble: "ADI::ServiceContainer.new"
 end
 
 # Happy Path

--- a/src/components/dependency_injection/spec/compiler_passes/resolve_parameter_placeholders_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/resolve_parameter_placeholders_spec.cr
@@ -1,11 +1,7 @@
 require "../spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
-    require "../spec_helper.cr"
-    #{code}
-    ADI::ServiceContainer.new
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: %(require "../spec_helper.cr"), postamble: "ADI::ServiceContainer.new"
 end
 
 describe ADI::ServiceContainer::ResolveParameterPlaceholders do

--- a/src/components/dependency_injection/spec/compiler_passes/resolve_values_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/resolve_values_spec.cr
@@ -1,11 +1,7 @@
 require "../spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
-    require "../spec_helper.cr"
-    #{code}
-    ADI::ServiceContainer.new
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: %(require "../spec_helper.cr"), postamble: "ADI::ServiceContainer.new"
 end
 
 module ResolveValuePriorityInterface; end

--- a/src/components/dependency_injection/spec/compiler_passes/validate_arguments_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/validate_arguments_spec.cr
@@ -1,11 +1,7 @@
 require "../spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
-    require "../spec_helper.cr"
-    #{code}
-    ADI::ServiceContainer.new
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: %(require "../spec_helper.cr"), postamble: "ADI::ServiceContainer.new"
 end
 
 describe ADI::ServiceContainer::ValidateArguments, tags: "compiled" do

--- a/src/components/dependency_injection/spec/compiler_passes/validate_generics_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/validate_generics_spec.cr
@@ -1,11 +1,7 @@
 require "../spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
-    require "../spec_helper.cr"
-    #{code}
-    ADI::ServiceContainer.new
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: %(require "../spec_helper.cr"), postamble: "ADI::ServiceContainer.new"
 end
 
 @[ADI::Register(Int32, Bool, public: true, name: "int_service")]

--- a/src/components/dependency_injection/spec/extension_spec.cr
+++ b/src/components/dependency_injection/spec/extension_spec.cr
@@ -1,18 +1,11 @@
 require "./spec_helper"
 
 private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compiles <<-CR, line: line - 1 # Account for spec_helper require
-    require "./spec_helper.cr"
-    #{code}
-  CR
+  ASPEC::Methods.assert_compiles code, line: line, preamble: %(require "./spec_helper.cr")
 end
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line - 1 # Account for spec_helper require
-    require "./spec_helper.cr"
-    #{code}
-    ADI::ServiceContainer.new
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: %(require "./spec_helper.cr"), postamble: "ADI::ServiceContainer.new"
 end
 
 describe ADI::Extension, tags: "compiled" do

--- a/src/components/framework/spec/bundle_spec.cr
+++ b/src/components/framework/spec/bundle_spec.cr
@@ -1,17 +1,11 @@
 require "./spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line - 1 # Account for spec_helper require
-    require "./spec_helper.cr"
-    #{code}
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: %(require "./spec_helper.cr")
 end
 
 private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compiles <<-CR, line: line - 1 # Account for spec_helper require
-    require "./spec_helper.cr"
-    #{code}
-  CR
+  ASPEC::Methods.assert_compiles code, line: line, preamble: %(require "./spec_helper.cr")
 end
 
 describe ATH::Bundle, tags: "compiled" do

--- a/src/components/framework/spec/compiler_spec.cr
+++ b/src/components/framework/spec/compiler_spec.cr
@@ -1,19 +1,11 @@
 require "./spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
-    require "./spec_helper.cr"
-    #{code}
-    ATH.run
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: %(require "./spec_helper.cr"), postamble: "ATH.run"
 end
 
 private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compiles <<-CR, line: line
-    require "./spec_helper.cr"
-    #{code}
-    ATH.run
-  CR
+  ASPEC::Methods.assert_compiles code, line: line, preamble: %(require "./spec_helper.cr"), postamble: "ATH.run"
 end
 
 describe Athena::Framework do

--- a/src/components/framework/spec/ext/console/register_commands_spec.cr
+++ b/src/components/framework/spec/ext/console/register_commands_spec.cr
@@ -1,11 +1,7 @@
 require "../../spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__, file : String = __FILE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line, file: file
-    require "../../spec_helper.cr"
-
-    #{code}
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, file: file, preamble: %(require "../../spec_helper.cr")
 end
 
 @[ADI::Register]

--- a/src/components/serializer/spec/compiler_spec.cr
+++ b/src/components/serializer/spec/compiler_spec.cr
@@ -1,10 +1,7 @@
 require "./spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
-    require "athena-serializer"
-    #{code}
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: %(require "athena-serializer")
 end
 
 describe Athena::Serializer, tags: "compiled" do

--- a/src/components/spec/spec/compiler_spec.cr
+++ b/src/components/spec/spec/compiler_spec.cr
@@ -1,11 +1,7 @@
 require "./spec_helper"
 
 private def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compile_time_error message, <<-CR, line: line
-    require "./spec_helper.cr"
-    #{code}
-    TestTestCase.run
-  CR
+  ASPEC::Methods.assert_compile_time_error message, code, line: line, preamble: %(require "./spec_helper.cr"), postamble: "TestTestCase.run"
 end
 
 private def assert_runtime_error(message : String, code : String, *, line : Int32 = __LINE__) : Nil
@@ -17,11 +13,7 @@ private def assert_runtime_error(message : String, code : String, *, line : Int3
 end
 
 private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
-  ASPEC::Methods.assert_compiles <<-CR, line: line
-    require "./spec_helper.cr"
-    #{code}
-    ASPEC.run_all
-  CR
+  ASPEC::Methods.assert_compiles code, line: line, preamble: %(require "./spec_helper.cr"), postamble: "ASPEC.run_all"
 end
 
 describe Athena::Spec do

--- a/src/components/spec/spec/methods_spec.cr
+++ b/src/components/spec/spec/methods_spec.cr
@@ -43,7 +43,7 @@ describe ASPEC::Methods do
         CR
     end
 
-    describe "adjusts macro coverage line numbers for the stdin file", focus: true do
+    describe "adjusts macro coverage line numbers for the stdin file" do
       it "without before/after code" do
         temp_dir = File.tempname
         Dir.mkdir_p(temp_dir)

--- a/src/components/spec/spec/methods_spec.cr
+++ b/src/components/spec/spec/methods_spec.cr
@@ -43,37 +43,76 @@ describe ASPEC::Methods do
         CR
     end
 
-    it "adjusts macro coverage line numbers for the stdin file" do
-      temp_dir = File.tempname
-      Dir.mkdir_p(temp_dir)
+    describe "adjusts macro coverage line numbers for the stdin file", focus: true do
+      it "without before/after code" do
+        temp_dir = File.tempname
+        Dir.mkdir_p(temp_dir)
 
-      ENV["ATHENA_SPEC_COVERAGE_OUTPUT_DIR"] = temp_dir
+        ENV["ATHENA_SPEC_COVERAGE_OUTPUT_DIR"] = temp_dir
 
-      # We expect the line `{% x = 1 %}` to be called. Using __LINE__ and adding 3 keeps this robust if other tests are added/removed/re-arranged.
-      expected_line = __LINE__ + 3
-      ASPEC::Methods.assert_compiles <<-'CR'
+        # We expect the line `{% x = 1 %}` to be called. Using __LINE__ and adding 3 keeps this robust if other tests are added/removed/re-arranged.
+        spec_line = __LINE__ + 2
+        code_line = __LINE__ + 3
+        ASPEC::Methods.assert_compiles <<-'CR'
           macro finished
             {% x = 1 %}
           end
         CR
 
-      coverage_file = Dir.glob(File.join(temp_dir, "macro_coverage.*.codecov.json")).first
+        coverage_file = Dir.glob(File.join(temp_dir, "macro_coverage.*.codecov.json")).first
+        coverage_file.should end_with "macro_coverage.methods_spec:#{spec_line}.codecov.json"
 
-      File.open coverage_file do |file|
-        coverage = JSON.parse file
+        File.open coverage_file do |file|
+          coverage = JSON.parse file
 
-        # Should be 1 coverage file.
-        coverages = coverage.as_h["coverage"].as_h
-        coverages.size.should eq 1
+          # Should be 1 coverage file.
+          coverages = coverage.as_h["coverage"].as_h
+          coverages.size.should eq 1
 
-        coverages.each_value do |file_coverage|
-          # The expected line number should be called once
-          file_coverage.as_h.should eq({expected_line.to_s => 1})
+          coverages.each_value do |file_coverage|
+            # The expected line number should be called once
+            file_coverage.as_h.should eq({code_line.to_s => 1})
+          end
         end
+      ensure
+        ENV.delete("ATHENA_SPEC_COVERAGE_OUTPUT_DIR")
+        FileUtils.rm_rf(temp_dir) if temp_dir
       end
-    ensure
-      ENV.delete("ATHENA_SPEC_COVERAGE_OUTPUT_DIR")
-      FileUtils.rm_rf(temp_dir) if temp_dir
+
+      it "with code before" do
+        temp_dir = File.tempname
+        Dir.mkdir_p(temp_dir)
+
+        ENV["ATHENA_SPEC_COVERAGE_OUTPUT_DIR"] = temp_dir
+
+        # We expect the line `{% x = 1 %}` to be called. Using __LINE__ and adding 3 keeps this robust if other tests are added/removed/re-arranged.
+        spec_line = __LINE__ + 2
+        code_line = __LINE__ + 3
+        ASPEC::Methods.assert_compiles <<-'CR', preamble: %(puts "hi")
+          macro finished
+            {% x = 1 %}
+          end
+        CR
+
+        coverage_file = Dir.glob(File.join(temp_dir, "macro_coverage.*.codecov.json")).first
+        coverage_file.should end_with "macro_coverage.methods_spec:#{spec_line}.codecov.json"
+
+        File.open coverage_file do |file|
+          coverage = JSON.parse file
+
+          # Should be 1 coverage file.
+          coverages = coverage.as_h["coverage"].as_h
+          coverages.size.should eq 1
+
+          coverages.each_value do |file_coverage|
+            # The expected line number should be called once
+            file_coverage.as_h.should eq({code_line.to_s => 1})
+          end
+        end
+      ensure
+        ENV.delete("ATHENA_SPEC_COVERAGE_OUTPUT_DIR")
+        FileUtils.rm_rf(temp_dir) if temp_dir
+      end
     end
   end
 

--- a/src/components/spec/src/methods.cr
+++ b/src/components/spec/src/methods.cr
@@ -18,12 +18,27 @@ module Athena::Spec::Methods
   # CR
   # ```
   #
+  # The *preamble* and *postamble* parameters may be used to add code before/after the actual *code*.
+  # This is primarily useful when wrapping this method in another private method for use within a specific test file to share common before/after code.
+  #
+  # ```
+  # private def assert_compiles(message : String, code : String, *, line : Int32 = __LINE__) : Nil
+  #   ASPEC::Methods.assert_compile_time_error message, code, preamble: %(require "../spec_helper.cr"), postamble: "MyClass.new", line: line
+  # end
+  # ```
+  #
   # NOTE: When files are required within the *code*, they are relative to the file calling this method.
-  def assert_compile_time_error(message : String, code : String, *, line : Int32 = __LINE__, file : String = __FILE__) : Nil
+  def assert_compile_time_error(message : String, code : String, *, preamble : String = "", postamble : String = "", line : Int32 = __LINE__, file : String = __FILE__) : Nil
+    full_code = String.build do |str|
+      str.puts preamble unless preamble.empty?
+      str.puts code
+      str.puts postamble unless postamble.empty?
+    end
+
     std_out = IO::Memory.new
     std_err = IO::Memory.new
 
-    result = execute code, std_out, std_err, file, codegen: false, macro_code_coverage: true
+    result = execute full_code, std_out, std_err, file, codegen: false, macro_code_coverage: true
 
     fail std_err.to_s, line: line if result.success?
     std_err.to_s.should contain(message), line: line
@@ -32,8 +47,9 @@ module Athena::Spec::Methods
     # Ignore coverage report output if the output dir is not defined, or if there is no report.
     # TODO: Maybe default this to something?
     if !std_out.empty? && (macro_coverage_output_dir = ENV["ATHENA_SPEC_COVERAGE_OUTPUT_DIR"]?.presence)
+      coverage_line_offset = preamble.empty? ? line : line - preamble.count('\n') - 1
       File.open ::Path[macro_coverage_output_dir, "macro_coverage.#{Path[file].stem}:#{line}.codecov.json"], "w" do |coverage_report|
-        coverage_report.print adjust_coverage_line_numbers(std_out, file, line)
+        coverage_report.print adjust_coverage_line_numbers(std_out, file, coverage_line_offset)
       end
     end
 
@@ -67,12 +83,27 @@ module Athena::Spec::Methods
   # CR
   # ```
   #
+  # The *preamble* and *postamble* parameters may be used to add code before/after the actual *code*.
+  # This is primarily useful when wrapping this method in another private method for use within a specific test file to share common before/after code.
+  #
+  # ```
+  # private def assert_compiles(code : String, *, line : Int32 = __LINE__) : Nil
+  #   ASPEC::Methods.assert_compiles code, preamble: %(require "../spec_helper.cr"), postamble: "MyClass.new", line: line
+  # end
+  # ```
+  #
   # NOTE: When files are required within the *code*, they are relative to the file calling this method.
-  def assert_compiles(code : String, *, line : Int32 = __LINE__, file : String = __FILE__) : Nil
+  def assert_compiles(code : String, *, preamble : String = "", postamble : String = "", line : Int32 = __LINE__, file : String = __FILE__) : Nil
+    full_code = String.build do |str|
+      str.puts preamble unless preamble.empty?
+      str.puts code
+      str.puts postamble unless postamble.empty?
+    end
+
     std_out = IO::Memory.new
     std_err = IO::Memory.new
 
-    result = execute code, std_out, std_err, file, codegen: false, macro_code_coverage: true
+    result = execute full_code, std_out, std_err, file, codegen: false, macro_code_coverage: true
 
     fail std_err.to_s, line: line unless result.success?
     std_err.close
@@ -80,8 +111,9 @@ module Athena::Spec::Methods
     # Ignore coverage report output if the output dir is not defined, or if there is no report.
     # TODO: Maybe default this to something?
     if !std_out.empty? && (macro_coverage_output_dir = ENV["ATHENA_SPEC_COVERAGE_OUTPUT_DIR"]?.presence)
+      coverage_line_offset = preamble.empty? ? line : line - preamble.count('\n') - 1
       File.open ::Path[macro_coverage_output_dir, "macro_coverage.#{Path[file].stem}:#{line}.codecov.json"], "w" do |coverage_report|
-        coverage_report.print adjust_coverage_line_numbers(std_out, file, line)
+        coverage_report.print adjust_coverage_line_numbers(std_out, file, coverage_line_offset)
       end
     end
 


### PR DESCRIPTION
## Context

It was common internally to want to require `spec_helper` or always run `ADI::ServiceContainer.new` etc before/after the compile time specs in some components. This PR adds first-class citizen support to `ASPEC::Methods.assert_compiles` and `ASPEC::Methods.assert_compile_time_error`. The main benefit of this is it automatically account for preamble code when calculating macro code coverage line offsets.

## Changelog

- Add ability to add code before/after the actual code of `ASPEC::Methods.assert_compiles` and `ASPEC::Methods.assert_compile_time_error`

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
