### PR TITLE
Allow manually auto-configuring types

### DIFF
--- a/src/components/dependency_injection/spec/compiler_passes/process_auto_configurations_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/process_auto_configurations_spec.cr
@@ -218,6 +218,75 @@ class ConstructorTwo < AutoConfigureConstructor
   private def initialize(@num : Int32); end
 end
 
+module ManualTagInterface; end
+
+module ManualPublicInterface; end
+
+module ManualCallsInterface; end
+
+abstract class ManualConstructorBase; end
+
+module ManualAutoConfigSetup
+  macro included
+    macro finished
+      {% verbatim do %}
+        {%
+          AUTO_CONFIGURATIONS[ManualTagInterface] = {tags: ["manual_tag"]}
+          AUTO_CONFIGURATIONS[ManualPublicInterface] = {public: true}
+          AUTO_CONFIGURATIONS[ManualCallsInterface] = {calls: [{"foo", {6}}, {"foo"}]}
+          AUTO_CONFIGURATIONS[ManualConstructorBase] = {constructor: "create", public: true}
+        %}
+      {% end %}
+    end
+  end
+end
+
+ADI.add_compiler_pass ManualAutoConfigSetup, priority: 200
+
+@[ADI::Register]
+record ManualTagService1 do
+  include ManualTagInterface
+end
+
+@[ADI::Register]
+record ManualTagService2 do
+  include ManualTagInterface
+end
+
+@[ADI::Register(public: true, _services: "!manual_tag")]
+class ManualTagClient
+  getter services : Array(ManualTagInterface)
+
+  def initialize(@services : Array(ManualTagInterface)); end
+end
+
+@[ADI::Register]
+record ManualPublicService do
+  include ManualPublicInterface
+end
+
+@[ADI::Register(public: true)]
+class ManualCallsClient
+  include ManualCallsInterface
+
+  getter values = [] of Int32
+
+  def foo(value : Int32 = 1)
+    @values << value
+  end
+end
+
+@[ADI::Register(public: true)]
+class ManualConstructorChild < ManualConstructorBase
+  getter num
+
+  def self.create : self
+    new 42
+  end
+
+  private def initialize(@num : Int32); end
+end
+
 describe ADI::ServiceContainer::ProcessAutoconfigureAnnotations do
   describe "compiler errors", tags: "compiled" do
     describe "tags" do
@@ -275,6 +344,30 @@ describe ADI::ServiceContainer::ProcessAutoconfigureAnnotations do
             end
           CR
         end
+      end
+
+      it "errors when both an annotation and a manual entry exist for the same type" do
+        assert_compile_time_error "Auto configuration for 'ManualConflict' is already defined in 'AUTO_CONFIGURATIONS'. Remove the annotation or the manual entry.", <<-CR
+          @[ADI::Autoconfigure(tags: ["conflict_tag"])]
+          module ManualConflict; end
+
+          module ConflictSetup
+            macro included
+              macro finished
+                {% verbatim do %}
+                  {% AUTO_CONFIGURATIONS[ManualConflict] = {tags: ["conflict_tag"]} %}
+                {% end %}
+              end
+            end
+          end
+
+          ADI.add_compiler_pass ConflictSetup, priority: 200
+
+          @[ADI::Register]
+          record Foo do
+            include ManualConflict
+          end
+        CR
       end
     end
 
@@ -374,18 +467,40 @@ describe ADI::ServiceContainer::ProcessAutoconfigureAnnotations do
     it "provides an empty array if there were no services configured with the desired tag" do
       ADI.container.unused_tag_client.services.should be_empty
     end
+
+    it "applies tags to manually configured matching services" do
+      ADI.container.manual_tag_client.services.should eq [ManualTagService1.new, ManualTagService2.new]
+    end
   end
 
-  it "allows making a service public" do
-    ADI.container.auto_configured_public_service.should be_a AutoConfiguredPublicService
+  describe "public" do
+    it "when wired up via annotation" do
+      ADI.container.auto_configured_public_service.should be_a AutoConfiguredPublicService
+    end
+
+    it "when manually wired up" do
+      ADI.container.manual_public_service.should be_a ManualPublicService
+    end
   end
 
-  it "allows defining calls" do
-    ADI.container.call_autoconfigure_client.values.should eq [6, 3, 1]
+  describe "calls" do
+    it "when wired up via annotation" do
+      ADI.container.call_autoconfigure_client.values.should eq [6, 3, 1]
+    end
+
+    it "when manually wired up" do
+      ADI.container.manual_calls_client.values.should eq [6, 1]
+    end
   end
 
-  it "allows specifying the constructor" do
-    ADI.container.constructor_one.num.should eq 123
-    ADI.container.constructor_two.num.should eq 999
+  describe "constructor" do
+    it "when wired up via annotation" do
+      ADI.container.constructor_one.num.should eq 123
+      ADI.container.constructor_two.num.should eq 999
+    end
+
+    it "when manually wired up" do
+      ADI.container.manual_constructor_child.num.should eq 42
+    end
   end
 end

--- a/src/components/dependency_injection/spec/compiler_passes/process_auto_configurations_spec.cr
+++ b/src/components/dependency_injection/spec/compiler_passes/process_auto_configurations_spec.cr
@@ -121,6 +121,9 @@ BAR_TAG = "bar"
 @[ADI::AutoconfigureTag(BAR_TAG)]
 module Namespace::ExplicitTagConstInterface; end
 
+@[ADI::AutoconfigureTag("prioritized_tag", priority: 10)]
+module Namespace::PrioritizedTagInterface; end
+
 @[ADI::Register]
 record FQNService1 do
   include Namespace::FQNTagInterface
@@ -131,6 +134,23 @@ end
 record FQNService2 do
   include Namespace::FQNTagInterface
   include Namespace::ExplicitTagInterface
+end
+
+@[ADI::Register]
+record PrioritizedService1 do
+  include Namespace::PrioritizedTagInterface
+end
+
+@[ADI::Register(tags: [{name: "prioritized_tag", priority: 20}])]
+record PrioritizedService2 do
+  include Namespace::PrioritizedTagInterface
+end
+
+@[ADI::Register(public: true, _services: "!prioritized_tag")]
+class PrioritizedTagClient
+  getter services : Array(Namespace::PrioritizedTagInterface)
+
+  def initialize(@services : Array(Namespace::PrioritizedTagInterface)); end
 end
 
 @[ADI::Register(public: true, _services: "!Namespace::FQNTagInterface")]
@@ -437,6 +457,12 @@ describe ADI::ServiceContainer::ProcessAutoconfigureAnnotations do
 
       it "with tag name const" do
         ADI.container.fqn_tag_const_client.services.should eq [FQNService1.new]
+      end
+
+      it "with named args" do
+        services = ADI.container.prioritized_tag_client.services
+        services[0].should eq PrioritizedService2.new
+        services[1].should eq PrioritizedService1.new
       end
     end
 

--- a/src/components/dependency_injection/src/athena-dependency_injection.cr
+++ b/src/components/dependency_injection/src/athena-dependency_injection.cr
@@ -17,8 +17,9 @@ alias ADI = Athena::DependencyInjection
 module Athena::DependencyInjection
   VERSION = "0.4.4"
 
-  private BINDINGS   = {} of Nil => Nil
-  private EXTENSIONS = {} of Nil => Nil
+  private BINDINGS            = {} of Nil => Nil
+  private AUTO_CONFIGURATIONS = {} of Nil => Nil
+  private EXTENSIONS          = {} of Nil => Nil
 
   # :nodoc:
   CONFIG = {parameters: {__nil: nil}} # Ensure this type is a NamedTupleLiteral

--- a/src/components/dependency_injection/src/compiler_passes/process_autoconfigure_annotations.cr
+++ b/src/components/dependency_injection/src/compiler_passes/process_autoconfigure_annotations.cr
@@ -1,12 +1,16 @@
 # :nodoc:
 #
-# Processes `@[ADI::Autoconfigure]` annotations
+# Processes `@[ADI::Autoconfigure]` annotations and `AUTO_CONFIGURATIONS` entries
 module Athena::DependencyInjection::ServiceContainer::ProcessAutoconfigureAnnotations
   macro included
     macro finished
       {% verbatim do %}
         {%
           __nil = nil
+
+          # Unified hash of auto configurations keyed by resolved type.
+          # Each value is a named tuple: {tags, calls, bind, public, constructor}
+          auto_configs = AUTO_CONFIGURATIONS
 
           # Build out a list of interfaces, and types that can be used to autoconfigure other services
           #
@@ -30,50 +34,74 @@ module Athena::DependencyInjection::ServiceContainer::ProcessAutoconfigureAnnota
           # Don't process types more than once.
           types_to_process = types_to_process.uniq
 
+          types_to_process.each do |t|
+            if auto_configs[t]
+              t.raise "Auto configuration for '#{t.id}' is already defined in 'AUTO_CONFIGURATIONS'. Remove the annotation or the manual entry."
+            end
+
+            tags = [] of Nil
+
+            if at = t.annotation(ADI::AutoconfigureTag)
+              tag_name = if n = at[0]
+                           if n.is_a?(Path)
+                             n.resolve
+                           else
+                             n
+                           end
+                         else
+                           t.stringify
+                         end
+
+              tag = {name: tag_name}
+
+              at.named_args.each do |k, v|
+                tag[k.id.stringify] = v
+              end
+
+              tags << tag
+            end
+
+            ann = t.annotation ADI::Autoconfigure
+
+            if ann && (v = ann["tags"]) != nil
+              unless v.is_a? ArrayLiteral
+                v.raise "'tags' field of auto configuration '#{t.id}' must be an 'ArrayLiteral', got '#{v.class_name.id}'."
+              end
+
+              v.each do |tag|
+                tags << tag
+              end
+            end
+
+            auto_configs[t] = {
+              tags:        tags,
+              calls:       ann ? ann["calls"] : nil,
+              bind:        ann ? ann["bind"] : nil,
+              public:      ann ? ann["public"] : nil,
+              constructor: ann ? ann["constructor"] : nil,
+            }
+          end
+
           SERVICE_HASH.each do |service_id, definition|
             klass = definition["class"]
 
-            types_to_process.each do |t|
-              if definition["class"] <= t
-                tags = [] of Nil
-
-                if at = t.annotation(ADI::AutoconfigureTag)
-                  tag_name = if n = at[0]
-                               if n.is_a?(Path)
-                                 n.resolve
-                               else
-                                 n
-                               end
-                             else
-                               t.stringify
-                             end
-
-                  tag = {name: tag_name}
-
-                  at.named_args.each do |k, v|
-                    tag[k.id.stringify] = v
-                  end
-
-                  tags << tag
+            auto_configs.each do |t, config|
+              if klass <= t
+                if (v = config["constructor"]) != nil
+                  definition["factory"] = {klass, v}
                 end
 
-                ann = t.annotation ADI::Autoconfigure
-
-                if ann && (v = ann["constructor"])
-                  definition["factory"] = {definition["class"], v}
-                end
-
-                if ann && (v = ann["bind"]) != nil
+                if (v = config["bind"]) != nil
                   v.each do |k, v|
                     definition["bindings"][k] = v
                   end
                 end
 
-                if ann && (v = ann["public"]) != nil
+                if (v = config["public"]) != nil
                   definition["public"] = v
                 end
 
-                if ann && (v = ann["calls"]) != nil
+                if (v = config["calls"]) != nil
                   calls = [] of Nil
 
                   v.each do |call|
@@ -94,18 +122,8 @@ module Athena::DependencyInjection::ServiceContainer::ProcessAutoconfigureAnnota
                   definition["calls"] = calls
                 end
 
-                if ann && (v = ann["tags"]) != nil
-                  unless v.is_a? ArrayLiteral
-                    v.raise "'tags' field of auto configuration '#{t.id}' must be an 'ArrayLiteral', got '#{v.class_name.id}'."
-                  end
-
-                  v.each do |t|
-                    tags << t
-                  end
-                end
-
                 # Append raw tags - will be normalized by ProcessTags pass
-                tags.each do |tag|
+                (config["tags"] || [] of Nil).each do |tag|
                   definition["tags"] << tag
                 end
               end

--- a/src/components/dependency_injection/src/compiler_passes/process_autoconfigure_annotations.cr
+++ b/src/components/dependency_injection/src/compiler_passes/process_autoconfigure_annotations.cr
@@ -123,8 +123,10 @@ module Athena::DependencyInjection::ServiceContainer::ProcessAutoconfigureAnnota
                 end
 
                 # Append raw tags - will be normalized by ProcessTags pass
-                (config["tags"] || [] of Nil).each do |tag|
-                  definition["tags"] << tag
+                if tags = config["tags"]
+                  tags.each do |tag|
+                    definition["tags"] << tag
+                  end
                 end
               end
             end


### PR DESCRIPTION
## Context

Refactors the auto configuration compiler pass to allow manually defining auto configurations instead of relying 100% on the annotation. Main use case being for internal bundle usages.

## Changelog

- Allow manually auto-configuring types

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
