### PR TITLE
Formatting fix

### DIFF
--- a/justfile
+++ b/justfile
@@ -51,12 +51,12 @@ lint: spellcheck format ameba
 # Check Crystal formatting
 [group('check')]
 format:
-    {{ CRYSTAL }} tool format
+    {{ CRYSTAL }} tool format --check
 
 # Fix Crystal formatting issues
 [group('check')]
 format-fix:
-    {{ CRYSTAL }} tool format --fix
+    {{ CRYSTAL }} tool format
 
 # Run Ameba static analysis
 [group('check')]

--- a/src/components/mime/src/encoder/quoted_printable_mime_header.cr
+++ b/src/components/mime/src/encoder/quoted_printable_mime_header.cr
@@ -12,7 +12,7 @@ struct Athena::MIME::Encoder::QuotedPrintableMIMEHeader
     allowed_bytes.concat('0'..'9')
     allowed_bytes.concat ['!', '*', '+', '-', '/']
     allowed_bytes.concat ['=', '\r', '\n'] # Not allowed as per spec, but don't want to modify them as they're handled elsewhere
-end
+  end
 
   # :inherit:
   def name : String


### PR DESCRIPTION
## Context

Back in #501 I moved CI jobs over to use the `justfile` recipes. However as it turns out, the `just format` recipe was doing what I thought `just format-fix` does, which in turn was just totally invalid. 

Because of this mishap, there was an _actual_ formatting difference in Crystal 1.20 that was not caught in CI, but _was_ caught via Ameba which recently started failing. This PR fixes the justfile recipes and fixes the format of that one file.

## Changelog

- Fix incorrectly configured `format` `just` recipe
- Fix misformatted file

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
