### PR TITLE
Support polymorphic generic event listeners

### DIFF
--- a/.changes/unreleased/event-dispatcher-Changed-20260502-225424.yaml
+++ b/.changes/unreleased/event-dispatcher-Changed-20260502-225424.yaml
@@ -1,0 +1,9 @@
+project: event-dispatcher
+kind: Changed
+body: Event listeners with a generic type parameter now match all subclasses and module includers of the parameter's type
+time: 2026-05-02T22:54:24.690293195-04:00
+custom:
+    Author: George Dietrich
+    Breaking: "No"
+    PR: "703"
+    Username: blacksmoke16

--- a/src/components/event_dispatcher/spec/event_dispatcher_spec.cr
+++ b/src/components/event_dispatcher/spec/event_dispatcher_spec.cr
@@ -36,6 +36,57 @@ class TestListener
   end
 end
 
+module SomeInterface; end
+
+abstract class Animal; end
+
+class Dog < Animal; end
+
+class Cat < Animal
+  include SomeInterface
+end
+
+abstract class ParentAnimal < Animal; end
+
+class Sloth < ParentAnimal
+  include SomeInterface
+end
+
+class ThreeToedSloth < Sloth; end
+
+class GenericAnimalEvent(T) < AED::Event
+  getter animal : T
+
+  def initialize(@animal : T); end
+end
+
+class AnimalListener
+  getter all_animal_calls : Array(Animal.class) = [] of Animal.class
+  getter only_child_animal_calls : Array(Animal.class) = [] of Animal.class
+  getter only_interface_animal_calls : Array(Animal.class) = [] of Animal.class
+  getter non_abstract_animal_calls : Array(Animal.class) = [] of Animal.class
+
+  @[AEDA::AsEventListener]
+  def all_animals(event : GenericAnimalEvent(Animal)) : Nil
+    @all_animal_calls << event.animal.class
+  end
+
+  @[AEDA::AsEventListener]
+  def only_child_animals(event : GenericAnimalEvent(ParentAnimal), dispatcher : AED::EventDispatcherInterface) : Nil
+    @only_child_animal_calls << event.animal.class
+  end
+
+  @[AEDA::AsEventListener]
+  def only_interface_animals(event : GenericAnimalEvent(SomeInterface)) : Nil
+    @only_interface_animal_calls << event.animal.class
+  end
+
+  @[AEDA::AsEventListener]
+  def non_abstract_animals(event : GenericAnimalEvent(Sloth)) : Nil
+    @non_abstract_animal_calls << event.animal.class
+  end
+end
+
 struct EventDispatcherTest < ASPEC::TestCase
   @dispatcher : AED::EventDispatcher
 
@@ -242,6 +293,32 @@ struct EventDispatcherTest < ASPEC::TestCase
 
     pre_foo_invoked.should be_true
     other_pre_foo_invoked.should be_false
+  end
+
+  def test_listener_generic_polymorphism : Nil
+    animal_listener = AnimalListener.new
+
+    @dispatcher.listener animal_listener
+
+    @dispatcher.has_listeners?(GenericAnimalEvent(Cat)).should be_true
+    @dispatcher.has_listeners?(GenericAnimalEvent(Sloth)).should be_true
+    @dispatcher.has_listeners?(GenericAnimalEvent(ThreeToedSloth)).should be_true
+    @dispatcher.has_listeners?(GenericAnimalEvent(Dog)).should be_true
+
+    # Should not include module/abstract types that cannot actually exist.
+    @dispatcher.has_listeners?(GenericAnimalEvent(Animal)).should be_false
+    @dispatcher.has_listeners?(GenericAnimalEvent(SomeInterface)).should be_false
+    @dispatcher.has_listeners?(GenericAnimalEvent(ParentAnimal)).should be_false
+
+    @dispatcher.dispatch GenericAnimalEvent(Cat).new Cat.new
+    @dispatcher.dispatch GenericAnimalEvent(Sloth).new Sloth.new
+    @dispatcher.dispatch GenericAnimalEvent(Dog).new Dog.new
+    @dispatcher.dispatch GenericAnimalEvent(ThreeToedSloth).new ThreeToedSloth.new
+
+    animal_listener.all_animal_calls.should eq [Cat, Sloth, Dog, ThreeToedSloth]
+    animal_listener.only_child_animal_calls.should eq [Sloth, ThreeToedSloth]
+    animal_listener.only_interface_animal_calls.should eq [Cat, Sloth]
+    animal_listener.non_abstract_animal_calls.should eq [Sloth, ThreeToedSloth]
   end
 
   def test_remove_listener : Nil

--- a/src/components/event_dispatcher/src/callable.cr
+++ b/src/components/event_dispatcher/src/callable.cr
@@ -146,10 +146,14 @@ abstract struct Athena::EventDispatcher::Callable
     def_equals @event_class, @priority, @callback, @instance
 
     # :nodoc:
-    def call(event : E, dispatcher : AED::EventDispatcherInterface) : Nil
+    def call(event : ACTR::EventDispatcher::Event, dispatcher : AED::EventDispatcherInterface) : Nil
+      return unless event.is_a?(E)
+
       case cb = @callback
-      in Proc(E, Nil)                                then cb.call event
-      in Proc(E, AED::EventDispatcherInterface, Nil) then cb.call event, dispatcher
+      when Proc(E, Nil)                                then cb.call event
+      when Proc(E, AED::EventDispatcherInterface, Nil) then cb.call event, dispatcher
+      else
+        raise "BUG: Tried to call unknown event type."
       end
     end
 

--- a/src/components/event_dispatcher/src/event.cr
+++ b/src/components/event_dispatcher/src/event.cr
@@ -33,9 +33,54 @@
 # The added benefit of this is that the listener is also aware of the type returned by the related methods, so no manual casting is required.
 #
 # TIP: Use type aliases to give better names to commonly used generic types.
+#
 # ```
 # alias UserCreatedEvent = AED::GenericEvent(User, String)
 # ```
+#
+# ### Polymorphism
+#
+# There is special handling for an event class has a single generic type variable.
+# When used within an event listener, if the generic type has child types or is included in other types (when it's a module), then that listener will be registered for each concrete descendant of that type.
+#
+# ```
+# abstract struct Animal; end
+#
+# struct Dog < Animal; end
+#
+# struct Cat < Animal; end
+#
+# class GenericAnimalEvent(T) < AED::Event
+#   getter animal : T
+#
+#   def initialize(@animal : T); end
+# end
+#
+# class AnimalsListener
+#   @[AEDA::AsEventListener]
+#   def all_animals(event : GenericAnimalEvent(Animal)) : Nil
+#     pp "All Animals: #{event.animal}"
+#   end
+#
+#   @[AEDA::AsEventListener]
+#   def dog_only(event : GenericAnimalEvent(Dog)) : Nil
+#     pp "Dog Only: #{event.animal}"
+#   end
+# end
+#
+# dispatcher = AED::EventDispatcher.new
+# animal_listener = AnimalsListener.new
+# dispatcher.listener animal_listener
+#
+# dispatcher.dispatch GenericAnimalEvent(Cat).new Cat.new
+# dispatcher.dispatch GenericAnimalEvent(Dog).new Dog.new
+# # "All Animals: Cat()"
+# # "All Animals: Dog()"
+# # "Dog Only: Dog()"
+# ```
+#
+# In this example, notice how the `all_animals` event listener's *event* parameter is typed as `GenericAnimalEvent(Animal)` and gets invoked for both children of the abstract `Animal` type.
+# Whereas the event for the `dog_only` event listener is typed as `GenericAnimalEvent(Dog)`, so it only gets invoked once when the animal is a `Dog`.
 abstract class Athena::EventDispatcher::Event < Athena::Contracts::EventDispatcher::Event
   # Returns an `AED::Callable` based on the event class the method was called on.
   # Optionally allows customizing the *priority* and *name* of the listener.

--- a/src/components/event_dispatcher/src/event_dispatcher.cr
+++ b/src/components/event_dispatcher/src/event_dispatcher.cr
@@ -95,7 +95,19 @@ class Athena::EventDispatcher::EventDispatcher
             m.raise "Event listener method '#{T.name}##{m.name}' expects a 'NumberLiteral' for its 'AEDA::AsEventListener#priority' field, but got a '#{priority.class_name.id}'."
           end
 
-          listeners << {event_arg.restriction.resolve.id, m.args.size, m.name.id, priority}
+          # A listener whose event arg is `Foo(Animal)` will not be invoked for a dispatched `Foo(Dog)`, because the dispatcher matches on exact `event.class`.
+          # To work around this, register a listener for each non-abstract descendant of that type.
+          restriction = event_arg.restriction
+          if restriction.is_a?(Generic) && restriction.type_vars.size == 1
+            type_param = restriction.type_vars.first.resolve
+            concrete_types = [type_param] + type_param.all_subclasses + type_param.includers
+            concrete_types.each do |concrete_type|
+              concrete_event = "#{restriction.name}(#{concrete_type})".id
+              listeners << {concrete_event, m.args.size, m.name.id, priority} if !(concrete_type.abstract? || concrete_type.module?)
+            end
+          else
+            listeners << {restriction.id, m.args.size, m.name.id, priority}
+          end
         end
       %}
 


### PR DESCRIPTION
## Context

This PR improves how events with a generic type var are handled. Previously if you were to have an event listener typed as like `MyEvent(T)` where `T` is an abstract type or module, then it just wouldn't get invoked if a an event that was a child of or included that module was actually dispatched.

After this PR, it'll register a listener for each child class or type that includes that module. This makes it so you can have a listener that can handle multiple different types, while still allowing typing the event parameter as `MyEvent(SomeConcreteType)` to handle only a specific descendant.

## Changelog

- Event listeners with a generic type parameter now match all subclasses and module includers of the parameter's type

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
