### PR TITLE
Update `clock` component upgrading guide

### DIFF
--- a/src/components/clock/UPGRADING.md
+++ b/src/components/clock/UPGRADING.md
@@ -2,13 +2,15 @@
 
 Documents the changes that may be required when upgrading to a newer component version.
 
-## Upgrade to 0.2.0
+## Upgrade to 0.3.0
 
 ### Remove `ACLK::Monotonic`
 
 `Time.monotonic` has been [deprecated](https://github.com/crystal-lang/rfcs/pull/15) in Crystal stdlib.
 The new `Time.instant` API doesn't, for good reason, doesn't have any overlap with `Time`, thus making it somewhat incompatible with `ACLK::Interface`.
 Use cases that require measuring time should likely just use `Time.instant` directly.
+
+## Upgrade to 0.2.0
 
 ### Dropped `ACLK::Interface#sleep(Number)` overload
 


### PR DESCRIPTION
## Context

Follow up to #701, the `clock` component did end up being a minor bump, so need to adjust the upgrading guide to call that out.

## Changelog

- Update `clock` component upgrading guide

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
