### PR TITLE
Fix remove `self` reference in top-level method

### DIFF
--- a/src/components/framework/spec/ext/routing/annotation_route_loader_spec.cr
+++ b/src/components/framework/spec/ext/routing/annotation_route_loader_spec.cr
@@ -8,7 +8,7 @@ private def assert_route(
 )
   route_collection.size.should eq 1
 
-  self.assert_route route_collection.first, **args, file: file, line: line
+  assert_route route_collection.first, **args, file: file, line: line
 end
 
 private def assert_route(


### PR DESCRIPTION
This `self` reference is an error in Crystal 1.22: https://github.com/crystal-lang/crystal/pull/17149
