### PR TITLE
Fix macro code coverage output file writing on windows

### DIFF
--- a/.changes/unreleased/spec-Fixed-20260411-103958.yaml
+++ b/.changes/unreleased/spec-Fixed-20260411-103958.yaml
@@ -1,0 +1,8 @@
+project: spec
+kind: Fixed
+body: Fix macro code coverage output file writing on windows
+time: 2026-04-11T10:39:58.355020284-04:00
+custom:
+    Author: George Dietrich
+    PR: "696"
+    Username: blacksmoke16

--- a/src/components/spec/spec/methods_spec.cr
+++ b/src/components/spec/spec/methods_spec.cr
@@ -60,7 +60,7 @@ describe ASPEC::Methods do
           end
         CR
 
-        coverage_file = Dir.glob(File.join(temp_dir, "macro_coverage.*.codecov.json")).first
+        coverage_file = Dir.glob(::Path[temp_dir, "macro_coverage.*.codecov.json"]).first
         coverage_file.should end_with "macro_coverage.methods_spec#L#{spec_line}.codecov.json"
 
         File.open coverage_file do |file|
@@ -95,7 +95,7 @@ describe ASPEC::Methods do
           end
         CR
 
-        coverage_file = Dir.glob(File.join(temp_dir, "macro_coverage.*.codecov.json")).first
+        coverage_file = Dir.glob(::Path[temp_dir, "macro_coverage.*.codecov.json"]).first
         coverage_file.should end_with "macro_coverage.methods_spec#L#{spec_line}.codecov.json"
 
         File.open coverage_file do |file|

--- a/src/components/spec/spec/methods_spec.cr
+++ b/src/components/spec/spec/methods_spec.cr
@@ -36,13 +36,14 @@ describe ASPEC::Methods do
     end
   end
 
-  describe ".assert_compiles", tags: "compiled" do
-    it do
+  describe ".assert_compiles" do
+    it tags: "compiled" do
       assert_compiles <<-CR
           raise "Oh no"
         CR
     end
 
+    # These run in the unit test suite to ensure this integration also works on other OSs.
     describe "adjusts macro coverage line numbers for the stdin file" do
       it "without before/after code" do
         temp_dir = File.tempname
@@ -60,7 +61,7 @@ describe ASPEC::Methods do
         CR
 
         coverage_file = Dir.glob(File.join(temp_dir, "macro_coverage.*.codecov.json")).first
-        coverage_file.should end_with "macro_coverage.methods_spec:#{spec_line}.codecov.json"
+        coverage_file.should end_with "macro_coverage.methods_spec#L#{spec_line}.codecov.json"
 
         File.open coverage_file do |file|
           coverage = JSON.parse file
@@ -95,7 +96,7 @@ describe ASPEC::Methods do
         CR
 
         coverage_file = Dir.glob(File.join(temp_dir, "macro_coverage.*.codecov.json")).first
-        coverage_file.should end_with "macro_coverage.methods_spec:#{spec_line}.codecov.json"
+        coverage_file.should end_with "macro_coverage.methods_spec#L#{spec_line}.codecov.json"
 
         File.open coverage_file do |file|
           coverage = JSON.parse file

--- a/src/components/spec/src/methods.cr
+++ b/src/components/spec/src/methods.cr
@@ -48,7 +48,7 @@ module Athena::Spec::Methods
     # TODO: Maybe default this to something?
     if !std_out.empty? && (macro_coverage_output_dir = ENV["ATHENA_SPEC_COVERAGE_OUTPUT_DIR"]?.presence)
       coverage_line_offset = preamble.empty? ? line : line - preamble.count('\n') - 1
-      File.open ::Path[macro_coverage_output_dir, "macro_coverage.#{Path[file].stem}:#{line}.codecov.json"], "w" do |coverage_report|
+      File.open ::Path[macro_coverage_output_dir, "macro_coverage.#{Path[file].stem}#L#{line}.codecov.json"], "w" do |coverage_report|
         coverage_report.print adjust_coverage_line_numbers(std_out, file, coverage_line_offset)
       end
     end
@@ -112,7 +112,7 @@ module Athena::Spec::Methods
     # TODO: Maybe default this to something?
     if !std_out.empty? && (macro_coverage_output_dir = ENV["ATHENA_SPEC_COVERAGE_OUTPUT_DIR"]?.presence)
       coverage_line_offset = preamble.empty? ? line : line - preamble.count('\n') - 1
-      File.open ::Path[macro_coverage_output_dir, "macro_coverage.#{Path[file].stem}:#{line}.codecov.json"], "w" do |coverage_report|
+      File.open ::Path[macro_coverage_output_dir, "macro_coverage.#{Path[file].stem}#L#{line}.codecov.json"], "w" do |coverage_report|
         coverage_report.print adjust_coverage_line_numbers(std_out, file, coverage_line_offset)
       end
     end


### PR DESCRIPTION
## Context

Fixup to #687.

Because the specs were using the `compiled` tag they only were running on Linux. However the `:` character is a reserved character on Windows and as such the filename was being truncated. It also turns out the glob pattern requires `/` path separators. Both of these made it so the `File.glob` returned no results and thus an error calling `#first` on an empty enumerable.

This PR moves this spec to the unit test suite so it runs on all OSs, and switches the `:` out for `#L` similar to how GH handles it.

## Changelog

- Fix macro code coverage output file writing on windows

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
