### PR TITLE
Remove git workaround

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -22,41 +22,6 @@ jobs:
         with:
           fetch-depth: 0 # Required so `git subtree` can find its split commit
           ssh-key: ${{ secrets.ATHENA_BOT_SSH_PRIV_KEY }}
-
-      # Workaround for git 2.52.0 regression breaking subtree split with --squash
-      # See: https://lore.kernel.org/git/176677910605.6.2281395015810449820.1087545551@dietrich.pub/T/
-      - name: Cache Git installation
-        id: cache-git
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/git-custom
-          key: git-2.51.1-subtree-${{ runner.os }}-${{ runner.arch }}
-      - name: Build Git with subtree support
-        if: steps.cache-git.outputs.cache-hit != 'true'
-        run: |
-          set -euo pipefail
-
-          GIT_VERSION="2.51.1"
-          INSTALL_DIR="$HOME/git-custom"
-
-          # Install build dependencies
-          sudo apt-get update
-          sudo apt-get install -y libcurl4-gnutls-dev libexpat1-dev gettext libz-dev libssl-dev
-
-          # Download and extract
-          wget -q "https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz"
-          tar -xzf "git-${GIT_VERSION}.tar.gz"
-          cd "git-${GIT_VERSION}"
-
-          # Build and install git
-          make -j$(nproc) prefix="$INSTALL_DIR" all
-          make prefix="$INSTALL_DIR" install
-
-          # Build and install contrib/subtree
-          cd contrib/subtree
-          make prefix="$INSTALL_DIR" install
-      - name: Add custom Git to PATH
-        run: echo "$HOME/git-custom/bin" >> "$GITHUB_PATH"
       - name: Sync Shards
         id: subtree-sync
         env:


### PR DESCRIPTION
## Context

The subtree issue was fixed in git `2.54.0`, and as of https://github.com/actions/runner-images/pull/14048 GHA runners have updated to that version by default. As such we no longer need the custom version workaround.

## Changelog

- Remove git workaround

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
