### PR TITLE
Upgrade `ameba` to fix build error

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -8,13 +8,43 @@ Lint/NotNil:
   Enabled: false
 Lint/Typos:
   Enabled: false # This has its own dedicated CI job
-Lint/UselessAssign:
-  ExcludeTypeDeclarations: true # TODO: Disable this once https://github.com/crystal-ameba/ameba/issues/447 is resolved
 Naming/AccessorMethodName:
   Enabled: false
 Naming/BlockParameterName:
   Enabled: false
 Naming/QueryBoolMethods:
   Enabled: false
+Style/RedundantSelf: # I like being explicit to differentiate method call vs local variable
+  Enabled: false
 Style/LargeNumbers:
   Enabled: true
+
+# TODO: Do a pass on 1.7 rules
+Lint/AssignmentInCallArgument:
+  Enabled: false
+Lint/UnusedExpression:
+  Enabled: false
+Style/VerboseNilType: # This flags usages of `Nil` in multi-type unions
+  Enabled: false
+Style/HeredocEscape:
+  Enabled: false
+Lint/WhitespaceAroundMacroExpression:
+  Enabled: false
+Style/HeredocIndent:
+  Enabled: false
+Style/MultilineStringLiteral:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
+Style/RedundantNilInControlExpression:
+  Enabled: false
+Lint/UnusedRescueVariable:
+  Enabled: false
+Style/RedundantReturn:
+  Enabled: false
+Lint/UselessAssign:
+  Enabled: false
+Lint/UnneededDisableDirective:
+  Enabled: false
+Lint/ElseNil:
+  Enabled: false

--- a/justfile
+++ b/justfile
@@ -61,7 +61,7 @@ format-fix:
 # Run Ameba static analysis
 [group('check')]
 ameba:
-    ./bin/ameba
+    ./lib/ameba/bin/ameba.cr
 
 # Run typos spellchecker
 [group('check')]

--- a/shard.yml
+++ b/shard.yml
@@ -57,7 +57,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.6.3
+    commit: f53fcd3382553121239c8f144aec5e27aeadbed8
   athena-spec:
     github: athena-framework/spec
     version: ~> 0.4.0

--- a/src/components/framework/src/listeners/cors.cr
+++ b/src/components/framework/src/listeners/cors.cr
@@ -134,6 +134,8 @@ struct Athena::Framework::Listeners::CORS
   end
 
   # Configures the given *response* for CORS preflight
+  #
+  # ameba:disable Metrics/CyclomaticComplexity
   private def set_preflight_response(request : AHTTP::Request) : AHTTP::Response
     response = AHTTP::Response.new
     response.headers["vary"] = "origin"

--- a/src/components/routing/src/request_context.cr
+++ b/src/components/routing/src/request_context.cr
@@ -19,8 +19,6 @@ class Athena::Routing::RequestContext
 
   # Creates a new instance of self from the provided *uri*.
   # The *host*, *scheme*, *http_port*, and *https_port* optionally act as fallbacks if they are not contained within the *uri*.
-  #
-  # ameba:disable Metrics/CyclomaticComplexity:
   def self.from_uri(uri : String, host : String = "localhost", scheme : String = "http", http_port : Int32 = 80, https_port : Int32 = 443) : self
     if (idx = uri.index('\\')) && (i = uri.index(/\?|\#/) || uri.bytesize) && idx < i
       uri = ""


### PR DESCRIPTION
## Context

Ameba fails to build on `1.6.4`, but was fixed in https://github.com/crystal-ameba/ameba/pull/823 but only for `1.7-dev`. This is really annoying IMO and _should_ have been backported as `1.6.5` as `1.7` isn't even released yet. So to get CI working this pins ameba to the latest commit as of writing this PR and disables all the failing checks. Will do another pass on them later.

## Changelog

- Upgrade `ameba` to fix build error

---

_Before merging, remember to add the `athena-framework/athena` prefix to the PR number in the PR title_
